### PR TITLE
docs: rewrite README, add LICENSE and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, 22]
+        node-version: [18, 20, 22]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18, 22]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+      - run: npm ci
+      - run: npm run typecheck
+      - run: npm run lint
+      - run: npm test
+      - run: npm run build

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Amir Shayegh
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ Defaults to `reviews.db` in the current directory. Set to `:memory:` for ephemer
 
 | Error | Fix |
 |-------|-----|
-| `AUTH_ERROR: No OpenAI API key found` | Run `codex login` to authenticate, or set `OPENAI_API_KEY`. |
+| `AUTH_ERROR: No OpenAI API key found` | Run `codex login` to use your ChatGPT subscription, or set `OPENAI_API_KEY` for API key auth. |
 | `MODEL_ERROR: Model "X" is not supported` | Try `gpt-5.2-codex`. Set `"model"` in `.reviewbridge.json`. |
 | `NETWORK_ERROR: Could not reach OpenAI API` | Check your internet connection. |
 | `RATE_LIMITED: Rate limited by OpenAI` | Wait a moment and retry. |

--- a/README.md
+++ b/README.md
@@ -11,8 +11,10 @@ Automated code review powered by [OpenAI Codex](https://developers.openai.com/co
 Stage some changes and run:
 
 ```bash
-npx codex-claude-bridge review-precommit
+npx -y codex-claude-bridge review-precommit
 ```
+
+Requires the [Codex CLI](https://developers.openai.com/codex) to be installed and authenticated (`codex login` or `OPENAI_API_KEY`). See [Setup](#setup).
 
 ## Example Output
 
@@ -247,7 +249,7 @@ Defaults to `reviews.db` in the current directory. Set to `:memory:` for ephemer
 
 | Error | Fix |
 |-------|-----|
-| `AUTH_ERROR: No OpenAI API key found` | Run `codex login` to authenticate, or set `OPENAI_API_KEY`. |
+| `AUTH_ERROR: No OpenAI auth configured` | Run `codex login` to use your ChatGPT subscription, or set `OPENAI_API_KEY` for API key auth. |
 | `MODEL_ERROR: Model "X" is not supported` | Try `gpt-5.2-codex` or `gpt-5.3-codex`. Set `"model"` in `.reviewbridge.json`. |
 | `NETWORK_ERROR: Could not reach OpenAI API` | Check your internet connection. |
 | `RATE_LIMITED: Rate limited by OpenAI` | Wait a moment and retry. |

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Stage some changes and run:
 npx -y codex-claude-bridge review-precommit
 ```
 
-Requires the [Codex CLI](https://developers.openai.com/codex) to be installed and authenticated (`codex login` or `OPENAI_API_KEY`). See [Setup](#setup).
+Before running this command, complete the [Setup](#setup) section to install and authenticate the [Codex CLI](https://developers.openai.com/codex).
 
 ## Example Output
 
@@ -249,8 +249,8 @@ Defaults to `reviews.db` in the current directory. Set to `:memory:` for ephemer
 
 | Error | Fix |
 |-------|-----|
-| `AUTH_ERROR: No OpenAI auth configured` | Run `codex login` to use your ChatGPT subscription, or set `OPENAI_API_KEY` for API key auth. |
-| `MODEL_ERROR: Model "X" is not supported` | Try `gpt-5.2-codex` or `gpt-5.3-codex`. Set `"model"` in `.reviewbridge.json`. |
+| `AUTH_ERROR: No OpenAI API key found` | Run `codex login` to authenticate, or set `OPENAI_API_KEY`. |
+| `MODEL_ERROR: Model "X" is not supported` | Try `gpt-5.2-codex`. Set `"model"` in `.reviewbridge.json`. |
 | `NETWORK_ERROR: Could not reach OpenAI API` | Check your internet connection. |
 | `RATE_LIMITED: Rate limited by OpenAI` | Wait a moment and retry. |
 | `CODEX_TIMEOUT: review timed out` | Increase `"timeout_seconds"` in `.reviewbridge.json` (default: 300). |

--- a/README.md
+++ b/README.md
@@ -1,12 +1,53 @@
-# Claude ↔ Codex Review Bridge
+# codex-claude-bridge
 
-MCP server for automated code review. Claude Code writes the code, [OpenAI Codex](https://developers.openai.com/codex) reviews it — structured feedback comes back inline, no copy-pasting between tools.
+Automated code review powered by [OpenAI Codex](https://developers.openai.com/codex). Run it from the terminal or plug it into Claude Code.
 
-**Works with your ChatGPT subscription — no API costs.**
+[![npm](https://img.shields.io/npm/v/codex-claude-bridge)](https://www.npmjs.com/package/codex-claude-bridge)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![CI](https://github.com/AmirShayegh/codex-claude-bridge/actions/workflows/ci.yml/badge.svg)](https://github.com/AmirShayegh/codex-claude-bridge/actions/workflows/ci.yml)
 
-## Quick Start
+## Try It Now
 
-### Free (ChatGPT subscription)
+Stage some changes and run:
+
+```bash
+npx codex-claude-bridge review-precommit
+```
+
+## Example Output
+
+```
+COMMIT BLOCKED
+
+Blockers:
+  - Missing error handling in database connection
+  - SQL injection vulnerability in query builder
+
+Warnings:
+  - Consider adding input validation
+
+Session: a1b2c3d4
+```
+
+Exits with code 2 when blockers are found, so you can gate commits:
+
+```bash
+npx codex-claude-bridge review-precommit && git commit
+```
+
+## What It Does
+
+- **Reviews plans** before you start coding (architecture, feasibility, security)
+- **Reviews diffs** for bugs, security issues, and style (with file and line references)
+- **Pre-commit checks** that auto-capture staged changes and block on critical issues
+
+Works with your ChatGPT subscription (no API costs) or an OpenAI API key.
+
+## Setup
+
+### Prerequisites
+
+**Node.js 18+** is required. Install from [nodejs.org](https://nodejs.org/).
 
 Install the Codex CLI and sign in with your ChatGPT account:
 
@@ -15,103 +56,113 @@ npm install -g @openai/codex
 codex login
 ```
 
-Then add the MCP server to Claude Code:
+The `codex login` step uses your ChatGPT subscription. No API key or per-token billing required.
 
-```bash
-claude mcp add codex-bridge -- npx -y codex-claude-bridge
-```
-
-### API key (pay per token)
-
-Set your API key:
+Alternatively, if you prefer to use an API key instead:
 
 ```bash
 export OPENAI_API_KEY=sk-...
 ```
 
-Then add the MCP server to Claude Code:
+### Standalone CLI
+
+No additional setup needed. Run commands directly with `npx`:
+
+```bash
+npx codex-claude-bridge review-precommit
+npx codex-claude-bridge review-plan --plan plan.md
+git diff main | npx codex-claude-bridge review-code --diff -
+```
+
+### Claude Code Integration
+
+Add the MCP server to Claude Code:
 
 ```bash
 claude mcp add codex-bridge -- npx -y codex-claude-bridge
 ```
 
-Restart Claude Code after setup. The review tools are now available.
+Restart Claude Code after setup. Five review tools become available that Claude Code can call directly.
 
-### How auth works
+## CLI Commands
 
-The SDK reads OAuth tokens from `~/.codex/auth.json` (created by `codex login`). When no `OPENAI_API_KEY` is set, it uses your ChatGPT subscription automatically.
+### `review-precommit`
 
-### Prerequisites
-
-- **Node.js 18+** — [nodejs.org](https://nodejs.org/)
-- **Claude Code** — [code.claude.com](https://code.claude.com/docs/en/overview)
-- **Codex CLI** (free path only) — installed via `npm install -g @openai/codex`
-
-## What You Get
-
-Once set up, Claude Code gains five new tools:
-
-- **`review_plan`** — Send an implementation plan for architectural review. Get a verdict (approve / revise / reject) with specific findings.
-- **`review_code`** — Send a code diff for review. Get findings with file and line references.
-- **`review_precommit`** — Quick sanity check before committing. Automatically captures your staged git changes.
-- **`review_status`** — Check whether a review is still in progress, completed, or failed.
-- **`review_history`** — Look up past reviews by session or count.
-
-All tools return structured JSON that Claude Code can act on directly.
-
-## Usage (MCP)
-
-In Claude Code, just describe what you want reviewed. Claude Code will pick the right tool:
-
-**Plan review:**
-> "Review this implementation plan before I start coding."
-> "Check my plan for security issues and scalability risks."
-
-**Code review:**
-> "Review the changes I just made." (Claude Code runs `git diff` and passes it)
-> "Review this diff for bugs and security issues."
-
-**Pre-commit check:**
-> "Run a pre-commit check on my staged changes."
-> "Check if these changes are safe to commit."
-
-**Session continuity** — pass the `session_id` from a plan review into a code review to maintain context across the full review lifecycle.
-
-## Standalone CLI
-
-Run reviews directly from the terminal — no MCP setup required.
-
-**Pre-commit check (auto-captures staged changes):**
+Auto-captures staged changes and checks for issues.
 
 ```bash
 npx codex-claude-bridge review-precommit
+npx codex-claude-bridge review-precommit --diff changes.patch
 ```
 
-**Block commits on issues (CI-friendly, exits 2 on blockers):**
+| Flag | Description |
+|------|-------------|
+| `--diff <path>` | Override auto-capture (file path or `-` for stdin) |
+| `--session <id>` | Resume session |
+| `--config <path>` | Path to `.reviewbridge.json` directory |
+| `--json` | Raw JSON output |
 
-```bash
-npx codex-claude-bridge review-precommit && git commit
-```
+### `review-code`
 
-**Review a plan:**
-
-```bash
-npx codex-claude-bridge review-plan --plan plan.md
-```
-
-**Review a diff:**
+Reviews a code diff for bugs, security, and style.
 
 ```bash
 git diff main | npx codex-claude-bridge review-code --diff -
+npx codex-claude-bridge review-code --diff changes.patch --focus security,performance
 ```
 
-Add `--json` to any command for raw JSON output. Use `--help` to see all options.
+| Flag | Description |
+|------|-------------|
+| `--diff <path>` | File path or `-` for stdin (required) |
+| `--focus <items>` | Comma-separated review criteria |
+| `--session <id>` | Resume session |
+| `--config <path>` | Path to `.reviewbridge.json` directory |
+| `--json` | Raw JSON output |
 
-## Tools Reference
+### `review-plan`
+
+Reviews an implementation plan for architecture and feasibility.
+
+```bash
+npx codex-claude-bridge review-plan --plan plan.md
+npx codex-claude-bridge review-plan --plan - --depth thorough < plan.md
+```
+
+| Flag | Description |
+|------|-------------|
+| `--plan <path>` | File path or `-` for stdin (required) |
+| `--focus <items>` | Comma-separated focus areas |
+| `--depth <level>` | `quick` or `thorough` |
+| `--session <id>` | Resume session |
+| `--config <path>` | Path to `.reviewbridge.json` directory |
+| `--json` | Raw JSON output |
+
+Add `--json` to any command for machine-readable output.
+
+## MCP Tools
+
+When used as a Claude Code MCP server, these tools are available:
+
+| Tool | Purpose | Returns |
+|------|---------|---------|
+| `review_plan` | Architectural review of an implementation plan | verdict, findings, session_id |
+| `review_code` | Code review of a diff | verdict, findings with file/line refs, session_id |
+| `review_precommit` | Pre-commit sanity check on staged changes | ready_to_commit, blockers, warnings, session_id |
+| `review_status` | Check progress of a review | status, elapsed_seconds |
+| `review_history` | Query past reviews | array of review summaries |
+
+In Claude Code, just describe what you want reviewed. Claude Code picks the right tool:
+
+> "Review this implementation plan before I start coding."
+> "Run a pre-commit check on my staged changes."
+> "Review this diff for bugs and security issues."
+
+Pass `session_id` between calls to maintain context across the plan-to-commit lifecycle.
+
+<details>
+<summary>Full MCP tool parameters</summary>
 
 ### `review_plan`
-
-Send an implementation plan to Codex for architectural/feasibility review.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -121,26 +172,16 @@ Send an implementation plan to Codex for architectural/feasibility review.
 | `depth` | `"quick"` \| `"thorough"` | no | Review depth |
 | `session_id` | string | no | Continue from a previous review session |
 
-Returns: `{ verdict, summary, findings[], session_id }`
-
 ### `review_code`
-
-Send a code diff to Codex for code review.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `diff` | string | yes | Git diff to review |
 | `context` | string | no | Intent of the changes |
-| `session_id` | string | no | Continue from previous review (e.g. plan review session) |
+| `session_id` | string | no | Continue from previous review |
 | `criteria` | string[] | no | Review criteria (e.g. `["bugs", "security", "performance"]`) |
 
-Returns: `{ verdict, summary, findings[], session_id }`
-
-Findings include `file` and `line` references when available.
-
 ### `review_precommit`
-
-Quick pre-commit sanity check. Auto-captures staged git changes by default.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -149,28 +190,20 @@ Quick pre-commit sanity check. Auto-captures staged git changes by default.
 | `session_id` | string | no | Continue from previous review |
 | `checklist` | string[] | no | Custom pre-commit checks |
 
-Returns: `{ ready_to_commit, blockers[], warnings[], session_id }`
-
 ### `review_status`
-
-Check status of a review session.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `session_id` | string | yes | Session ID to check |
 
-Returns: `{ status, session_id, elapsed_seconds }`
-
 ### `review_history`
-
-Query past reviews.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `session_id` | string | no | Query reviews for a specific session |
 | `last_n` | number | no | Return last N reviews (default: 10) |
 
-Returns: `{ reviews[] }` with `session_id`, `type`, `verdict`, `summary`, `timestamp` per entry.
+</details>
 
 ## Configuration
 
@@ -200,13 +233,9 @@ Create `.reviewbridge.json` in your project root to customize review behavior:
 }
 ```
 
-All fields are optional. Missing fields use the defaults shown above.
+All fields are optional. Missing fields use sensible defaults.
 
-**Model options:** The default is `gpt-5.2-codex`. You can also use `gpt-5.3-codex` or other models supported by your account.
-
-## Storage
-
-Set `REVIEW_BRIDGE_DB` to persist review history and session state:
+Set `REVIEW_BRIDGE_DB` to customize where review history is stored:
 
 ```bash
 export REVIEW_BRIDGE_DB=~/.codex-reviews.db
@@ -218,7 +247,7 @@ Defaults to `reviews.db` in the current directory. Set to `:memory:` for ephemer
 
 | Error | Fix |
 |-------|-----|
-| `AUTH_ERROR: No OpenAI API key found` | Run `codex login` to authenticate, or set `OPENAI_API_KEY`. Check that `~/.codex/auth.json` exists. |
+| `AUTH_ERROR: No OpenAI API key found` | Run `codex login` to authenticate, or set `OPENAI_API_KEY`. |
 | `MODEL_ERROR: Model "X" is not supported` | Try `gpt-5.2-codex` or `gpt-5.3-codex`. Set `"model"` in `.reviewbridge.json`. |
 | `NETWORK_ERROR: Could not reach OpenAI API` | Check your internet connection. |
 | `RATE_LIMITED: Rate limited by OpenAI` | Wait a moment and retry. |
@@ -227,26 +256,13 @@ Defaults to `reviews.db` in the current directory. Set to `:memory:` for ephemer
 ## Architecture
 
 ```
-Claude Code ──MCP──► codex-claude-bridge ──SDK──► OpenAI Codex
-                            │
-                        SQLite DB
-                     (review history)
+Terminal / Claude Code ──► codex-claude-bridge ──SDK──► OpenAI Codex
+                                    │
+                                SQLite DB
+                             (review history)
 ```
 
-The SDK (`@openai/codex-sdk`) internally spawns `codex exec` as a subprocess — there is no separate "CLI mode." Both ChatGPT subscription auth and API key auth use the same SDK path.
-
-```
-src/
-  index.ts          → Entry point (routes to MCP or CLI)
-  mcp.ts            → MCP server startup
-  server.ts         → Server setup, tool registration
-  cli/              → Standalone CLI (Commander.js)
-  tools/            → MCP tool handlers (5 tools)
-  codex/            → Codex SDK wrapper, prompts, types
-  config/           → .reviewbridge.json loader
-  storage/          → SQLite persistence (reviews, sessions)
-  utils/            → Git diff, chunking, error types
-```
+Both CLI and MCP modes share the same review engine. The SDK uses your ChatGPT subscription auth or API key — both paths go through the same `@openai/codex-sdk`.
 
 ## Development
 
@@ -268,4 +284,4 @@ npm run build
 
 ## License
 
-MIT
+[MIT](LICENSE)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codex-claude-bridge",
   "version": "0.1.2",
-  "description": "MCP server that automates code review workflows between Claude Code and OpenAI Codex",
+  "description": "Automated code review powered by OpenAI Codex. CLI + Claude Code MCP integration.",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -27,7 +27,11 @@
     "codex",
     "code-review",
     "openai",
-    "anthropic"
+    "anthropic",
+    "cli",
+    "precommit",
+    "ai-code-review",
+    "developer-tools"
   ],
   "author": "Amir Shayegh",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- Rewrite README to lead with CLI instead of MCP jargon — hook outsiders in 5 seconds
- Add "Try it now" section at the top with a single `npx` command
- Show example terminal output (COMMIT BLOCKED with blockers/warnings)
- Add npm version, MIT license, and CI status badges
- Condense MCP tool parameter tables into collapsible `<details>` block
- Drop `src/` file tree from Architecture section (already in CLAUDE.md)
- Create MIT LICENSE file (was declared in package.json but the file was missing)
- Add GitHub Actions CI workflow (Node 18 + 22 matrix: typecheck, lint, test, build)
- Update package.json description and keywords for npm discoverability

## Test plan

- [x] `npm test` — 368 tests passing
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] Verify README renders correctly on GitHub (badges, code blocks, `<details>` expand)
- [ ] Verify CI workflow passes on GitHub Actions after push