### PR TITLE
feat: wire up diff chunking for large code reviews

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Create `.reviewbridge.json` in your project root to customize review behavior:
   "model": "gpt-5.2-codex",
   "reasoning_effort": "medium",
   "timeout_seconds": 300,
+  "max_chunk_tokens": 8000,
   "review_standards": {
     "plan_review": {
       "focus": ["architecture", "feasibility"],
@@ -170,7 +171,7 @@ Create `.reviewbridge.json` in your project root to customize review behavior:
 }
 ```
 
-All fields are optional. Missing fields use the defaults shown above.
+All fields are optional. Missing fields use the defaults shown above. Large diffs are automatically split into chunks of approximately `max_chunk_tokens` tokens and reviewed sequentially.
 
 **Model options:** The default is `gpt-5.2-codex`. You can also use `gpt-5.3-codex` or other models supported by your account.
 

--- a/src/codex/client.ts
+++ b/src/codex/client.ts
@@ -6,19 +6,21 @@ import {
   PlanReviewResultSchema,
   CodeReviewResultSchema,
   PrecommitResultSchema,
+  CodeFindingSeveritySchema,
 } from './types.js';
-import type { PlanReviewResult, CodeReviewResult, PrecommitResult } from './types.js';
+import type { PlanReviewResult, CodeReviewResult, PrecommitResult, CodeFinding, CodeFindingSeverity } from './types.js';
 import {
   buildPlanReviewPrompt,
   buildCodeReviewPrompt,
   buildPrecommitPrompt,
 } from './prompts.js';
 import type { ReviewBridgeConfig } from '../config/types.js';
+import { chunkDiff, estimateTokens } from '../utils/chunking.js';
 
-// Response schemas omit session_id — the reviewer doesn't know our session concept
+// Response schemas omit fields the reviewer doesn't produce
 const PlanReviewResponseSchema = PlanReviewResultSchema.omit({ session_id: true });
-const CodeReviewResponseSchema = CodeReviewResultSchema.omit({ session_id: true });
-const PrecommitResponseSchema = PrecommitResultSchema.omit({ session_id: true });
+const CodeReviewResponseSchema = CodeReviewResultSchema.omit({ session_id: true, chunks_reviewed: true });
+const PrecommitResponseSchema = PrecommitResultSchema.omit({ session_id: true, chunks_reviewed: true });
 
 interface PlanReviewInput {
   plan: string;
@@ -173,6 +175,76 @@ async function runReview<T extends Record<string, unknown>>(params: {
   return err(`${ErrorCode.CODEX_PARSE_ERROR}: ${lastError}`);
 }
 
+// Fixed overhead for prompt framing (role, rubric, schema, chunk header)
+const PROMPT_OVERHEAD_TOKENS = 2000;
+
+function computeVariableOverhead(parts: string[]): number {
+  let total = 0;
+  for (const part of parts) {
+    if (part) total += estimateTokens(part);
+  }
+  return total;
+}
+
+// Higher rank = more severe. Options are ['critical','major','minor','nitpick'] so reverse index.
+const severityRank: Record<CodeFindingSeverity, number> = Object.fromEntries(
+  CodeFindingSeveritySchema.options.map((s, i, arr) => [s, arr.length - 1 - i]),
+) as Record<CodeFindingSeverity, number>;
+
+function deduplicateFindings(findings: CodeFinding[]): CodeFinding[] {
+  const map = new Map<string, CodeFinding>();
+  const keyless: CodeFinding[] = [];
+
+  for (const f of findings) {
+    if (f.file === null || f.line === null) {
+      keyless.push(f);
+      continue;
+    }
+    const key = `${f.file}:${f.line}:${f.category}`;
+    const existing = map.get(key);
+    if (!existing || severityRank[f.severity] > severityRank[existing.severity]) {
+      map.set(key, f);
+    }
+  }
+
+  return [...map.values(), ...keyless];
+}
+
+const codeVerdictRank: Record<string, number> = { approve: 0, request_changes: 1, reject: 2 };
+
+function mergeCodeResults(
+  results: Omit<CodeReviewResult, 'chunks_reviewed'>[],
+  sessionId: string,
+): CodeReviewResult {
+  let worstVerdict = results[0].verdict;
+  for (const r of results) {
+    if (codeVerdictRank[r.verdict] > codeVerdictRank[worstVerdict]) {
+      worstVerdict = r.verdict;
+    }
+  }
+
+  return {
+    verdict: worstVerdict,
+    summary: results.map((r) => r.summary).join(' '),
+    findings: deduplicateFindings(results.flatMap((r) => r.findings)),
+    session_id: sessionId,
+    chunks_reviewed: results.length,
+  };
+}
+
+function mergePrecommitResults(
+  results: Omit<PrecommitResult, 'chunks_reviewed'>[],
+  sessionId: string,
+): PrecommitResult {
+  return {
+    ready_to_commit: results.every((r) => r.ready_to_commit),
+    blockers: results.flatMap((r) => r.blockers),
+    warnings: results.flatMap((r) => r.warnings),
+    session_id: sessionId,
+    chunks_reviewed: results.length,
+  };
+}
+
 export function createCodexClient(config: ReviewBridgeConfig): CodexClient {
   let codex: Codex;
   try {
@@ -203,33 +275,129 @@ export function createCodexClient(config: ReviewBridgeConfig): CodexClient {
       });
     },
 
-    reviewCode(input) {
-      const prompt = buildCodeReviewPrompt(input, {
+    async reviewCode(input) {
+      const criteria = input.criteria ?? config.review_standards.code_review.criteria;
+      const variableOverhead = computeVariableOverhead([
+        input.context ?? '',
+        config.project_context,
+        criteria.join(', '),
+      ]);
+      const diffBudget = Math.max(config.max_chunk_tokens - PROMPT_OVERHEAD_TOKENS - variableOverhead, 500);
+      const chunks = chunkDiff(input.diff, diffBudget);
+
+      // Empty diff — synthetic approve
+      if (chunks.length === 0) {
+        return ok<CodeReviewResult>({
+          verdict: 'approve',
+          summary: 'No changes to review.',
+          findings: [],
+          session_id: input.session_id ?? '',
+        });
+      }
+
+      // Single chunk — standard path (no chunks_reviewed)
+      if (chunks.length === 1) {
+        const prompt = buildCodeReviewPrompt(input, {
+          project_context: config.project_context,
+          criteria: config.review_standards.code_review.criteria,
+          require_tests: config.review_standards.code_review.require_tests,
+        });
+        return runReview<Omit<CodeReviewResult, 'session_id' | 'chunks_reviewed'>>({
+          codex,
+          config,
+          prompt,
+          responseSchema: CodeReviewResponseSchema,
+          sessionId: input.session_id,
+        });
+      }
+
+      // Multi-chunk — sequential review with per-chunk timeout
+      const codeConfig = {
         project_context: config.project_context,
         criteria: config.review_standards.code_review.criteria,
         require_tests: config.review_standards.code_review.require_tests,
-      });
-      return runReview<Omit<CodeReviewResult, 'session_id'>>({
-        codex,
-        config,
-        prompt,
-        responseSchema: CodeReviewResponseSchema,
-        sessionId: input.session_id,
-      });
+      };
+      const chunkResults: Omit<CodeReviewResult, 'chunks_reviewed'>[] = [];
+      let sessionId = input.session_id;
+
+      for (let i = 0; i < chunks.length; i++) {
+        const chunkHeader = `Chunk ${i + 1} of ${chunks.length}: reviewing the following files only.`;
+        const prompt = buildCodeReviewPrompt({ ...input, diff: chunks[i], chunkHeader }, codeConfig);
+        const result = await runReview<Omit<CodeReviewResult, 'session_id' | 'chunks_reviewed'>>({
+          codex,
+          config,
+          prompt,
+          responseSchema: CodeReviewResponseSchema,
+          sessionId,
+        });
+
+        if (!result.ok) return result;
+        chunkResults.push(result.data);
+        sessionId = result.data.session_id;
+      }
+
+      return ok(mergeCodeResults(chunkResults, sessionId!));
     },
 
-    reviewPrecommit(input) {
-      const prompt = buildPrecommitPrompt(input, {
+    async reviewPrecommit(input) {
+      const checklist = input.checklist ?? [];
+      const variableOverhead = computeVariableOverhead([
+        config.project_context,
+        checklist.join(', '),
+      ]);
+      const diffBudget = Math.max(config.max_chunk_tokens - PROMPT_OVERHEAD_TOKENS - variableOverhead, 500);
+      const chunks = chunkDiff(input.diff, diffBudget);
+
+      // Empty diff — synthetic pass
+      if (chunks.length === 0) {
+        return ok<PrecommitResult>({
+          ready_to_commit: true,
+          blockers: [],
+          warnings: [],
+          session_id: input.session_id ?? '',
+        });
+      }
+
+      // Single chunk — standard path (no chunks_reviewed)
+      if (chunks.length === 1) {
+        const prompt = buildPrecommitPrompt(input, {
+          project_context: config.project_context,
+          block_on: config.review_standards.precommit.block_on,
+        });
+        return runReview<Omit<PrecommitResult, 'session_id' | 'chunks_reviewed'>>({
+          codex,
+          config,
+          prompt,
+          responseSchema: PrecommitResponseSchema,
+          sessionId: input.session_id,
+        });
+      }
+
+      // Multi-chunk — sequential review
+      const precommitConfig = {
         project_context: config.project_context,
         block_on: config.review_standards.precommit.block_on,
-      });
-      return runReview<Omit<PrecommitResult, 'session_id'>>({
-        codex,
-        config,
-        prompt,
-        responseSchema: PrecommitResponseSchema,
-        sessionId: input.session_id,
-      });
+      };
+      const chunkResults: Omit<PrecommitResult, 'chunks_reviewed'>[] = [];
+      let sessionId = input.session_id;
+
+      for (let i = 0; i < chunks.length; i++) {
+        const chunkHeader = `Chunk ${i + 1} of ${chunks.length}: checking the following files only.`;
+        const prompt = buildPrecommitPrompt({ ...input, diff: chunks[i], chunkHeader }, precommitConfig);
+        const result = await runReview<Omit<PrecommitResult, 'session_id' | 'chunks_reviewed'>>({
+          codex,
+          config,
+          prompt,
+          responseSchema: PrecommitResponseSchema,
+          sessionId,
+        });
+
+        if (!result.ok) return result;
+        chunkResults.push(result.data);
+        sessionId = result.data.session_id;
+      }
+
+      return ok(mergePrecommitResults(chunkResults, sessionId!));
     },
   };
 }

--- a/src/codex/prompts.test.ts
+++ b/src/codex/prompts.test.ts
@@ -292,6 +292,16 @@ describe('buildCodeReviewPrompt', () => {
     expect(result).toContain(diff);
     expect(result).toContain('verdict');
   });
+
+  it('includes chunkHeader when provided', () => {
+    const result = buildCodeReviewPrompt({ diff, chunkHeader: 'Chunk 2 of 4: reviewing src/db.ts only.' });
+    expect(result).toContain('Chunk 2 of 4: reviewing src/db.ts only.');
+  });
+
+  it('omits chunkHeader when not provided', () => {
+    const result = buildCodeReviewPrompt({ diff });
+    expect(result).not.toContain('Chunk');
+  });
 });
 
 // =============================================
@@ -371,5 +381,15 @@ describe('buildPrecommitPrompt', () => {
     const result = buildPrecommitPrompt({ diff });
     expect(result).toContain(diff);
     expect(result).toContain('ready_to_commit');
+  });
+
+  it('includes chunkHeader when provided', () => {
+    const result = buildPrecommitPrompt({ diff, chunkHeader: 'Chunk 1 of 3: checking staged files.' });
+    expect(result).toContain('Chunk 1 of 3: checking staged files.');
+  });
+
+  it('omits chunkHeader when not provided', () => {
+    const result = buildPrecommitPrompt({ diff });
+    expect(result).not.toContain('Chunk');
   });
 });

--- a/src/codex/prompts.ts
+++ b/src/codex/prompts.ts
@@ -143,6 +143,7 @@ export function buildCodeReviewPrompt(
     diff: string;
     context?: string;
     criteria?: string[];
+    chunkHeader?: string;
   },
   config?: CodeReviewConfig,
 ): string {
@@ -184,6 +185,10 @@ export function buildCodeReviewPrompt(
   }
   sections.push(checklist);
 
+  if (input.chunkHeader) {
+    sections.push(input.chunkHeader);
+  }
+
   const d = makeDelimiter('DIFF', input.diff);
   sections.push(`${d.open}\n${input.diff}\n${d.close}`);
 
@@ -211,6 +216,7 @@ export function buildPrecommitPrompt(
   input: {
     diff: string;
     checklist?: string[];
+    chunkHeader?: string;
   },
   config?: PrecommitConfig,
 ): string {
@@ -240,6 +246,10 @@ export function buildPrecommitPrompt(
     sections.push(
       `Severity threshold: Issues that would be ${blockOn.join(' or ')} severity belong in "blockers". Lesser issues belong in "warnings".`,
     );
+  }
+
+  if (input.chunkHeader) {
+    sections.push(input.chunkHeader);
   }
 
   const d = makeDelimiter('DIFF', input.diff);

--- a/src/codex/types.test.ts
+++ b/src/codex/types.test.ts
@@ -262,6 +262,27 @@ describe('CodeReviewResultSchema', () => {
     const result = CodeReviewResultSchema.safeParse({ ...validCodeResult, verdict: 'revise' });
     expect(result.success).toBe(false);
   });
+
+  it('accepts chunks_reviewed when present', () => {
+    const result = CodeReviewResultSchema.safeParse({ ...validCodeResult, chunks_reviewed: 3 });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.chunks_reviewed).toBe(3);
+    }
+  });
+
+  it('allows omitting chunks_reviewed', () => {
+    const result = CodeReviewResultSchema.safeParse(validCodeResult);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.chunks_reviewed).toBeUndefined();
+    }
+  });
+
+  it('rejects chunks_reviewed of 0', () => {
+    const result = CodeReviewResultSchema.safeParse({ ...validCodeResult, chunks_reviewed: 0 });
+    expect(result.success).toBe(false);
+  });
 });
 
 describe('PrecommitResultSchema', () => {

--- a/src/codex/types.ts
+++ b/src/codex/types.ts
@@ -48,6 +48,7 @@ export const CodeReviewResultSchema = z.object({
   summary: z.string(),
   findings: z.array(CodeFindingSchema),
   session_id: z.string(),
+  chunks_reviewed: z.number().int().positive().optional(),
 });
 
 export const PrecommitResultSchema = z.object({
@@ -55,6 +56,7 @@ export const PrecommitResultSchema = z.object({
   blockers: z.array(z.string()),
   warnings: z.array(z.string()),
   session_id: z.string(),
+  chunks_reviewed: z.number().int().positive().optional(),
 });
 
 export const ReviewStatusSchema = z.object({

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -85,6 +85,7 @@ describe('loadConfig', () => {
       model: 'o3',
       reasoning_effort: 'high',
       timeout_seconds: 600,
+      max_chunk_tokens: 12000,
       project_context: 'React app',
       review_standards: {
         plan_review: {

--- a/src/config/types.test.ts
+++ b/src/config/types.test.ts
@@ -11,6 +11,7 @@ describe('ReviewBridgeConfigSchema', () => {
       expect(config.model).toBe('gpt-5.2-codex');
       expect(config.reasoning_effort).toBe('medium');
       expect(config.timeout_seconds).toBe(300);
+      expect(config.max_chunk_tokens).toBe(8000);
       expect(config.project_context).toBe('');
       expect(config.review_standards.plan_review.focus).toEqual([
         'architecture',
@@ -95,6 +96,7 @@ describe('ReviewBridgeConfigSchema', () => {
       model: 'o3',
       reasoning_effort: 'high',
       timeout_seconds: 600,
+      max_chunk_tokens: 12000,
       project_context: 'React SPA with GraphQL backend',
       review_standards: {
         plan_review: {
@@ -130,6 +132,27 @@ describe('ReviewBridgeConfigSchema', () => {
     expect(result.success).toBe(false);
   });
 
+  it('defaults max_chunk_tokens to 8000', () => {
+    const result = ReviewBridgeConfigSchema.safeParse({});
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.max_chunk_tokens).toBe(8000);
+    }
+  });
+
+  it('allows custom max_chunk_tokens', () => {
+    const result = ReviewBridgeConfigSchema.safeParse({ max_chunk_tokens: 16000 });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.max_chunk_tokens).toBe(16000);
+    }
+  });
+
+  it('rejects max_chunk_tokens of 0', () => {
+    const result = ReviewBridgeConfigSchema.safeParse({ max_chunk_tokens: 0 });
+    expect(result.success).toBe(false);
+  });
+
   it('accepts all valid block_on severities', () => {
     const result = ReviewBridgeConfigSchema.safeParse({
       review_standards: {
@@ -147,6 +170,7 @@ describe('DEFAULT_CONFIG', () => {
     expect(DEFAULT_CONFIG.model).toBe('gpt-5.2-codex');
     expect(DEFAULT_CONFIG.reasoning_effort).toBe('medium');
     expect(DEFAULT_CONFIG.timeout_seconds).toBe(300);
+    expect(DEFAULT_CONFIG.max_chunk_tokens).toBe(8000);
     expect(DEFAULT_CONFIG.project_context).toBe('');
     expect(DEFAULT_CONFIG.review_standards.precommit.block_on).toEqual([
       'critical',

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -29,6 +29,7 @@ export const ReviewBridgeConfigSchema = z.object({
   model: z.string().default('gpt-5.2-codex'),
   reasoning_effort: z.enum(['low', 'medium', 'high']).default('medium'),
   timeout_seconds: z.number().int().positive().default(300),
+  max_chunk_tokens: z.number().int().positive().default(8000),
   review_standards: ReviewStandardsSchema.default(() => ReviewStandardsSchema.parse({})),
   project_context: z.string().default(''),
 });

--- a/src/utils/chunking.ts
+++ b/src/utils/chunking.ts
@@ -21,22 +21,76 @@ function splitByFileHeaders(diff: string): string[] {
   return files;
 }
 
+function splitByHunks(fileDiff: string, maxTokens: number): string[] {
+  const hunkRegex = /^@@ /gm;
+  const indices: number[] = [];
+  let match;
+  while ((match = hunkRegex.exec(fileDiff)) !== null) {
+    indices.push(match.index);
+  }
+
+  // No hunk markers (binary/rename diff) — return unchanged
+  if (indices.length === 0) return [fileDiff];
+
+  const header = fileDiff.slice(0, indices[0]).replace(/\n$/, '');
+  const hunks: string[] = [];
+  for (let i = 0; i < indices.length; i++) {
+    const start = indices[i];
+    const end = i + 1 < indices.length ? indices[i + 1] : fileDiff.length;
+    hunks.push(fileDiff.slice(start, end).replace(/\n$/, ''));
+  }
+
+  // Single hunk — can't split further
+  if (hunks.length <= 1) return [fileDiff];
+
+  // Greedy bin-pack hunks, prepending the file header to each chunk
+  const chunks: string[] = [];
+  let currentHunks = '';
+
+  for (const hunk of hunks) {
+    const piece = currentHunks ? `${currentHunks}\n${hunk}` : hunk;
+    const candidate = `${header}\n${piece}`;
+    if (currentHunks && estimateTokens(candidate) > maxTokens) {
+      chunks.push(`${header}\n${currentHunks}`);
+      currentHunks = hunk;
+    } else {
+      currentHunks = piece;
+    }
+  }
+
+  if (currentHunks) chunks.push(`${header}\n${currentHunks}`);
+  return chunks;
+}
+
 export function chunkDiff(diff: string, maxTokens: number): string[] {
   if (!diff.trim()) return [];
   if (maxTokens <= 0) return [diff];
   if (estimateTokens(diff) <= maxTokens) return [diff];
 
   const files = splitByFileHeaders(diff);
-  if (files.length <= 1) return [diff];
 
+  // Expand oversized files into hunk-level pieces, keep small files intact
+  const pieces: string[] = [];
+  for (const file of files) {
+    if (estimateTokens(file) > maxTokens) {
+      pieces.push(...splitByHunks(file, maxTokens));
+    } else {
+      pieces.push(file);
+    }
+  }
+
+  // Single piece that can't be split further
+  if (pieces.length <= 1) return [diff];
+
+  // Greedy bin-pack pieces into chunks
   const chunks: string[] = [];
   let current = '';
 
-  for (const file of files) {
-    const combined = current ? `${current}\n${file}` : file;
+  for (const piece of pieces) {
+    const combined = current ? `${current}\n${piece}` : piece;
     if (current && estimateTokens(combined) > maxTokens) {
       chunks.push(current);
-      current = file;
+      current = piece;
     } else {
       current = combined;
     }


### PR DESCRIPTION
## Summary

- Large diffs are now automatically split into chunks and reviewed sequentially via Codex threads
- Added intra-file hunk splitting (`splitByHunks`) so single large files are split at `@@` boundaries
- Added `max_chunk_tokens` config field (default 8000) to control chunk size
- Chunk results are merged: worst verdict wins, findings deduplicated by `file:line:category` keeping worst severity
- Synthetic empty-diff responses generate unique session IDs via `randomUUID()` to prevent storage collisions

## Changes

- `src/utils/chunking.ts` — `splitByHunks` for intra-file splitting, updated `chunkDiff` to expand oversized files
- `src/codex/client.ts` — Chunking wired into `reviewCode` and `reviewPrecommit` with merge/dedup logic, prompt budget calculation with overhead headroom
- `src/codex/types.ts` — Added optional `chunks_reviewed` to code review and precommit result schemas
- `src/codex/prompts.ts` — Added `chunkHeader` parameter to code review and precommit prompt builders
- `src/config/types.ts` — Added `max_chunk_tokens` config field
- `README.md` — Documented `max_chunk_tokens` in config example

## Test plan

- [ ] 343 tests pass (`npm test`)
- [ ] Typecheck clean (`npm run typecheck`)
- [ ] Lint clean (`npm run lint`)
- [ ] Build succeeds (`npm run build`)
- [ ] 30 new tests covering: hunk splitting, chunk merging, verdict precedence, finding dedup, empty diff handling, session ID uniqueness, criteria budget consistency