### PR TITLE
feat: add auto_diff to review_code tool

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -20,7 +20,8 @@ WORKFLOW: Use these tools in order during a feature lifecycle:
 1. review_plan — Call AFTER drafting an implementation plan, BEFORE writing code.
    Returns a verdict (approve/revise/reject) with findings. Save the session_id.
 
-2. review_code — Call AFTER writing or modifying code. Pass a git diff as input.
+2. review_code — Call AFTER writing or modifying code. Auto-captures working changes,
+   or pass a git diff explicitly for PR/branch reviews.
    Pass the session_id from review_plan so the reviewer checks code against the plan.
    Returns a verdict (approve/request_changes/reject) with file and line references.
 
@@ -41,7 +42,7 @@ ACTING ON RESULTS:
 - reject → Rethink the approach. Consider a new plan and start a fresh session.
 
 TIPS:
-- For review_code, capture the diff with git diff and pass it as the diff parameter.
+- review_code auto-captures working changes (git diff HEAD) — pass diff explicitly only for PR or branch diffs.
 - review_precommit auto-captures staged changes — no need to pass a diff manually.
 - You do not need to review every change. Use your judgement on when a review adds value.`;
 

--- a/src/tools/review-code.test.ts
+++ b/src/tools/review-code.test.ts
@@ -16,8 +16,17 @@ vi.mock('../storage/sessions.js', () => ({
   activateSession: vi.fn(),
 }));
 
+vi.mock('../utils/resolve-diff.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../utils/resolve-diff.js')>();
+  return {
+    ...actual,
+    resolveCodeDiff: vi.fn(),
+  };
+});
+
 import { saveReview } from '../storage/reviews.js';
 import { getOrCreateSession, markSessionCompleted, markSessionFailed, activateSession } from '../storage/sessions.js';
+import { resolveCodeDiff } from '../utils/resolve-diff.js';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type HandlerFn = (args: Record<string, unknown>, extra: unknown) => Promise<any>;
@@ -50,6 +59,10 @@ beforeEach(() => {
     reviewPrecommit: vi.fn(),
   };
   mockServer = { registerTool: vi.fn() };
+  // Default: resolveCodeDiff passes through whatever diff is provided
+  vi.mocked(resolveCodeDiff).mockImplementation(async (args) => {
+    return ok(args.diff ?? 'auto-captured diff');
+  });
 });
 
 function setupHandler(db?: unknown) {
@@ -274,5 +287,68 @@ describe('registerReviewCodeTool with db', () => {
     await handler({ diff: 'some diff', session_id: 'thread_xyz' }, {});
 
     expect(markSessionCompleted).toHaveBeenCalledWith(mockDb, 'thread_xyz');
+  });
+});
+
+describe('review_code auto_diff', () => {
+  beforeEach(() => setupHandler());
+
+  it('auto-captures changes when diff is omitted', async () => {
+    vi.mocked(resolveCodeDiff).mockResolvedValue(ok('auto-captured diff'));
+    vi.mocked(mockClient.reviewCode).mockResolvedValue(ok(validResult));
+
+    await handler({}, {});
+
+    expect(resolveCodeDiff).toHaveBeenCalledWith({ diff: undefined, auto_diff: undefined });
+    expect(mockClient.reviewCode).toHaveBeenCalledWith(
+      expect.objectContaining({ diff: 'auto-captured diff' }),
+    );
+  });
+
+  it('passes explicit diff through resolveCodeDiff', async () => {
+    vi.mocked(resolveCodeDiff).mockResolvedValue(ok('explicit diff'));
+    vi.mocked(mockClient.reviewCode).mockResolvedValue(ok(validResult));
+
+    await handler({ diff: 'explicit diff' }, {});
+
+    expect(resolveCodeDiff).toHaveBeenCalledWith(
+      expect.objectContaining({ diff: 'explicit diff' }),
+    );
+  });
+
+  it('returns approve-shaped response when no working changes', async () => {
+    vi.mocked(resolveCodeDiff).mockResolvedValue(
+      err('NO_WORKING_CHANGES: No changes found vs HEAD.'),
+    );
+
+    const result = await handler({}, {});
+
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.verdict).toBe('approve');
+    expect(parsed.summary).toBe('No changes found to review.');
+    expect(parsed.findings).toEqual([]);
+    expect(parsed.session_id).toBe('');
+  });
+
+  it('returns MCP error when git fails', async () => {
+    vi.mocked(resolveCodeDiff).mockResolvedValue(
+      err('GIT_ERROR: fatal: not a git repository'),
+    );
+
+    const result = await handler({}, {});
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('GIT_ERROR');
+  });
+
+  it('does not call client.reviewCode when no working changes', async () => {
+    vi.mocked(resolveCodeDiff).mockResolvedValue(
+      err('NO_WORKING_CHANGES: No changes found vs HEAD.'),
+    );
+
+    await handler({}, {});
+
+    expect(mockClient.reviewCode).not.toHaveBeenCalled();
   });
 });

--- a/src/tools/review-code.ts
+++ b/src/tools/review-code.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type Database from 'better-sqlite3';
 import type { CodexClient } from '../codex/client.js';
+import { resolveCodeDiff, NO_WORKING_CHANGES } from '../utils/resolve-diff.js';
 import { createSessionTracker } from '../storage/session-tracker.js';
 
 export function registerReviewCodeTool(server: McpServer, client: CodexClient, db?: Database.Database): void {
@@ -16,9 +17,13 @@ export function registerReviewCodeTool(server: McpServer, client: CodexClient, d
         'If you reviewed a plan first, pass the same session_id so the reviewer checks the code against the plan. ' +
         'Returns a verdict (approve/request_changes/reject) and findings with file, line, severity, and suggestions.',
       inputSchema: {
-        diff: z.string().describe(
+        diff: z.string().optional().describe(
           'Raw git diff output to review. Must be unified diff format ' +
-          '(output of git diff, gh pr diff, etc.). Do NOT pass summaries or descriptions.',
+          '(output of git diff, gh pr diff, etc.). Do NOT pass summaries or descriptions. ' +
+          'If omitted, auto-captures changes via git diff HEAD.',
+        ),
+        auto_diff: z.boolean().optional().default(true).describe(
+          'Auto-capture working tree changes (staged + unstaged) via git diff HEAD',
         ),
         context: z.string().optional().describe('Intent of the changes'),
         session_id: z.string().optional().describe('Continue from previous review'),
@@ -28,9 +33,31 @@ export function registerReviewCodeTool(server: McpServer, client: CodexClient, d
     async (args) => {
       const tracker = createSessionTracker(db);
       try {
+        // Resolve diff (auto-capture or explicit)
+        const diffResult = await resolveCodeDiff({ diff: args.diff, auto_diff: args.auto_diff });
+        if (!diffResult.ok) {
+          if (diffResult.error.startsWith(NO_WORKING_CHANGES)) {
+            return {
+              content: [
+                {
+                  type: 'text' as const,
+                  text: JSON.stringify({
+                    verdict: 'approve',
+                    summary: 'No changes found to review.',
+                    findings: [],
+                    session_id: args.session_id ?? '',
+                  }),
+                },
+              ],
+            };
+          }
+          return { content: [{ type: 'text' as const, text: diffResult.error }], isError: true };
+        }
+        const diff = diffResult.data;
+
         tracker.preflight(args.session_id);
 
-        const result = await client.reviewCode(args);
+        const result = await client.reviewCode({ ...args, diff });
         if (!result.ok) {
           tracker.recordFailure();
           return { content: [{ type: 'text' as const, text: result.error }], isError: true };

--- a/src/utils/git.test.ts
+++ b/src/utils/git.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { getStagedDiff, getUnstagedDiff, getDiffBetween, isGitRepo } from './git.js';
+import { getStagedDiff, getUnstagedDiff, getDiffBetween, getWorkingDiff, isGitRepo } from './git.js';
 
 vi.mock('node:child_process', () => ({ exec: vi.fn() }));
 
@@ -155,6 +155,85 @@ describe('isGitRepo', () => {
     mockSuccess('false\n');
     const result = await isGitRepo();
     expect(result).toBe(false);
+  });
+});
+
+describe('getWorkingDiff', () => {
+  it('returns diff vs HEAD when HEAD exists', async () => {
+    // First call: rev-parse --verify HEAD succeeds
+    // Second call: git diff HEAD returns diff
+    let callCount = 0;
+    mockExec.mockImplementation(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ((cmd: string, opts: any, cb: (err: Error | null, stdout: string, stderr: string) => void) => {
+        callCount++;
+        if (callCount === 1) {
+          cb(null, 'abc123\n', ''); // HEAD exists
+        } else {
+          cb(null, sampleDiff + '\n', '');
+        }
+      }) as typeof exec,
+    );
+
+    const result = await getWorkingDiff();
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data).toBe(sampleDiff);
+    }
+  });
+
+  it('returns empty string when HEAD exists but no changes', async () => {
+    let callCount = 0;
+    mockExec.mockImplementation(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ((cmd: string, opts: any, cb: (err: Error | null, stdout: string, stderr: string) => void) => {
+        callCount++;
+        if (callCount === 1) {
+          cb(null, 'abc123\n', '');
+        } else {
+          cb(null, '', '');
+        }
+      }) as typeof exec,
+    );
+
+    const result = await getWorkingDiff();
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data).toBe('');
+    }
+  });
+
+  it('falls back to staged + unstaged when HEAD does not exist', async () => {
+    let callCount = 0;
+    mockExec.mockImplementation(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ((cmd: string, opts: any, cb: (err: Error | null, stdout: string, stderr: string) => void) => {
+        callCount++;
+        if (callCount === 1) {
+          // rev-parse --verify HEAD fails on unborn repo
+          cb(Object.assign(new Error('HEAD'), { stderr: "fatal: Needed a single revision\nHEAD" }), '', "fatal: Needed a single revision\nHEAD");
+        } else if (callCount === 2) {
+          cb(null, sampleDiff + '\n', ''); // staged
+        } else {
+          cb(null, '', ''); // unstaged (empty)
+        }
+      }) as typeof exec,
+    );
+
+    const result = await getWorkingDiff();
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data).toBe(sampleDiff);
+    }
+  });
+
+  it('returns GIT_ERROR when not in a git repo', async () => {
+    mockFailure('fatal: not a git repository');
+    const result = await getWorkingDiff();
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('GIT_ERROR');
+    }
   });
 });
 

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -57,6 +57,29 @@ export async function getDiffBetween(base: string, head: string): Promise<Result
   }
 }
 
+export async function getWorkingDiff(): Promise<Result<string>> {
+  try {
+    // Check if HEAD exists (fails on repos with no commits)
+    await execAsync('git rev-parse --verify HEAD');
+    const { stdout } = await execAsync('git diff HEAD --no-color');
+    return ok(stdout.trim());
+  } catch (e: unknown) {
+    // If HEAD doesn't exist (unborn repo), fall back to staged + unstaged
+    const stderr = (e as { stderr?: string }).stderr ?? '';
+    if (stderr.includes('HEAD')) {
+      try {
+        const staged = await execAsync('git diff --cached --no-color');
+        const unstaged = await execAsync('git diff --no-color');
+        const combined = [staged.stdout.trim(), unstaged.stdout.trim()].filter(Boolean).join('\n');
+        return ok(combined);
+      } catch (fallbackErr: unknown) {
+        return gitError(fallbackErr);
+      }
+    }
+    return gitError(e);
+  }
+}
+
 export async function isGitRepo(): Promise<boolean> {
   try {
     const { stdout } = await execAsync('git rev-parse --is-inside-work-tree');

--- a/src/utils/resolve-diff.test.ts
+++ b/src/utils/resolve-diff.test.ts
@@ -1,13 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { resolvePrecommitDiff, NO_STAGED_CHANGES } from './resolve-diff.js';
+import { resolvePrecommitDiff, resolveCodeDiff, NO_STAGED_CHANGES, NO_WORKING_CHANGES } from './resolve-diff.js';
 
 vi.mock('./git.js', () => ({
   getStagedDiff: vi.fn(),
+  getWorkingDiff: vi.fn(),
 }));
 
-import { getStagedDiff } from './git.js';
+import { getStagedDiff, getWorkingDiff } from './git.js';
 
 const mockGetStagedDiff = vi.mocked(getStagedDiff);
+const mockGetWorkingDiff = vi.mocked(getWorkingDiff);
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -81,6 +83,88 @@ describe('resolvePrecommitDiff', () => {
         expect(result.error).toBe('auto_diff disabled and no diff provided');
       }
       expect(mockGetStagedDiff).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe('resolveCodeDiff', () => {
+  describe('explicit diff precedence', () => {
+    it('returns explicit non-empty diff when provided', async () => {
+      const result = await resolveCodeDiff({ diff: sampleDiff });
+      expect(result).toEqual({ ok: true, data: sampleDiff });
+      expect(mockGetWorkingDiff).not.toHaveBeenCalled();
+    });
+
+    it('uses explicit diff even when auto_diff is true', async () => {
+      const result = await resolveCodeDiff({ diff: sampleDiff, auto_diff: true });
+      expect(result).toEqual({ ok: true, data: sampleDiff });
+      expect(mockGetWorkingDiff).not.toHaveBeenCalled();
+    });
+
+    it('treats empty string as no diff (triggers auto-capture)', async () => {
+      mockGetWorkingDiff.mockResolvedValue({ ok: true, data: sampleDiff });
+      const result = await resolveCodeDiff({ diff: '' });
+      expect(result).toEqual({ ok: true, data: sampleDiff });
+      expect(mockGetWorkingDiff).toHaveBeenCalledOnce();
+    });
+
+    it('treats whitespace-only string as no diff (triggers auto-capture)', async () => {
+      mockGetWorkingDiff.mockResolvedValue({ ok: true, data: sampleDiff });
+      const result = await resolveCodeDiff({ diff: '   ' });
+      expect(result).toEqual({ ok: true, data: sampleDiff });
+      expect(mockGetWorkingDiff).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('auto_diff capture', () => {
+    it('auto-captures working diff when no explicit diff and auto_diff is true', async () => {
+      mockGetWorkingDiff.mockResolvedValue({ ok: true, data: sampleDiff });
+      const result = await resolveCodeDiff({ auto_diff: true });
+      expect(result).toEqual({ ok: true, data: sampleDiff });
+      expect(mockGetWorkingDiff).toHaveBeenCalledOnce();
+    });
+
+    it('auto-captures working diff when no explicit diff and auto_diff is undefined', async () => {
+      mockGetWorkingDiff.mockResolvedValue({ ok: true, data: sampleDiff });
+      const result = await resolveCodeDiff({});
+      expect(result).toEqual({ ok: true, data: sampleDiff });
+      expect(mockGetWorkingDiff).toHaveBeenCalledOnce();
+    });
+
+    it('returns NO_WORKING_CHANGES error when working diff is empty', async () => {
+      mockGetWorkingDiff.mockResolvedValue({ ok: true, data: '' });
+      const result = await resolveCodeDiff({});
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toMatch(new RegExp(`^${NO_WORKING_CHANGES}:`));
+        expect(result.error).toContain('No changes found vs HEAD');
+      }
+    });
+
+    it('propagates git errors from getWorkingDiff', async () => {
+      mockGetWorkingDiff.mockResolvedValue({ ok: false, error: 'GIT_ERROR: fatal: not a git repository' });
+      const result = await resolveCodeDiff({});
+      expect(result).toEqual({ ok: false, error: 'GIT_ERROR: fatal: not a git repository' });
+    });
+  });
+
+  describe('auto_diff disabled', () => {
+    it('returns error when auto_diff is false and no diff provided', async () => {
+      const result = await resolveCodeDiff({ auto_diff: false });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toBe('auto_diff disabled and no diff provided');
+      }
+      expect(mockGetWorkingDiff).not.toHaveBeenCalled();
+    });
+
+    it('returns error when auto_diff is false and empty diff provided', async () => {
+      const result = await resolveCodeDiff({ diff: '', auto_diff: false });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toBe('auto_diff disabled and no diff provided');
+      }
+      expect(mockGetWorkingDiff).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/utils/resolve-diff.ts
+++ b/src/utils/resolve-diff.ts
@@ -1,8 +1,9 @@
 import { ok, err } from './errors.js';
 import type { Result } from './errors.js';
-import { getStagedDiff } from './git.js';
+import { getStagedDiff, getWorkingDiff } from './git.js';
 
 export const NO_STAGED_CHANGES = 'NO_STAGED_CHANGES';
+export const NO_WORKING_CHANGES = 'NO_WORKING_CHANGES';
 
 export async function resolvePrecommitDiff(args: {
   diff?: string;
@@ -21,6 +22,30 @@ export async function resolvePrecommitDiff(args: {
     }
     if (!gitResult.data) {
       return err(`${NO_STAGED_CHANGES}: No staged changes found. Stage files with git add first.`);
+    }
+    return ok(gitResult.data);
+  }
+
+  return err('auto_diff disabled and no diff provided');
+}
+
+export async function resolveCodeDiff(args: {
+  diff?: string;
+  auto_diff?: boolean;
+}): Promise<Result<string>> {
+  // Explicit non-empty diff takes precedence
+  if (args.diff !== undefined && args.diff.trim() !== '') {
+    return ok(args.diff);
+  }
+
+  // auto_diff defaults to true (undefined !== false)
+  if (args.auto_diff !== false) {
+    const gitResult = await getWorkingDiff();
+    if (!gitResult.ok) {
+      return gitResult;
+    }
+    if (!gitResult.data) {
+      return err(`${NO_WORKING_CHANGES}: No changes found vs HEAD.`);
     }
     return ok(gitResult.data);
   }


### PR DESCRIPTION
## Summary
- When `diff` is omitted, `review_code` now auto-captures working changes via `git diff HEAD` (staged + unstaged)
- Fixes the issue where MCP tool parameters don't support shell expansion, causing `$(cat file.diff)` to be sent literally and rejected by `looksLikeDiff()` validation
- Follows the same `auto_diff` pattern already used by `review_precommit`

## Changes
- **`src/utils/git.ts`**: Add `getWorkingDiff()` with unborn repo fallback (staged + unstaged when HEAD doesn't exist)
- **`src/utils/resolve-diff.ts`**: Add `resolveCodeDiff()` — empty string triggers auto-capture (unlike `resolvePrecommitDiff` which passes it through)
- **`src/tools/review-code.ts`**: Make `diff` optional, add `auto_diff` (default: true), resolve before client call
- **`src/server.ts`**: Update `SERVER_INSTRUCTIONS` to document auto-capture
- **Tests**: 9 new tests covering auto-capture, empty string handling, no-changes response, git errors, unborn repos

## Test plan
- [x] `npm run build` — compiles
- [x] `npm test` — all 473 tests pass
- [ ] Manual: call `review_code` without diff → auto-captures working changes
- [ ] Manual: call `review_code` with explicit diff → uses that diff
- [ ] Manual: call `review_code` with no changes → returns approve response

🤖 Generated with [Claude Code](https://claude.com/claude-code)