### PR TITLE
fix: thread cwd through auto-capture, agy/codex provider spawns, and precommit config discovery

### DIFF
--- a/src/backends/backend.ts
+++ b/src/backends/backend.ts
@@ -30,6 +30,10 @@ export interface CodeReviewInput {
   model?: string;
   // See PlanReviewInput.deliberate.
   deliberate?: boolean;
+  // Repository directory for auto-capture and provider spawns (e.g. the agy
+  // CLI). Undefined preserves prior behavior (the server process's own cwd).
+  // Already validated to an existing directory by the tool layer.
+  cwd?: string;
 }
 
 export interface PrecommitReviewInput {
@@ -37,6 +41,8 @@ export interface PrecommitReviewInput {
   checklist?: string[];
   session_id?: string;
   model?: string;
+  // See CodeReviewInput.cwd.
+  cwd?: string;
 }
 
 // One finding (from another reviewer) to adjudicate in a cross-review round.

--- a/src/backends/codex.test.ts
+++ b/src/backends/codex.test.ts
@@ -1185,6 +1185,62 @@ describe('config passthrough', () => {
   });
 });
 
+// The SDK's ThreadOptions.workingDirectory is forwarded as `--cd <dir>` by
+// @openai/codex-sdk — verified against its compiled output. Unlike model,
+// there's no evidence it's resume-restricted (see the comment on
+// baseThreadOpts), so it threads through uniformly on both start and resume.
+describe('cwd threading (workingDirectory)', () => {
+  it('reviewCode: forwards cwd as workingDirectory on a fresh startThread', async () => {
+    mockRun.mockResolvedValue({ finalResponse: JSON.stringify(validCodeResponse) });
+
+    const client = createCodexBackend(config);
+    await client.reviewCode({ diff: 'diff --git a/f b/f\n@@ -1 +1 @@\n-a\n+b', cwd: '/some/repo' });
+
+    expect(mockStartThread).toHaveBeenCalledWith(
+      expect.objectContaining({ workingDirectory: '/some/repo' }),
+    );
+  });
+
+  it('reviewPrecommit: forwards cwd as workingDirectory on a resumeThread', async () => {
+    mockRun.mockResolvedValue({ finalResponse: JSON.stringify(validPrecommitResponse) });
+
+    const client = createCodexBackend(config);
+    await client.reviewPrecommit({
+      diff: 'diff --git a/f b/f\n@@ -1 +1 @@\n-a\n+b',
+      session_id: 'existing_thread',
+      cwd: '/some/repo',
+    });
+
+    expect(mockResumeThread).toHaveBeenCalledWith(
+      'existing_thread',
+      expect.objectContaining({ workingDirectory: '/some/repo' }),
+    );
+  });
+
+  it('omitting cwd leaves workingDirectory undefined (preserves default behavior — no --cd added)', async () => {
+    mockRun.mockResolvedValue({ finalResponse: JSON.stringify(validPlanResponse) });
+
+    const client = createCodexBackend(config);
+    await client.reviewPlan({ plan: 'plan' });
+
+    expect(mockStartThread).toHaveBeenCalledWith(
+      expect.objectContaining({ workingDirectory: undefined }),
+    );
+  });
+
+  it('review_plan never threads cwd — PlanReviewInput has no cwd field, workingDirectory stays undefined even on resume', async () => {
+    mockRun.mockResolvedValue({ finalResponse: JSON.stringify(validPlanResponse) });
+
+    const client = createCodexBackend(config);
+    await client.reviewPlan({ plan: 'plan', session_id: 'existing_thread' });
+
+    expect(mockResumeThread).toHaveBeenCalledWith(
+      'existing_thread',
+      expect.objectContaining({ workingDirectory: undefined }),
+    );
+  });
+});
+
 describe('config flows to prompts', () => {
   const configWithContext: ReviewBridgeConfig = {
     ...DEFAULT_CONFIG,

--- a/src/backends/codex.ts
+++ b/src/backends/codex.ts
@@ -154,32 +154,45 @@ export function classifyError(
 // is set. The backend owns this default — the config schema no longer supplies one.
 const CODEX_DEFAULT_MODEL = RECOMMENDED_MODELS.codex[0];
 
-// Thread options shared by the start and resume paths. The model is handled by
-// the two wrappers below: a fresh start always sets it (the orchestrator
-// resolves a concrete model for every start — see startThreadOpts), while the
-// resume path deliberately omits it. The SDK forwards `--model` to `codex exec`
-// unconditionally whenever the field is present (see
-// @openai/codex-sdk/dist/index.js:170), which would reassert a model on resume
-// and either break a thread created with an override or fail auth on
-// ChatGPT-tier Codex if the new model isn't available there. A resumed thread
-// keeps whatever model it was started with.
-function baseThreadOpts(config: ReviewBridgeConfig) {
+// Thread options shared by the start and resume paths.
+//
+// workingDirectory applies uniformly to both. Confirmed against the SDK's
+// actual compiled output (@openai/codex-sdk/dist/index.js): it's forwarded as
+// `--cd <dir>` unconditionally whenever set, built into the command args
+// independently of whether a `resume <id>` subcommand is also appended, and
+// `ThreadOptions` (the type both startThread and resumeThread accept) makes no
+// start/resume distinction for it. `codex exec resume --help` doesn't even
+// list --cd as a resume-specific option — it's a top-level `codex exec` flag
+// governing where the whole invocation runs, not a server-side session
+// parameter. That's structurally unlike model (below): unset/undefined here
+// means no `--cd` is added at all, identical to today's behavior.
+//
+// model is different, and stays resume-restricted. A fresh start always sets
+// it (the orchestrator resolves a concrete model for every start — see
+// startThreadOpts), while the resume path deliberately omits it. The SDK
+// forwards `--model` to `codex exec` unconditionally whenever the field is
+// present (see @openai/codex-sdk/dist/index.js:170), which would reassert a
+// model on resume and either break a thread created with an override or fail
+// auth on ChatGPT-tier Codex if the new model isn't available there. A
+// resumed thread keeps whatever model it was started with.
+function baseThreadOpts(config: ReviewBridgeConfig, cwd?: string) {
   return {
     sandboxMode: 'read-only' as const,
     skipGitRepoCheck: true,
     modelReasoningEffort: config.reasoning_effort,
+    workingDirectory: cwd,
   };
 }
 
 // A fresh thread always starts on a resolved model (the orchestrator resolves
 // one — an explicit pin, config.model, or CODEX_DEFAULT_MODEL — before every
 // start), so it's a required argument here rather than a defaulted fallback.
-function startThreadOpts(config: ReviewBridgeConfig, model: string) {
-  return { model, ...baseThreadOpts(config) };
+function startThreadOpts(config: ReviewBridgeConfig, model: string, cwd?: string) {
+  return { model, ...baseThreadOpts(config, cwd) };
 }
 
-function resumeThreadOpts(config: ReviewBridgeConfig) {
-  return baseThreadOpts(config);
+function resumeThreadOpts(config: ReviewBridgeConfig, cwd?: string) {
+  return baseThreadOpts(config, cwd);
 }
 
 // Codex implementation of the orchestrator's TurnRunner: create or resume a
@@ -187,13 +200,13 @@ function resumeThreadOpts(config: ReviewBridgeConfig) {
 async function runReview<T extends Record<string, unknown>>(
   params: TurnParams & { codex: Codex; config: ReviewBridgeConfig },
 ): Promise<Result<T & { session_id: string }>> {
-  const { codex, config, prompt, responseSchema, sessionId, model, resolvedModel } = params;
+  const { codex, config, prompt, responseSchema, sessionId, model, resolvedModel, cwd } = params;
 
   let thread;
   try {
     thread = sessionId
-      ? codex.resumeThread(sessionId, resumeThreadOpts(config))
-      : codex.startThread(startThreadOpts(config, model ?? resolvedModel));
+      ? codex.resumeThread(sessionId, resumeThreadOpts(config, cwd))
+      : codex.startThread(startThreadOpts(config, model ?? resolvedModel, cwd));
   } catch (e: unknown) {
     if (sessionId) {
       const msg = e instanceof Error ? e.message : String(e);

--- a/src/backends/gemini.test.ts
+++ b/src/backends/gemini.test.ts
@@ -513,6 +513,34 @@ describe('createGeminiBackend', () => {
     expect(lastArgs[lastArgs.indexOf('--conversation') + 1]).toBe('conv-prev');
   });
 
+  it('reviewCode: an explicit cwd is spawned into and used for id capture, instead of process.cwd()', async () => {
+    fakeFiles[CACHE] = JSON.stringify({ '/some/repo': 'conv-cwd' });
+    script({ stdout: JSON.stringify(CODE_OK) });
+
+    const res = await createGeminiBackend(PINNED_CONFIG).reviewCode({
+      diff: SMALL_DIFF,
+      cwd: '/some/repo',
+    });
+
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.data.session_id).toBe('conv-cwd');
+    expect(lastCwd).toBe('/some/repo');
+  });
+
+  it('reviewPrecommit: an explicit cwd is spawned into and used for id capture, instead of process.cwd()', async () => {
+    fakeFiles[CACHE] = JSON.stringify({ '/some/repo': 'conv-precommit-cwd' });
+    script({ stdout: JSON.stringify({ ready_to_commit: true, blockers: [], warnings: [] }) });
+
+    const res = await createGeminiBackend(PINNED_CONFIG).reviewPrecommit({
+      diff: SMALL_DIFF,
+      cwd: '/some/repo',
+    });
+
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.data.session_id).toBe('conv-precommit-cwd');
+    expect(lastCwd).toBe('/some/repo');
+  });
+
   it('retries once on malformed JSON, then succeeds (two spawns)', async () => {
     fakeFiles[CACHE] = JSON.stringify({ [CWD]: 'conv-retry' });
     script({ stdout: 'not json at all' }, { stdout: JSON.stringify(PLAN_OK) });

--- a/src/backends/gemini.ts
+++ b/src/backends/gemini.ts
@@ -241,6 +241,11 @@ export function readConversationId(cwd: string): string | undefined {
 // critical section through a process-global chain so captures can't interleave.
 // Documented limitation: this serializes same-process Gemini reviews; it does
 // not guard against a separate agy process writing the same cwd entry.
+//
+// This chain is GLOBAL (every Gemini review in this process, regardless of
+// cwd, shares it) — not per-cwd. Its scope never varies with the caller's
+// cwd param, so a resumed session passing a different (or no) cwd cannot
+// change what gets serialized against what.
 let serialChain: Promise<unknown> = Promise.resolve();
 export function runSerialized<T>(fn: () => Promise<T>): Promise<T> {
   const result = serialChain.then(fn);
@@ -454,6 +459,21 @@ async function runAgyReview<T extends Record<string, unknown>>(
 
       // Resume → reuse the conversation we resumed; fresh → capture the new id
       // agy just recorded for this cwd.
+      //
+      // Cross-cwd resume safety: this cwd-keyed cache lookup is reachable
+      // ONLY on the fresh branch (sessionId falsy) — the `??` short-circuits
+      // it entirely whenever sessionId is present. A resumed call always
+      // returns the caller's OWN sessionId verbatim, regardless of what cwd
+      // (if any) is passed alongside it: the cache can never substitute a
+      // different id, so a resume can't silently "fork" via this mechanism.
+      // A resume DOES still spawn the agy subprocess in whatever cwd this
+      // particular call specifies (see runAgyPrint above) while asking it to
+      // continue conversation `sessionId` — if that cwd differs from the one
+      // the session started in, the review's *content* may be about the
+      // wrong repo relative to the conversation's history, same as passing
+      // an unrelated `diff`/`plan` to a resumed session always could. That's
+      // a caller-coherence concern, not a data-corruption or identity-
+      // confusion one, and pre-dates cwd threading.
       const resolvedId = sessionId ?? readConversationId(cwd);
       if (!resolvedId) {
         // The review itself parsed fine — this is a storage read failure (agy's
@@ -488,8 +508,13 @@ export function createGeminiBackend(
     );
   }
 
+  // params.cwd is the caller's resolved repository directory (from
+  // CodeReviewInput/PrecommitReviewInput.cwd); fall back to the server
+  // process's own cwd when omitted — the pre-existing, zero-footprint
+  // default. Spreading params first means an explicit cwd wins over the
+  // fallback rather than being silently clobbered by it.
   const turn: TurnRunner = <T extends Record<string, unknown>>(params: TurnParams) =>
-    runAgyReview<T>({ ...params, config, cwd: process.cwd() });
+    runAgyReview<T>({ ...params, config, cwd: params.cwd ?? process.cwd() });
   const deps = {
     config,
     copilotInstructions,

--- a/src/backends/orchestrator.test.ts
+++ b/src/backends/orchestrator.test.ts
@@ -128,6 +128,33 @@ describe('orchestrator — allowsModelOverrideOnResume capability', () => {
     expect(calls[0].model).toBe('m');
     expect(calls.slice(1).every((c) => c.model === undefined)).toBe(true);
   });
+
+  it('single-chunk code review: forwards input.cwd to the turn', async () => {
+    const { turn, calls } = makeFakeTurn(CANNED_CODE);
+    const res = await runCodeReview({ diff: SMALL_DIFF, cwd: '/some/repo' }, deps(true), turn);
+    expect(res.ok).toBe(true);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].cwd).toBe('/some/repo');
+  });
+
+  it('multi-chunk code review: forwards input.cwd on every chunk', async () => {
+    const { turn, calls } = makeFakeTurn(CANNED_CODE);
+    const res = await runCodeReview(
+      { diff: bigDiff(3, 30), cwd: '/some/repo' },
+      deps(true, { max_chunk_tokens: 2500 }),
+      turn,
+    );
+    expect(res.ok).toBe(true);
+    expect(calls.length).toBeGreaterThanOrEqual(2);
+    expect(calls.every((c) => c.cwd === '/some/repo')).toBe(true);
+  });
+
+  it('code review: leaves cwd undefined on the turn when not provided (preserves default behavior)', async () => {
+    const { turn, calls } = makeFakeTurn(CANNED_CODE);
+    const res = await runCodeReview({ diff: SMALL_DIFF }, deps(true), turn);
+    expect(res.ok).toBe(true);
+    expect(calls[0].cwd).toBeUndefined();
+  });
 });
 
 describe('orchestrator — model resolution wiring', () => {

--- a/src/backends/orchestrator.ts
+++ b/src/backends/orchestrator.ts
@@ -195,6 +195,11 @@ export interface TurnParams {
   // error-context so messages report the correct model even when `model` is
   // intentionally undefined on resumed chunks of a chunked review.
   resolvedModel: string;
+  // Repository directory for backends that spawn a subprocess (Gemini/agy).
+  // Forwarded from CodeReviewInput/PrecommitReviewInput.cwd; undefined
+  // preserves prior behavior. Ignored by backends that don't need repo
+  // context (Codex).
+  cwd?: string;
 }
 
 export type TurnRunner = <T extends Record<string, unknown>>(
@@ -348,6 +353,7 @@ export async function runCodeReview(
       sessionId: input.session_id,
       model: perTurnModel(resolved, input.session_id, allowsModelOverrideOnResume),
       resolvedModel: resolved,
+      cwd: input.cwd,
     });
   }
 
@@ -375,6 +381,7 @@ export async function runCodeReview(
       sessionId: chunkSession,
       model: perTurnModel(resolved, chunkSession, allowsModelOverrideOnResume),
       resolvedModel: resolved,
+      cwd: input.cwd,
     });
 
     if (!result.ok) {
@@ -454,6 +461,7 @@ export async function runPrecommitReview(
       sessionId: input.session_id,
       model: perTurnModel(resolved, input.session_id, allowsModelOverrideOnResume),
       resolvedModel: resolved,
+      cwd: input.cwd,
     });
   }
 
@@ -477,6 +485,7 @@ export async function runPrecommitReview(
       sessionId: chunkSession,
       model: perTurnModel(resolved, chunkSession, allowsModelOverrideOnResume),
       resolvedModel: resolved,
+      cwd: input.cwd,
     });
 
     if (!result.ok) {

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -1,21 +1,28 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { loadConfig, formatConfigSource } from './loader.js';
+import {
+  loadConfig,
+  formatConfigSource,
+  discoverProjectConfig,
+  resetConfigWarningMemo,
+} from './loader.js';
 import { DEFAULT_CONFIG } from './types.js';
 
 vi.mock('node:fs', () => ({
   readFileSync: vi.fn(),
   existsSync: vi.fn(),
+  statSync: vi.fn(),
 }));
 
 vi.mock('node:os', () => ({
   homedir: vi.fn(() => '/Users/test'),
 }));
 
-import { readFileSync, existsSync } from 'node:fs';
+import { readFileSync, existsSync, statSync } from 'node:fs';
 import { homedir } from 'node:os';
 
 const mockReadFileSync = vi.mocked(readFileSync);
 const mockExistsSync = vi.mocked(existsSync);
+const mockStatSync = vi.mocked(statSync);
 const mockHomedir = vi.mocked(homedir);
 
 // Helper: build an fs layout where each path either has content,
@@ -44,13 +51,31 @@ function applyLayout(layout: Layout) {
   });
 }
 
+// Minimal fake fs.Stats — only mtimeMs is read by loader.ts. One `as` cast
+// (not `any`), matching the rest of this file's mocking style.
+function fakeStats(mtimeMs: number) {
+  return { mtimeMs } as ReturnType<typeof statSync>;
+}
+
 const ORIGINAL_ENV = process.env.RB_CONFIG_PATH;
 const ORIGINAL_CWD = process.cwd;
 
 beforeEach(() => {
   vi.resetAllMocks();
   mockHomedir.mockReturnValue('/Users/test');
+  // Stable default mtime for every path — existing tests below don't care
+  // about mtime and expect the pre-P2 "warns once per path" behavior, which
+  // this preserves (same path + same mtime = same memo key). Tests that
+  // specifically exercise mtime-based re-warning override this.
+  mockStatSync.mockReturnValue(fakeStats(1000));
   delete process.env.RB_CONFIG_PATH;
+  // warnUnknownConfigKeys' one-time-per-(path,mtime) memo is process-lifetime
+  // module state, not a vi mock — vi.resetAllMocks() above doesn't touch it.
+  // Several tests below intentionally reuse the same config path across
+  // cases, so it must be cleared here or a later test's warning assertion
+  // would silently never fire (already "warned" by an earlier test in this
+  // file, at the same default mtime).
+  resetConfigWarningMemo();
 });
 
 afterEach(() => {
@@ -465,5 +490,130 @@ describe('loadConfig — unknown-key warnings (ISS-004)', () => {
     applyLayout({ '/p/.reviewbridge.json': JSON.stringify({ review_standards: 'nope' }) });
     expect(() => loadConfig('/p')).not.toThrow();
     spy.mockRestore();
+  });
+
+  it('warns only once per (path, mtime) across repeated loads of the SAME unchanged file (F9)', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    applyLayout({
+      '/p/.reviewbridge.json': JSON.stringify({ model: 'gpt-5.4', bogus_field: 1 }),
+    });
+    // mtime stays at the beforeEach default (1000) for every read — an
+    // unchanged file, the common case.
+
+    loadConfig('/p');
+    loadConfig('/p');
+    loadConfig('/p');
+
+    const warnings = spy.mock.calls
+      .map((c) => String(c[0]))
+      .filter((w) => w.includes('unrecognized config field'));
+    expect(warnings).toHaveLength(1);
+    spy.mockRestore();
+  });
+
+  it('P2: an EDITED file (different mtime, new unknown key) re-warns instead of being silently suppressed by the earlier warning', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    // First read: mtime 1000, one unknown key (old_bogus).
+    mockStatSync.mockReturnValueOnce(fakeStats(1000));
+    applyLayout({
+      '/p/.reviewbridge.json': JSON.stringify({ model: 'gpt-5.4', old_bogus: 1 }),
+    });
+    loadConfig('/p');
+
+    // "Edit" the file mid-process: same path, later mtime, a DIFFERENT
+    // unknown key. Before P2 (path-only keying) this second call would have
+    // been silently swallowed by the first call's memo entry — new_bogus
+    // would never surface.
+    mockStatSync.mockReturnValueOnce(fakeStats(2000));
+    applyLayout({
+      '/p/.reviewbridge.json': JSON.stringify({ model: 'gpt-5.4', new_bogus: 1 }),
+    });
+    loadConfig('/p');
+
+    const warnings = spy.mock.calls
+      .map((c) => String(c[0]))
+      .filter((w) => w.includes('unrecognized config field'));
+    expect(warnings).toHaveLength(2);
+    expect(warnings.some((w) => w.includes('old_bogus'))).toBe(true);
+    expect(warnings.some((w) => w.includes('new_bogus'))).toBe(true);
+    spy.mockRestore();
+  });
+
+  it('still warns for a DIFFERENT path even after another path was already warned', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    applyLayout({
+      '/p1/.reviewbridge.json': JSON.stringify({ bogus_a: 1 }),
+      '/p2/.reviewbridge.json': JSON.stringify({ bogus_b: 1 }),
+    });
+
+    loadConfig('/p1');
+    loadConfig('/p2');
+
+    const warnings = spy.mock.calls
+      .map((c) => String(c[0]))
+      .filter((w) => w.includes('unrecognized config field'));
+    expect(warnings.some((w) => w.includes('bogus_a'))).toBe(true);
+    expect(warnings.some((w) => w.includes('bogus_b'))).toBe(true);
+    spy.mockRestore();
+  });
+});
+
+describe('discoverProjectConfig (F4)', () => {
+  it('finds .reviewbridge.json in the exact start directory', () => {
+    applyLayout({
+      '/repo/.reviewbridge.json': JSON.stringify({ model: 'gpt-5.4' }),
+    });
+
+    const result = discoverProjectConfig('/repo');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data?.config.model).toBe('gpt-5.4');
+      expect(result.data?.source).toEqual({ kind: 'project', path: '/repo/.reviewbridge.json' });
+    }
+  });
+
+  it("walks up from a SUBDIRECTORY to find the repo-root config — the exact case loadConfig(cwd)'s single-directory lookup misses", () => {
+    applyLayout({
+      '/repo/.reviewbridge.json': JSON.stringify({ model: 'root-model' }),
+    });
+
+    const result = discoverProjectConfig('/repo/src/deep/subdir');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data?.config.model).toBe('root-model');
+      expect(result.data?.source).toEqual({ kind: 'project', path: '/repo/.reviewbridge.json' });
+    }
+  });
+
+  it("stops at a .git boundary, same as loadConfig()'s own implicit walk-up", () => {
+    applyLayout({
+      '/repo/.git': '', // .git boundary at /repo
+      '/.reviewbridge.json': JSON.stringify({ model: 'above-boundary' }), // above it — must not be found
+    });
+
+    const result = discoverProjectConfig('/repo/sub');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data).toBeNull();
+    }
+  });
+
+  it('returns ok(null) — not schema defaults, not an error — when nothing is found anywhere up the tree', () => {
+    applyLayout({});
+
+    const result = discoverProjectConfig('/nowhere/at/all');
+    expect(result).toEqual({ ok: true, data: null });
+  });
+
+  it('aborts on a malformed config found while walking up', () => {
+    applyLayout({
+      '/repo/sub/.reviewbridge.json': '{ broken',
+    });
+
+    const result = discoverProjectConfig('/repo/sub');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('invalid JSON');
+    }
   });
 });

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, statSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { ok, err, ErrorCode } from '../utils/errors.js';
@@ -25,12 +25,40 @@ function unknownKeys(raw: unknown, known: string[]): string[] {
   return isPlainObject(raw) ? Object.keys(raw).filter((k) => !known.includes(k)) : [];
 }
 
+// `${path}:${mtimeMs}` keys already checked for unrecognized keys this
+// process lifetime. Config used to load exactly once per process (server
+// startup, or one CLI invocation); discoverProjectConfig below makes
+// per-call discovery possible from the MCP tool layer, so the SAME on-disk
+// file can now be probed many times across many tool calls in one
+// long-lived server run — without this, each call would re-emit the
+// identical stderr warning. Keying by mtime (not path alone) means a file
+// edited mid-process — e.g. someone adds a new typo'd key to a running
+// server's .reviewbridge.json — still gets checked and warned about again,
+// instead of being silently suppressed forever by the first, now-stale,
+// warning. A plain Set is fine here: bounded in practice by the number of
+// distinct config files on the machine times how many times each gets
+// edited during one server's lifetime, not an unbounded stream. Exported
+// ONLY so loader.test.ts can reset it between cases; production code never
+// calls resetConfigWarningMemo.
+const warnedConfigPaths = new Set<string>();
+export function resetConfigWarningMemo(): void {
+  warnedConfigPaths.clear();
+}
+
 // Warn (never reject) about config keys the schema silently strips, at every
 // level — so a stale field like a removed review_standards.code_review.max_file_size
 // surfaces instead of being an invisible no-op. STDERR only: the MCP transport's
 // JSON-RPC stream is on stdout, so a stdout write would corrupt it. `raw` is
 // untrusted JSON.parse output, so every descent is guarded by isPlainObject.
-function warnUnknownConfigKeys(raw: unknown, path: string): void {
+// Checks (and warns for) a given (path, mtime) pair at most once per process
+// — see warnedConfigPaths. `mtimeMs` is undefined when it couldn't be
+// stat'd (e.g. a race between the successful read and the stat); that
+// degrades gracefully to a stable per-path key, matching the simpler
+// once-per-path behavior this had before mtime keying.
+function warnUnknownConfigKeys(raw: unknown, path: string, mtimeMs: number | undefined): void {
+  const memoKey = `${path}:${mtimeMs}`;
+  if (warnedConfigPaths.has(memoKey)) return;
+  warnedConfigPaths.add(memoKey);
   const warn = (loc: string, keys: string[]): void => {
     if (keys.length > 0) {
       console.error(`[codex-bridge] ignoring unrecognized config field(s) in ${loc} (${path}): ${keys.join(', ')}`);
@@ -96,7 +124,18 @@ function probe(path: string): ProbeResult {
     };
   }
 
-  warnUnknownConfigKeys(parsed, path);
+  // Best-effort: the mtime only sharpens the warning memo (see
+  // warnUnknownConfigKeys). A stat failure here — e.g. the file vanished in
+  // the brief window since the successful readFileSync above — must never
+  // block returning the config we already successfully parsed.
+  let mtimeMs: number | undefined;
+  try {
+    mtimeMs = statSync(path).mtimeMs;
+  } catch {
+    mtimeMs = undefined;
+  }
+
+  warnUnknownConfigKeys(parsed, path, mtimeMs);
   return { hit: true, result: ok(validated.data) };
 }
 
@@ -159,6 +198,39 @@ export function loadConfig(cwd?: string): Result<LoadedConfig> {
 
   // 4. Built-in default.
   return ok(defaultLoaded());
+}
+
+// Walk up from an arbitrary starting directory — NOT necessarily
+// process.cwd() — looking for `.reviewbridge.json`, stopping at the first hit
+// or a `.git` boundary. Same algorithm as loadConfig()'s own implicit-mode
+// walk-up (step 2 above), just anchored at a caller-supplied start instead of
+// process.cwd(). Used by the MCP tool layer's per-call `cwd` param so a
+// config discovered from a NAMED repo behaves the way discovery from the
+// server's own launch directory would — including finding a repo-root config
+// from a cwd that names a SUBDIRECTORY of that repo, which loadConfig(cwd)'s
+// own explicit mode deliberately does NOT do (that single-directory lookup is
+// the CLI's `--config <dir>` contract — "look only there" — and is
+// unmodified here; do not repurpose it for this).
+//
+// Returns ok(null) — not a config, not an error — when nothing is found
+// anywhere up the tree. Callers decide what "not found" means for them:
+// falling back to loadConfig()'s built-in schema defaults here would be
+// wrong whenever the server's own boot-time config came from RB_CONFIG_PATH,
+// $HOME, or its own launch-directory walk-up — none of which this per-cwd
+// walk repeats (they're already reflected in whatever config object the
+// caller holds as its own fallback). See review-precommit.ts, the current
+// caller, for the actual fallback-to-boot-config policy this enables.
+export function discoverProjectConfig(startDir: string): Result<LoadedConfig | null> {
+  for (const dir of walkUp(startDir)) {
+    const path = join(dir, CONFIG_FILENAME);
+    const p = probe(path);
+    if (p.hit) {
+      if (!p.result.ok) return p.result;
+      return ok({ config: p.result.data, source: { kind: 'project', path } });
+    }
+    if (existsSync(join(dir, '.git'))) break;
+  }
+  return ok(null);
 }
 
 export function formatConfigSource(source: ConfigSource): string {

--- a/src/tools/review-code.test.ts
+++ b/src/tools/review-code.test.ts
@@ -163,6 +163,42 @@ describe('registerReviewCodeTool', () => {
 
     expect(saveReview).not.toHaveBeenCalled();
   });
+
+  describe('cwd param', () => {
+    it('a valid cwd is resolved to an absolute path and forwarded to resolveCodeDiff and the client', async () => {
+      vi.mocked(mockClient.reviewCode).mockResolvedValue(ok(validResult));
+
+      const result = await handler({ diff: 'some diff', cwd: process.cwd() }, {});
+
+      expect(result.isError).toBeUndefined();
+      expect(resolveCodeDiff).toHaveBeenCalledWith(expect.objectContaining({ cwd: process.cwd() }));
+      expect(mockClient.reviewCode).toHaveBeenCalledWith(
+        expect.objectContaining({ cwd: process.cwd() }),
+      );
+    });
+
+    it('an invalid cwd returns a clear tool error instead of calling resolveCodeDiff or the client', async () => {
+      const missing = `${process.cwd()}/definitely-does-not-exist-${Date.now()}`;
+
+      const result = await handler({ diff: 'some diff', cwd: missing }, {});
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('INVALID_INPUT');
+      expect(resolveCodeDiff).not.toHaveBeenCalled();
+      expect(mockClient.reviewCode).not.toHaveBeenCalled();
+    });
+
+    it('omitting cwd leaves it undefined downstream (preserves default behavior)', async () => {
+      vi.mocked(mockClient.reviewCode).mockResolvedValue(ok(validResult));
+
+      await handler({ diff: 'some diff' }, {});
+
+      expect(resolveCodeDiff).toHaveBeenCalledWith(expect.objectContaining({ cwd: undefined }));
+      expect(mockClient.reviewCode).toHaveBeenCalledWith(
+        expect.objectContaining({ cwd: undefined }),
+      );
+    });
+  });
 });
 
 describe('registerReviewCodeTool with db', () => {

--- a/src/tools/review-code.ts
+++ b/src/tools/review-code.ts
@@ -4,6 +4,7 @@ import type Database from 'better-sqlite3';
 import type { ReviewBackend } from '../backends/backend.js';
 import { sessionModelConflictMessage } from '../backends/orchestrator.js';
 import { resolveCodeDiff, NO_WORKING_CHANGES } from '../utils/resolve-diff.js';
+import { resolveCwd } from '../utils/cwd.js';
 import { createSessionTracker } from '../storage/session-tracker.js';
 
 export function registerReviewCodeTool(server: McpServer, client: ReviewBackend, db?: Database.Database): void {
@@ -49,6 +50,13 @@ export function registerReviewCodeTool(server: McpServer, client: ReviewBackend,
               'recomputed from cross-review adjudications — treat deliberation.divergent[].adjudication as ' +
               'advisory input for your own synthesis.',
           ),
+        cwd: z
+          .string()
+          .optional()
+          .describe(
+            'Repository directory for auto-capture; git commands run here. ' +
+              'Defaults to the server process cwd.',
+          ),
       },
     },
     async (args) => {
@@ -60,10 +68,19 @@ export function registerReviewCodeTool(server: McpServer, client: ReviewBackend,
           isError: true,
         };
       }
+      const cwdResult = resolveCwd(args.cwd);
+      if (!cwdResult.ok) {
+        return { content: [{ type: 'text' as const, text: cwdResult.error }], isError: true };
+      }
+      const cwd = cwdResult.data;
       const tracker = createSessionTracker(db, client.providers, client.provider);
       try {
         // Resolve diff (auto-capture or explicit)
-        const diffResult = await resolveCodeDiff({ diff: args.diff, auto_diff: args.auto_diff });
+        const diffResult = await resolveCodeDiff({
+          diff: args.diff,
+          auto_diff: args.auto_diff,
+          cwd,
+        });
         if (!diffResult.ok) {
           if (diffResult.error.startsWith(NO_WORKING_CHANGES)) {
             return {
@@ -89,7 +106,9 @@ export function registerReviewCodeTool(server: McpServer, client: ReviewBackend,
           return { content: [{ type: 'text' as const, text: preflight.error }], isError: true };
         }
 
-        const result = await client.reviewCode({ ...args, diff });
+        // Override args.cwd (the raw, possibly-relative caller value already
+        // consumed by resolveCwd above) with the validated absolute path.
+        const result = await client.reviewCode({ ...args, cwd, diff });
         if (!result.ok) {
           tracker.recordFailure(result.session_id);
           return { content: [{ type: 'text' as const, text: result.error }], isError: true };

--- a/src/tools/review-precommit.test.ts
+++ b/src/tools/review-precommit.test.ts
@@ -22,9 +22,21 @@ vi.mock('../storage/sessions.js', () => ({
   activateSession: vi.fn(),
 }));
 
+// Only exercised when a test passes `cwd` — the handler calls
+// discoverProjectConfig(cwd) exclusively on that path (see
+// review-precommit.ts), so every existing cwd-omitted test below never
+// touches this mock. Real walk-up behavior (subdirectory discovery, .git
+// boundary) is tested directly against discoverProjectConfig's own real
+// implementation in config/loader.test.ts — this file only needs to verify
+// review-precommit.ts's OWN policy for using what it returns.
+vi.mock('../config/loader.js', () => ({
+  discoverProjectConfig: vi.fn(),
+}));
+
 import { getStagedDiff } from '../utils/git.js';
 import { saveReview } from '../storage/reviews.js';
 import { getOrCreateSession, getSession, markSessionCompleted, markSessionFailed, activateSession } from '../storage/sessions.js';
+import { discoverProjectConfig } from '../config/loader.js';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type HandlerFn = (args: Record<string, unknown>, extra: unknown) => Promise<any>;
@@ -240,6 +252,133 @@ describe('registerReviewPrecommitTool', () => {
     await handler({}, {});
 
     expect(saveReview).not.toHaveBeenCalled();
+  });
+
+  describe('cwd param', () => {
+    it('a valid cwd is resolved to an absolute path and forwarded to getStagedDiff and the client', async () => {
+      vi.mocked(discoverProjectConfig).mockReturnValue(ok(null)); // nothing found — irrelevant to this test
+      vi.mocked(getStagedDiff).mockResolvedValue(ok('staged diff content'));
+      vi.mocked(mockClient.reviewPrecommit).mockResolvedValue(ok(validResult));
+
+      const result = await handler({ cwd: process.cwd() }, {});
+
+      expect(result.isError).toBeUndefined();
+      expect(getStagedDiff).toHaveBeenCalledWith(process.cwd());
+      expect(mockClient.reviewPrecommit).toHaveBeenCalledWith(
+        expect.objectContaining({ cwd: process.cwd() }),
+      );
+    });
+
+    it('an invalid cwd returns a clear tool error instead of calling getStagedDiff, discoverProjectConfig, or the client', async () => {
+      const missing = `${process.cwd()}/definitely-does-not-exist-${Date.now()}`;
+
+      const result = await handler({ cwd: missing }, {});
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('INVALID_INPUT');
+      expect(getStagedDiff).not.toHaveBeenCalled();
+      expect(discoverProjectConfig).not.toHaveBeenCalled();
+      expect(mockClient.reviewPrecommit).not.toHaveBeenCalled();
+    });
+
+    it('omitting cwd leaves it undefined downstream and never calls discoverProjectConfig (preserves default behavior)', async () => {
+      vi.mocked(getStagedDiff).mockResolvedValue(ok('staged diff content'));
+      vi.mocked(mockClient.reviewPrecommit).mockResolvedValue(ok(validResult));
+
+      await handler({}, {});
+
+      expect(getStagedDiff).toHaveBeenCalledWith(undefined);
+      expect(discoverProjectConfig).not.toHaveBeenCalled();
+      expect(mockClient.reviewPrecommit).toHaveBeenCalledWith(
+        expect.objectContaining({ cwd: undefined }),
+      );
+    });
+
+    it('ISS-004 per-repo (F4): auto_diff default comes from the cwd-scoped repo config, not the server boot-time config', async () => {
+      // The server booted with auto_diff:true (DEFAULT_CONFIG); the repo named
+      // by cwd has its own .reviewbridge.json with auto_diff:false.
+      const repoConfig = {
+        ...DEFAULT_CONFIG,
+        review_standards: {
+          ...DEFAULT_CONFIG.review_standards,
+          precommit: { ...DEFAULT_CONFIG.review_standards.precommit, auto_diff: false },
+        },
+      };
+      vi.mocked(discoverProjectConfig).mockReturnValue(
+        ok({
+          config: repoConfig,
+          source: { kind: 'project', path: `${process.cwd()}/.reviewbridge.json` },
+        }),
+      );
+
+      const result = await handler({ cwd: process.cwd() }, {});
+
+      expect(discoverProjectConfig).toHaveBeenCalledWith(process.cwd());
+      expect(getStagedDiff).not.toHaveBeenCalled(); // the repo config disabled auto_diff
+      // Mirrors the pre-existing "ISS-004: falls back to config precommit.auto_diff"
+      // test above: auto_diff off + no explicit diff is a genuine tool error, not
+      // the friendly no-staged-changes response (that's the "capture ran and found
+      // nothing" case, distinct from "capture never ran").
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('auto_diff disabled and no diff provided');
+    });
+
+    it('F4: no config found ANYWHERE up the tree from cwd preserves a non-default BOOT config value — never resets to schema defaults', async () => {
+      // The server booted with a NON-default config (auto_diff:false, set via
+      // e.g. RB_CONFIG_PATH or $HOME/.reviewbridge.json — irrelevant which).
+      // discoverProjectConfig finds nothing walking up from cwd. Before F4,
+      // this silently fell back to loadConfig(cwd)'s built-in schema default
+      // (auto_diff:true) instead of the boot config — this test is the
+      // regression guard for that.
+      const bootConfig = {
+        ...DEFAULT_CONFIG,
+        review_standards: {
+          ...DEFAULT_CONFIG.review_standards,
+          precommit: { ...DEFAULT_CONFIG.review_standards.precommit, auto_diff: false },
+        },
+      };
+      setupHandler(undefined, bootConfig);
+      vi.mocked(discoverProjectConfig).mockReturnValue(ok(null)); // nothing found anywhere
+
+      const result = await handler({ cwd: process.cwd() }, {});
+
+      expect(discoverProjectConfig).toHaveBeenCalledWith(process.cwd());
+      expect(getStagedDiff).not.toHaveBeenCalled(); // boot config's auto_diff:false won, not the schema default (true)
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('auto_diff disabled and no diff provided');
+    });
+
+    it('an explicit auto_diff arg still overrides the cwd-scoped repo config', async () => {
+      const repoConfig = {
+        ...DEFAULT_CONFIG,
+        review_standards: {
+          ...DEFAULT_CONFIG.review_standards,
+          precommit: { ...DEFAULT_CONFIG.review_standards.precommit, auto_diff: false },
+        },
+      };
+      vi.mocked(discoverProjectConfig).mockReturnValue(
+        ok({ config: repoConfig, source: { kind: 'default' } }),
+      );
+      vi.mocked(getStagedDiff).mockResolvedValue(ok('staged diff content'));
+      vi.mocked(mockClient.reviewPrecommit).mockResolvedValue(ok(validResult));
+
+      await handler({ cwd: process.cwd(), auto_diff: true }, {});
+
+      expect(getStagedDiff).toHaveBeenCalledTimes(1);
+    });
+
+    it('a broken .reviewbridge.json found while walking up from the named cwd returns a clear tool error', async () => {
+      vi.mocked(discoverProjectConfig).mockReturnValue(
+        err('CONFIG_ERROR: invalid config in /some/repo/.reviewbridge.json'),
+      );
+
+      const result = await handler({ cwd: process.cwd() }, {});
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('CONFIG_ERROR');
+      expect(getStagedDiff).not.toHaveBeenCalled();
+      expect(mockClient.reviewPrecommit).not.toHaveBeenCalled();
+    });
   });
 });
 

--- a/src/tools/review-precommit.ts
+++ b/src/tools/review-precommit.ts
@@ -5,6 +5,8 @@ import type { ReviewBackend } from '../backends/backend.js';
 import type { ReviewBridgeConfig } from '../config/types.js';
 import { sessionModelConflictMessage } from '../backends/orchestrator.js';
 import { resolvePrecommitDiff, NO_STAGED_CHANGES } from '../utils/resolve-diff.js';
+import { resolveCwd } from '../utils/cwd.js';
+import { discoverProjectConfig } from '../config/loader.js';
 import { createSessionTracker } from '../storage/session-tracker.js';
 
 export function registerReviewPrecommitTool(
@@ -37,6 +39,14 @@ export function registerReviewPrecommitTool(
               'With the Codex provider this cannot be combined with session_id (a resumed thread ' +
               'keeps its model); the Gemini provider allows changing model on a resumed session.',
           ),
+        cwd: z
+          .string()
+          .optional()
+          .describe(
+            'Repository directory for auto-capture and config discovery; git commands run here, ' +
+              "and this repo's .reviewbridge.json (if any, searched by walking up from here) is " +
+              'used for defaults like auto_diff. Defaults to the server process cwd.',
+          ),
       },
     },
     async (args) => {
@@ -48,13 +58,60 @@ export function registerReviewPrecommitTool(
           isError: true,
         };
       }
+      const cwdResult = resolveCwd(args.cwd);
+      if (!cwdResult.ok) {
+        return { content: [{ type: 'text' as const, text: cwdResult.error }], isError: true };
+      }
+      const cwd = cwdResult.data;
+
+      // config is loaded once at server startup from the server process's own
+      // launch directory (src/server.ts), so it can't reflect a repo named by
+      // a per-call cwd. When the caller names one, walk up from THAT
+      // directory the same way the server's own boot-time discovery would
+      // (discoverProjectConfig — same walk-up/.git-boundary algorithm as
+      // loadConfig()'s implicit mode, just anchored at cwd instead of
+      // process.cwd()), so a repo-root .reviewbridge.json becomes reachable
+      // even when cwd names a SUBDIRECTORY of that repo. This only affects
+      // the one field this tool reads per call
+      // (review_standards.precommit.auto_diff) — provider/backend selection,
+      // deliberate-mode capability, and copilot instructions are still wired
+      // once when the backend is constructed at server startup and stay tied
+      // to the server's launch directory; re-resolving those per call would
+      // mean reconstructing the backend per call, out of scope for this fix.
+      //
+      // If nothing is found anywhere up the tree from cwd, precommitConfig
+      // stays the server's own BOOT-TIME config — never built-in schema
+      // defaults. Falling back to schema defaults here would silently
+      // discard whatever the server actually loaded at startup
+      // (RB_CONFIG_PATH, $HOME/.reviewbridge.json, or its own
+      // launch-directory walk-up): e.g. a user who set
+      // precommit.auto_diff:false globally would see it silently reset to
+      // the schema default (true) the instant they passed a cwd whose own
+      // tree has no config file of its own.
+      let precommitConfig = config;
+      if (cwd !== undefined) {
+        const discovered = discoverProjectConfig(cwd);
+        if (!discovered.ok) {
+          return { content: [{ type: 'text' as const, text: discovered.error }], isError: true };
+        }
+        if (discovered.data) {
+          precommitConfig = discovered.data.config;
+        }
+        // else: nothing found walking up from cwd — precommitConfig stays
+        // the boot-time config set above, by design.
+      }
+
       const tracker = createSessionTracker(db, client.providers, client.provider);
       try {
         // An explicit auto_diff arg wins; otherwise fall back to the project
         // config default (config is the validated ReviewBridgeConfig, so the
         // field is always present — no optional chaining needed).
-        const autoDiff = args.auto_diff ?? config.review_standards.precommit.auto_diff;
-        const diffResult = await resolvePrecommitDiff({ diff: args.diff, auto_diff: autoDiff });
+        const autoDiff = args.auto_diff ?? precommitConfig.review_standards.precommit.auto_diff;
+        const diffResult = await resolvePrecommitDiff({
+          diff: args.diff,
+          auto_diff: autoDiff,
+          cwd,
+        });
         if (!diffResult.ok) {
           // "No staged changes" is not an error — return structured response
           if (diffResult.error.startsWith(NO_STAGED_CHANGES)) {
@@ -88,6 +145,7 @@ export function registerReviewPrecommitTool(
           checklist: args.checklist,
           session_id: args.session_id,
           model: args.model,
+          cwd,
         });
         if (!result.ok) {
           tracker.recordFailure(result.session_id);

--- a/src/utils/cwd.test.ts
+++ b/src/utils/cwd.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { resolveCwd, classifyStatError } from './cwd.js';
+
+const tempDirs: string[] = [];
+function makeTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'codex-bridge-cwd-test-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('resolveCwd', () => {
+  it('passes undefined through unchanged (default: use the process cwd)', () => {
+    const result = resolveCwd(undefined);
+    expect(result).toEqual({ ok: true, data: undefined });
+  });
+
+  it('resolves an existing directory to an absolute path', () => {
+    const dir = makeTempDir();
+    const result = resolveCwd(dir);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data).toBe(resolve(dir));
+    }
+  });
+
+  it('resolves a relative path to an absolute one', () => {
+    const dir = makeTempDir();
+    const relative = `${dir}/.`;
+    const result = resolveCwd(relative);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data).toBe(resolve(dir));
+    }
+  });
+
+  it('returns INVALID_INPUT for a path that does not exist (F3: single statSync, ENOENT via catch — never throws)', () => {
+    const missing = join(makeTempDir(), 'does-not-exist');
+    expect(() => resolveCwd(missing)).not.toThrow();
+    const result = resolveCwd(missing);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('INVALID_INPUT');
+      expect(result.error).toContain(missing);
+      expect(result.error).toContain('does not exist');
+    }
+  });
+
+  it('returns INVALID_INPUT for a path that is a file, not a directory', () => {
+    const dir = makeTempDir();
+    const filePath = join(dir, 'a-file.txt');
+    writeFileSync(filePath, 'not a directory');
+    const result = resolveCwd(filePath);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('INVALID_INPUT');
+      expect(result.error).toContain('not a directory');
+    }
+  });
+
+  it('treats an empty string the same as undefined, instead of silently resolving to the process cwd', () => {
+    // path.resolve('') would otherwise resolve to process.cwd() — surprising
+    // for what's almost certainly an unset variable on the caller's side.
+    const result = resolveCwd('');
+    expect(result).toEqual({ ok: true, data: undefined });
+  });
+
+  it('treats a whitespace-only string the same as undefined', () => {
+    const result = resolveCwd('   ');
+    expect(result).toEqual({ ok: true, data: undefined });
+  });
+});
+
+// F3: the errno → message mapping resolveCwd's catch delegates to. Unit-tested
+// directly with synthetic errno codes rather than via resolveCwd end-to-end —
+// reliably reproducing a real EACCES (permission-denied) race on disk is
+// fiddly and platform/root-dependent, and would make the test itself flaky
+// for the exact reason F3 exists (permission state is hard to pin down).
+describe('classifyStatError', () => {
+  function errnoError(code: string, message = 'synthetic'): NodeJS.ErrnoException {
+    return Object.assign(new Error(message), { code });
+  }
+
+  it('maps ENOENT to a "does not exist" message', () => {
+    const msg = classifyStatError(errnoError('ENOENT'), '/some/path', '/abs/some/path');
+    expect(msg).toContain('INVALID_INPUT');
+    expect(msg).toContain('does not exist');
+    expect(msg).toContain('/some/path');
+    expect(msg).toContain('/abs/some/path');
+  });
+
+  it('maps ENOTDIR (a path component is not a directory) to the same "does not exist" message', () => {
+    const msg = classifyStatError(
+      errnoError('ENOTDIR'),
+      '/some/file.txt/sub',
+      '/abs/some/file.txt/sub',
+    );
+    expect(msg).toContain('INVALID_INPUT');
+    expect(msg).toContain('does not exist');
+  });
+
+  it('maps EACCES to a distinct "not accessible / permission denied" message', () => {
+    const msg = classifyStatError(errnoError('EACCES'), '/locked', '/abs/locked');
+    expect(msg).toContain('INVALID_INPUT');
+    expect(msg).toContain('not accessible');
+    expect(msg).toContain('permission denied');
+    expect(msg).not.toContain('does not exist');
+  });
+
+  it('maps an unrecognized errno to a generic-but-still-actionable message including the original text', () => {
+    const msg = classifyStatError(errnoError('EMFILE', 'too many open files'), '/x', '/abs/x');
+    expect(msg).toContain('INVALID_INPUT');
+    expect(msg).toContain('could not be checked');
+    expect(msg).toContain('too many open files');
+  });
+
+  it('never throws, even for a non-Error, code-less thrown value', () => {
+    expect(() => classifyStatError('a plain string throw', '/x', '/abs/x')).not.toThrow();
+    const msg = classifyStatError('a plain string throw', '/x', '/abs/x');
+    expect(msg).toContain('INVALID_INPUT');
+    expect(msg).toContain('a plain string throw');
+  });
+});

--- a/src/utils/cwd.ts
+++ b/src/utils/cwd.ts
@@ -1,0 +1,69 @@
+import { statSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { ok, err, ErrorCode } from './errors.js';
+import type { Result } from './errors.js';
+
+// Maps a statSync failure's errno to a clear, actionable INVALID_INPUT
+// message. Split out so the mapping itself is directly unit-testable with
+// synthetic errno codes, without needing to reproduce real filesystem races
+// (a permission-denied directory in particular is fiddly and platform/
+// root-dependent to set up reliably in a test) — see cwd.test.ts.
+export function classifyStatError(e: unknown, cwd: string, absolute: string): string {
+  const code = (e as NodeJS.ErrnoException | undefined)?.code;
+  if (code === 'ENOENT' || code === 'ENOTDIR') {
+    return `${ErrorCode.INVALID_INPUT}: cwd "${cwd}" does not exist (resolved to "${absolute}")`;
+  }
+  if (code === 'EACCES') {
+    return (
+      `${ErrorCode.INVALID_INPUT}: cwd "${cwd}" is not accessible ` +
+      `(permission denied; resolved to "${absolute}")`
+    );
+  }
+  const msg = e instanceof Error ? e.message : String(e);
+  return `${ErrorCode.INVALID_INPUT}: cwd "${cwd}" could not be checked (resolved to "${absolute}"): ${msg}`;
+}
+
+/**
+ * Validate and resolve an optional caller-supplied `cwd` (e.g. the review
+ * tools' `cwd` param) to an absolute path.
+ *
+ * `undefined` passes through unchanged — the zero-footprint default, meaning
+ * "use the server process's own cwd" everywhere downstream. A blank string
+ * (empty or all-whitespace) is treated the same way: `path.resolve('')`
+ * would otherwise silently resolve to the server's own cwd, which is a
+ * confusing thing to do quietly for what's almost certainly an unset
+ * variable on the caller's side rather than an intentional value. Any other
+ * defined value must name an existing directory; anything else is a clear,
+ * actionable INVALID_INPUT error rather than a crash or a confusing
+ * downstream git/fs failure.
+ *
+ * A single statSync call (never existsSync-then-statSync): checking
+ * existence and then separately stat-ing leaves a window where the path can
+ * vanish, or its permissions change, between the two calls — and a plain
+ * statSync throws on failure, which would have escaped this function's
+ * Result contract straight past both tool handlers' try blocks (they call
+ * resolveCwd before entering them). One call, wrapped in try/catch, closes
+ * that window and guarantees this function never throws.
+ */
+export function resolveCwd(cwd: string | undefined): Result<string | undefined> {
+  if (cwd === undefined || cwd.trim() === '') {
+    return ok(undefined);
+  }
+
+  const absolute = resolve(cwd);
+
+  let stats;
+  try {
+    stats = statSync(absolute);
+  } catch (e: unknown) {
+    return err(classifyStatError(e, cwd, absolute));
+  }
+
+  if (!stats.isDirectory()) {
+    return err(
+      `${ErrorCode.INVALID_INPUT}: cwd "${cwd}" is not a directory (resolved to "${absolute}")`,
+    );
+  }
+
+  return ok(absolute);
+}

--- a/src/utils/git.integration.test.ts
+++ b/src/utils/git.integration.test.ts
@@ -1,0 +1,88 @@
+// Real git, no mocks — the exact scenario the bug report is about: auto-
+// capture running against a repo named by `cwd` while the TEST's own
+// process.cwd() is somewhere else entirely (this file's own directory,
+// unrelated to either fixture). Complements git.test.ts's mocked unit
+// coverage of every branch (preflight classification, error narrowing,
+// etc.) with one end-to-end pass against a real git binary and a real work
+// tree, colocated per the repo's own *.integration.test.ts convention (see
+// src/server.integration.test.ts, src/storage/session-tracker.integration.test.ts).
+//
+// CI-safe: skips cleanly (not a failure) when git isn't on PATH.
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { getStagedDiff, getWorkingDiff, isGitRepo } from './git.js';
+
+function hasGit(): boolean {
+  try {
+    execFileSync('git', ['--version'], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe.skipIf(!hasGit())('REAL git (no mocks) — the behavior the bug report is about', () => {
+  let repo: string;
+  let nonRepo: string;
+
+  beforeAll(() => {
+    repo = mkdtempSync(join(tmpdir(), 'codex-bridge-realgit-repo-'));
+    execFileSync('git', ['init', '-q'], { cwd: repo });
+    execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: repo });
+    execFileSync('git', ['config', 'user.name', 'codex-bridge test'], { cwd: repo });
+    writeFileSync(join(repo, 'seed.txt'), 'seed\n');
+    execFileSync('git', ['add', '.'], { cwd: repo });
+    execFileSync('git', ['commit', '-q', '-m', 'seed'], { cwd: repo });
+    writeFileSync(join(repo, 'staged.txt'), 'hello staged\n');
+    execFileSync('git', ['add', 'staged.txt'], { cwd: repo });
+
+    nonRepo = mkdtempSync(join(tmpdir(), 'codex-bridge-realgit-nonrepo-'));
+  });
+
+  afterAll(() => {
+    rmSync(repo, { recursive: true, force: true });
+    rmSync(nonRepo, { recursive: true, force: true });
+  });
+
+  it('getStagedDiff(cwd) returns the real staged diff from a foreign process.cwd() — THE bug', async () => {
+    // This test process's own cwd is wherever vitest launched from (this
+    // repo's root), not `repo` — exactly the MCP-server-launched-elsewhere
+    // scenario. Only the cwd param, not process.cwd(), should matter.
+    const result = await getStagedDiff(repo);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data).toContain('staged.txt');
+      expect(result.data).toContain('hello staged');
+    }
+  });
+
+  it('getWorkingDiff(cwd) returns the real unstaged diff from a foreign process.cwd()', async () => {
+    writeFileSync(join(repo, 'seed.txt'), 'seed changed\n');
+    const result = await getWorkingDiff(repo);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data).toContain('seed.txt');
+    }
+  });
+
+  it('a non-repo cwd yields the friendly, cwd-naming message — never the raw --no-index dump', async () => {
+    const result = await getStagedDiff(nonRepo);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('GIT_ERROR');
+      expect(result.error).toContain('is not inside a git repository');
+      expect(result.error).toContain(nonRepo);
+      // The exact old failure mode this fix replaces: git's --no-index
+      // fallback complaining about --cached as an unknown option.
+      expect(result.error.toLowerCase()).not.toContain('unknown option');
+    }
+  });
+
+  it('isGitRepo discriminates a real repo from a real non-repo directory', async () => {
+    expect(await isGitRepo(repo)).toBe(true);
+    expect(await isGitRepo(nonRepo)).toBe(false);
+  });
+});

--- a/src/utils/git.test.ts
+++ b/src/utils/git.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { getStagedDiff, getUnstagedDiff, getDiffBetween, getWorkingDiff, isGitRepo } from './git.js';
+import {
+  getStagedDiff,
+  getUnstagedDiff,
+  getDiffBetween,
+  getWorkingDiff,
+  isGitRepo,
+} from './git.js';
 
 vi.mock('node:child_process', () => ({ exec: vi.fn() }));
 
@@ -25,6 +31,35 @@ function mockFailure(stderr: string) {
   );
 }
 
+// getStagedDiff/getWorkingDiff now preflight with `git rev-parse
+// --is-inside-work-tree` before their real command. `first` scripts that
+// preflight call (defaults to a passing 'true\n'); `rest` scripts every call
+// after it in order, repeating the last entry once exhausted.
+function mockSequence(
+  first: { stdout?: string; stderr?: string } | 'preflight-ok',
+  ...rest: { stdout?: string; stderr?: string }[]
+) {
+  const preflight = first === 'preflight-ok' ? { stdout: 'true\n' } : first;
+  const calls = [preflight, ...rest];
+  let callCount = 0;
+  mockExec.mockImplementation(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ((cmd: string, opts: any, cb: (err: Error | null, stdout: string, stderr: string) => void) => {
+      const entry = calls[Math.min(callCount, calls.length - 1)];
+      callCount++;
+      if (entry.stderr !== undefined) {
+        cb(
+          Object.assign(new Error(entry.stderr), { stderr: entry.stderr }),
+          entry.stdout ?? '',
+          entry.stderr,
+        );
+      } else {
+        cb(null, entry.stdout ?? '', '');
+      }
+    }) as typeof exec,
+  );
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
 });
@@ -38,7 +73,7 @@ const sampleDiff = `diff --git a/src/index.ts b/src/index.ts
 
 describe('getStagedDiff', () => {
   it('returns ok with diff string when changes are staged', async () => {
-    mockSuccess(sampleDiff + '\n');
+    mockSequence('preflight-ok', { stdout: sampleDiff + '\n' });
     const result = await getStagedDiff();
     expect(result.ok).toBe(true);
     if (result.ok) {
@@ -47,7 +82,7 @@ describe('getStagedDiff', () => {
   });
 
   it('returns ok with empty string when no staged changes', async () => {
-    mockSuccess('');
+    mockSequence('preflight-ok', { stdout: '' });
     const result = await getStagedDiff();
     expect(result.ok).toBe(true);
     if (result.ok) {
@@ -55,24 +90,184 @@ describe('getStagedDiff', () => {
     }
   });
 
-  it('returns err with GIT_ERROR when not a git repo', async () => {
+  it('returns the friendly not-a-repo error when the preflight check fails outright', async () => {
     mockFailure('fatal: not a git repository');
     const result = await getStagedDiff();
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.error).toContain('GIT_ERROR');
-      expect(result.error).toContain('fatal: not a git repository');
+      expect(result.error).toContain('is not inside a git repository');
+      expect(result.error).toContain('cwd');
+      expect(result.error).not.toContain('fatal: not a git repository');
     }
   });
 
-  it('returns err containing stderr message when git command fails', async () => {
-    mockFailure('error: pathspec not found');
+  it('returns the friendly not-a-repo error when the preflight reports false (e.g. a bare repo)', async () => {
+    mockSuccess('false\n');
+    const result = await getStagedDiff();
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('is not inside a git repository');
+    }
+  });
+
+  it('F1: a real, non-repo preflight failure (dubious ownership) surfaces its own text — NOT the misleading not-a-repo message', async () => {
+    // A well-known real git message (safe.directory ownership check, git
+    // 2.35.2+): the directory genuinely IS a repo, but git refuses to
+    // operate in it. Rewriting this to "not inside a git repository" would
+    // send someone chasing the wrong fix (passing cwd/diff instead of
+    // running the git config command git itself is telling them to run).
+    const dubiousOwnership =
+      "fatal: detected dubious ownership in repository at '/my/repo'\n" +
+      'To add an exception for this directory, call:\n\n' +
+      '\tgit config --global --add safe.directory /my/repo';
+    mockFailure(dubiousOwnership);
+
+    const result = await getStagedDiff('/my/repo');
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('GIT_ERROR');
+      expect(result.error).toContain('dubious ownership');
+      expect(result.error).toContain('safe.directory');
+      expect(result.error).not.toContain('is not inside a git repository');
+    }
+  });
+
+  it('F1: a preflight failure from a missing git binary / other real error also surfaces its own text', async () => {
+    mockFailure('spawn git ENOENT');
+
+    const result = await getStagedDiff();
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('GIT_ERROR');
+      expect(result.error).toContain('ENOENT');
+      expect(result.error).not.toContain('is not inside a git repository');
+    }
+  });
+
+  it('P1: a real error whose PATH literally contains the phrase "not a git repository" is NOT misclassified (anchored match, not a bare substring test)', async () => {
+    // The exact adversarial case: a dubious-ownership error naming a
+    // directory that happens to be called "not a git repository". An
+    // unanchored /not a git repository/i test would match this anywhere in
+    // the string and wrongly rewrite it to the friendly not-a-repo message —
+    // actively wrong advice, since the real fix is `git config --global
+    // --add safe.directory`, not the cwd param.
+    const trickyPath = '/tmp/not a git repository/repo';
+    const dubiousOwnershipWithTrickyPath =
+      `fatal: detected dubious ownership in repository at '${trickyPath}'\n` +
+      'To add an exception for this directory, call:\n\n' +
+      `\tgit config --global --add safe.directory '${trickyPath}'`;
+    mockFailure(dubiousOwnershipWithTrickyPath);
+
+    const result = await getStagedDiff(trickyPath);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('GIT_ERROR');
+      expect(result.error).toContain('dubious ownership');
+      expect(result.error).toContain('safe.directory');
+      expect(result.error).not.toContain('is not inside a git repository');
+    }
+  });
+
+  it('P1: the anchored pattern still matches the real "not a git repository" fatal line, verified live against git 2.39.5', async () => {
+    // Both git rev-parse --is-inside-work-tree and --verify HEAD print
+    // exactly this outside a work tree (re-confirmed live for this fix).
+    mockFailure('fatal: not a git repository (or any of the parent directories): .git');
+
+    const result = await getStagedDiff();
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('is not inside a git repository');
+    }
+  });
+
+  it('names the resolved cwd in the not-a-repo message, falling back to process.cwd() when omitted', async () => {
+    mockFailure('fatal: not a git repository');
+    const result = await getStagedDiff();
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain(process.cwd());
+    }
+  });
+
+  it('names an explicit cwd in the not-a-repo message instead of process.cwd()', async () => {
+    mockFailure('fatal: not a git repository');
+    const result = await getStagedDiff('/some/other/repo');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('/some/other/repo');
+    }
+  });
+
+  it('returns err containing stderr message when the diff command fails for an unrelated reason (preflight passed)', async () => {
+    mockSequence('preflight-ok', { stderr: 'error: pathspec not found' });
     const result = await getStagedDiff();
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.error).toContain('GIT_ERROR');
       expect(result.error).toContain('error: pathspec not found');
     }
+  });
+
+  it('rewrites the real --no-index "unknown option" failure to the friendly message even if the preflight passed', async () => {
+    // Verified live against git 2.39.5 (Apple Git-154): `git diff --cached`
+    // outside a work tree fails with exactly this shape — backtick-quoted
+    // flag name, followed by the --no-index usage block.
+    mockSequence('preflight-ok', {
+      stderr:
+        "error: unknown option `cached'\nusage: git diff --no-index [<options>] <path> <path>",
+    });
+    const result = await getStagedDiff();
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('is not inside a git repository');
+    }
+  });
+
+  it('does NOT rewrite an "unknown option" failure that does not name cached (F2: narrowed, not a generic match)', async () => {
+    mockSequence('preflight-ok', { stderr: "error: unknown option `bogus-flag'" });
+    const result = await getStagedDiff();
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('GIT_ERROR');
+      expect(result.error).toContain('bogus-flag');
+      expect(result.error).not.toContain('is not inside a git repository');
+    }
+  });
+
+  it('does NOT rewrite "unknown option ... cached" without --no-index context (F2: requires both signals)', async () => {
+    mockSequence('preflight-ok', {
+      stderr: "error: unknown option `cached' in some unrelated context",
+    });
+    const result = await getStagedDiff();
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('GIT_ERROR');
+      expect(result.error).not.toContain('is not inside a git repository');
+    }
+  });
+
+  it('passes cwd through to the underlying git commands', async () => {
+    mockSequence('preflight-ok', { stdout: '' });
+    await getStagedDiff('/my/repo');
+    expect(mockExec).toHaveBeenCalledTimes(2);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((mockExec.mock.calls[0][1] as any).cwd).toBe('/my/repo');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((mockExec.mock.calls[1][1] as any).cwd).toBe('/my/repo');
+  });
+
+  it('omits cwd from exec options when not provided (preserves prior default behavior)', async () => {
+    mockSequence('preflight-ok', { stdout: '' });
+    await getStagedDiff();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((mockExec.mock.calls[0][1] as any).cwd).toBeUndefined();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((mockExec.mock.calls[1][1] as any).cwd).toBeUndefined();
   });
 });
 
@@ -156,24 +351,20 @@ describe('isGitRepo', () => {
     const result = await isGitRepo();
     expect(result).toBe(false);
   });
+
+  it('passes cwd through to the underlying git command', async () => {
+    mockSuccess('true\n');
+    await isGitRepo('/my/repo');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((mockExec.mock.calls[0][1] as any).cwd).toBe('/my/repo');
+  });
 });
 
 describe('getWorkingDiff', () => {
   it('returns diff vs HEAD when HEAD exists', async () => {
-    // First call: rev-parse --verify HEAD succeeds
-    // Second call: git diff HEAD returns diff
-    let callCount = 0;
-    mockExec.mockImplementation(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      ((cmd: string, opts: any, cb: (err: Error | null, stdout: string, stderr: string) => void) => {
-        callCount++;
-        if (callCount === 1) {
-          cb(null, 'abc123\n', ''); // HEAD exists
-        } else {
-          cb(null, sampleDiff + '\n', '');
-        }
-      }) as typeof exec,
-    );
+    // Call 1: preflight (is-inside-work-tree). Call 2: rev-parse --verify HEAD.
+    // Call 3: git diff HEAD.
+    mockSequence('preflight-ok', { stdout: 'abc123\n' }, { stdout: sampleDiff + '\n' });
 
     const result = await getWorkingDiff();
     expect(result.ok).toBe(true);
@@ -183,18 +374,7 @@ describe('getWorkingDiff', () => {
   });
 
   it('returns empty string when HEAD exists but no changes', async () => {
-    let callCount = 0;
-    mockExec.mockImplementation(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      ((cmd: string, opts: any, cb: (err: Error | null, stdout: string, stderr: string) => void) => {
-        callCount++;
-        if (callCount === 1) {
-          cb(null, 'abc123\n', '');
-        } else {
-          cb(null, '', '');
-        }
-      }) as typeof exec,
-    );
+    mockSequence('preflight-ok', { stdout: 'abc123\n' }, { stdout: '' });
 
     const result = await getWorkingDiff();
     expect(result.ok).toBe(true);
@@ -205,20 +385,28 @@ describe('getWorkingDiff', () => {
 
   it('falls back to staged + unstaged when HEAD does not exist', async () => {
     let callCount = 0;
-    mockExec.mockImplementation(
+    mockExec.mockImplementation(((
+      cmd: string,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      ((cmd: string, opts: any, cb: (err: Error | null, stdout: string, stderr: string) => void) => {
-        callCount++;
-        if (callCount === 1) {
-          // rev-parse --verify HEAD fails on unborn repo
-          cb(Object.assign(new Error('HEAD'), { stderr: "fatal: Needed a single revision\nHEAD" }), '', "fatal: Needed a single revision\nHEAD");
-        } else if (callCount === 2) {
-          cb(null, sampleDiff + '\n', ''); // staged
-        } else {
-          cb(null, '', ''); // unstaged (empty)
-        }
-      }) as typeof exec,
-    );
+      opts: any,
+      cb: (err: Error | null, stdout: string, stderr: string) => void,
+    ) => {
+      callCount++;
+      if (callCount === 1) {
+        cb(null, 'true\n', ''); // preflight: inside a work tree
+      } else if (callCount === 2) {
+        // rev-parse --verify HEAD fails on unborn repo
+        cb(
+          Object.assign(new Error('HEAD'), { stderr: 'fatal: Needed a single revision\nHEAD' }),
+          '',
+          'fatal: Needed a single revision\nHEAD',
+        );
+      } else if (callCount === 3) {
+        cb(null, sampleDiff + '\n', ''); // staged
+      } else {
+        cb(null, '', ''); // unstaged (empty)
+      }
+    }) as typeof exec);
 
     const result = await getWorkingDiff();
     expect(result.ok).toBe(true);
@@ -227,23 +415,97 @@ describe('getWorkingDiff', () => {
     }
   });
 
-  it('returns GIT_ERROR when not in a git repo', async () => {
+  it('F2: the --cached no-index rewrite is scoped to the actual --cached call — a same-shaped failure on the unstaged half of the HEAD-less fallback is NOT rewritten', async () => {
+    // Preflight ok, HEAD missing (unborn repo) → falls back to staged +
+    // unstaged. The STAGED call succeeds; the UNSTAGED call (git diff
+    // --no-color, no --cached) fails with a contrived message that would
+    // match looksLikeCachedNoIndexFallback's pattern IF it weren't call-site
+    // gated. It must surface as-is, not be rewritten — that call never ran
+    // --cached, so the rewrite doesn't apply to it.
+    let callCount = 0;
+    mockExec.mockImplementation(((
+      cmd: string,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      opts: any,
+      cb: (err: Error | null, stdout: string, stderr: string) => void,
+    ) => {
+      callCount++;
+      if (callCount === 1) {
+        cb(null, 'true\n', ''); // preflight
+      } else if (callCount === 2) {
+        cb(
+          Object.assign(new Error('HEAD'), { stderr: 'fatal: Needed a single revision\nHEAD' }),
+          '',
+          'fatal: Needed a single revision\nHEAD',
+        );
+      } else if (callCount === 3) {
+        cb(null, sampleDiff + '\n', ''); // staged — succeeds
+      } else {
+        // unstaged — fails with a contrived cached/no-index-shaped message
+        cb(
+          Object.assign(new Error('contrived'), {
+            stderr:
+              "error: unknown option `cached'\nusage: git diff --no-index [<options>] <path> <path>",
+          }),
+          '',
+          "error: unknown option `cached'\nusage: git diff --no-index [<options>] <path> <path>",
+        );
+      }
+    }) as typeof exec);
+
+    const result = await getWorkingDiff();
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('GIT_ERROR');
+      expect(result.error).not.toContain('is not inside a git repository');
+    }
+  });
+
+  it('returns the friendly not-a-repo error when the preflight check fails', async () => {
     mockFailure('fatal: not a git repository');
     const result = await getWorkingDiff();
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.error).toContain('GIT_ERROR');
+      expect(result.error).toContain('is not inside a git repository');
+      expect(result.error).not.toContain('fatal: not a git repository');
+    }
+  });
+
+  it('F1: a real, non-repo preflight failure (dubious ownership) surfaces its own text here too — shares checkWorkTreeForCapture with getStagedDiff', async () => {
+    const dubiousOwnership =
+      "fatal: detected dubious ownership in repository at '/my/repo'\n" +
+      'To add an exception for this directory, call:\n\n' +
+      '\tgit config --global --add safe.directory /my/repo';
+    mockFailure(dubiousOwnership);
+
+    const result = await getWorkingDiff('/my/repo');
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('dubious ownership');
+      expect(result.error).not.toContain('is not inside a git repository');
+    }
+  });
+
+  it('passes cwd through to every underlying git command', async () => {
+    mockSequence('preflight-ok', { stdout: 'abc123\n' }, { stdout: '' });
+    await getWorkingDiff('/my/repo');
+    expect(mockExec).toHaveBeenCalledTimes(3);
+    for (const call of mockExec.mock.calls) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((call[1] as any).cwd).toBe('/my/repo');
     }
   });
 });
 
 describe('command verification', () => {
-  it('getStagedDiff runs git diff --cached --no-color', async () => {
-    mockSuccess('');
+  it('getStagedDiff runs git diff --cached --no-color (after the preflight)', async () => {
+    mockSequence('preflight-ok', { stdout: '' });
     await getStagedDiff();
-    expect(mockExec).toHaveBeenCalledTimes(1);
-    const cmd = mockExec.mock.calls[0][0];
-    expect(cmd).toBe('git diff --cached --no-color');
+    expect(mockExec).toHaveBeenCalledTimes(2);
+    expect(mockExec.mock.calls[0][0]).toBe('git rev-parse --is-inside-work-tree');
+    expect(mockExec.mock.calls[1][0]).toBe('git diff --cached --no-color');
   });
 
   it('getUnstagedDiff runs git diff --no-color', async () => {

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -6,9 +6,14 @@ const MAX_BUFFER = 10 * 1024 * 1024; // 10 MB — default 1 MB is too small for 
 
 const GIT_REF_PATTERN = /^[\w.\-/^~@{}]+$/;
 
-function execAsync(cmd: string): Promise<{ stdout: string; stderr: string }> {
+// cwd is undefined by default, which node's exec() treats as "inherit
+// process.cwd()" — the pre-existing, zero-footprint default. Auto-capture
+// callers (getStagedDiff/getWorkingDiff) pass an explicit cwd when the caller
+// (e.g. the MCP tool layer) named a repository directory, so git commands run
+// there instead of wherever the server process happened to start.
+function execAsync(cmd: string, cwd?: string): Promise<{ stdout: string; stderr: string }> {
   return new Promise((resolve, reject) => {
-    exec(cmd, { maxBuffer: MAX_BUFFER, timeout: 30_000 }, (error, stdout, stderr) => {
+    exec(cmd, { maxBuffer: MAX_BUFFER, timeout: 30_000, cwd }, (error, stdout, stderr) => {
       if (error) {
         reject(Object.assign(error, { stderr }));
         return;
@@ -18,18 +23,119 @@ function execAsync(cmd: string): Promise<{ stdout: string; stderr: string }> {
   });
 }
 
-function gitError(e: unknown): Result<string> {
+// git's own, stable fatal message for "there is no repository here"
+// (confirmed live against git 2.39.5: `git rev-parse --is-inside-work-tree`
+// and `git rev-parse --verify HEAD` outside a work tree both print exactly
+// "fatal: not a git repository (or any of the parent directories): .git").
+// Used to recognize a GENUINE not-a-repo failure so it — and only it — gets
+// rewritten into the friendlier, cwd-naming message. Every other failure (a
+// `safe.directory` dubious-ownership refusal, permission errors, a missing
+// git binary, a command timeout, ...) must keep its real text: rewriting
+// those into "not a repo" would send someone chasing the wrong fix.
+//
+// Anchored to the start of the fatal line (not a bare substring test): a
+// dubious-ownership error can legitimately quote a PATH that itself contains
+// the words "not a git repository" (e.g. a directory literally named that),
+// and an unanchored match would misclassify it. Requires "fatal: not a git
+// repository" right after a line start, followed by a space, colon, paren,
+// or end of string — covering both the "(or any of the parent
+// directories)" and "(or any parent up to mount point ...)" phrasings.
+function looksLikeNotARepoMessage(message: string): boolean {
+  return /(?:^|\n)fatal: not a git repository(?:[ :(]|$)/i.test(message);
+}
+
+// The --no-index "unknown option" fallback is specific to running `git diff
+// --cached` OUTSIDE a work tree — confirmed live: `error: unknown option
+// \`cached'` followed by a `usage: git diff --no-index ...` block. That is
+// NOT a generic "unknown option" signature: an unrelated bad flag, or
+// version-skew usage text, could plausibly contain one of those phrases
+// without meaning this fallback. Require both "unknown option" naming
+// "cached" AND --no-index context on the same message before treating it as
+// this specific fallback. Callers additionally gate this on cachedCommand
+// (see gitError) so it can only ever fire for the one command it describes.
+function looksLikeCachedNoIndexFallback(message: string): boolean {
+  const lower = message.toLowerCase();
+  const namesCachedAsUnknownOption = /unknown option[^\n]*cached/.test(lower);
+  const noIndexContext = lower.includes('--no-index');
+  return namesCachedAsUnknownOption && noIndexContext;
+}
+
+function notAGitRepoError(cwd: string | undefined): string {
+  const resolved = cwd ?? process.cwd();
+  return (
+    `${ErrorCode.GIT_ERROR}: "${resolved}" is not inside a git repository (or any parent of it). ` +
+    'Auto-capture runs git commands there. If the MCP server started from a different directory, ' +
+    'pass the "cwd" parameter with your repository path, or pass an explicit "diff" instead.'
+  );
+}
+
+// cachedCommand: set ONLY by the call site that just ran `git diff --cached`
+// — every other call site omits it, so the no-index rewrite can never fire
+// for a command it doesn't describe (e.g. `git rev-parse --verify HEAD`, or
+// the unstaged half of getWorkingDiff's HEAD-less fallback).
+function gitError<T>(e: unknown, cwd?: string, opts?: { cachedCommand?: boolean }): Result<T> {
   const stderr = (e as { stderr?: string }).stderr;
   const msg = stderr || (e instanceof Error ? e.message : String(e));
+  if (opts?.cachedCommand && looksLikeCachedNoIndexFallback(msg)) {
+    return err(notAGitRepoError(cwd));
+  }
   return err(`${ErrorCode.GIT_ERROR}: ${msg}`);
 }
 
-export async function getStagedDiff(): Promise<Result<string>> {
+// Inside/outside classification shared by isGitRepo and the auto-capture
+// preflight (checkWorkTreeForCapture below). A genuine "not a repository"
+// outcome is reported distinctly from every other failure so callers can
+// choose not to collapse permission errors, dubious-ownership refusals, a
+// missing git binary, or a timeout into a misleading "not a repo" message.
+type WorkTreeProbe = { kind: 'inside' } | { kind: 'not-a-repo' } | { kind: 'error'; error: string };
+
+async function probeWorkTree(cwd?: string): Promise<WorkTreeProbe> {
   try {
-    const { stdout } = await execAsync('git diff --cached --no-color');
+    const { stdout } = await execAsync('git rev-parse --is-inside-work-tree', cwd);
+    // Success with stdout other than 'true' (e.g. 'false' in a bare repo —
+    // no work tree to diff against) is "not a repo" for our purposes, same
+    // as the classic fatal message below.
+    return stdout.trim() === 'true' ? { kind: 'inside' } : { kind: 'not-a-repo' };
+  } catch (e: unknown) {
+    const stderr = (e as { stderr?: string }).stderr;
+    const msg = stderr || (e instanceof Error ? e.message : String(e));
+    if (looksLikeNotARepoMessage(msg)) {
+      return { kind: 'not-a-repo' };
+    }
+    // A real failure that has nothing to do with "no repo here" — a
+    // safe.directory dubious-ownership refusal, permission denied, git
+    // itself missing, a timeout, etc. Preserve it verbatim.
+    return { kind: 'error', error: `${ErrorCode.GIT_ERROR}: ${msg}` };
+  }
+}
+
+// Preflight for getStagedDiff/getWorkingDiff: ok(true) inside a usable work
+// tree; the friendly, cwd-naming error for a genuine "no repo here"; the
+// real underlying error, untouched, for anything else — so the caller sees
+// what actually needs fixing instead of always "pass the cwd param", which
+// would be actively wrong advice for e.g. a dubious-ownership refusal.
+async function checkWorkTreeForCapture(cwd?: string): Promise<Result<true>> {
+  const probe = await probeWorkTree(cwd);
+  switch (probe.kind) {
+    case 'inside':
+      return ok(true);
+    case 'not-a-repo':
+      return err(notAGitRepoError(cwd));
+    case 'error':
+      return err(probe.error);
+  }
+}
+
+export async function getStagedDiff(cwd?: string): Promise<Result<string>> {
+  const repoCheck = await checkWorkTreeForCapture(cwd);
+  if (!repoCheck.ok) {
+    return repoCheck;
+  }
+  try {
+    const { stdout } = await execAsync('git diff --cached --no-color', cwd);
     return ok(stdout.trim());
   } catch (e: unknown) {
-    return gitError(e);
+    return gitError(e, cwd, { cachedCommand: true });
   }
 }
 
@@ -57,34 +163,44 @@ export async function getDiffBetween(base: string, head: string): Promise<Result
   }
 }
 
-export async function getWorkingDiff(): Promise<Result<string>> {
+export async function getWorkingDiff(cwd?: string): Promise<Result<string>> {
+  // Same preflight rationale as getStagedDiff: fail fast with a clear,
+  // cwd-naming message for a genuine "no repo here" — and the real error for
+  // anything else — before ever attempting the commands below.
+  const repoCheck = await checkWorkTreeForCapture(cwd);
+  if (!repoCheck.ok) {
+    return repoCheck;
+  }
   try {
     // Check if HEAD exists (fails on repos with no commits)
-    await execAsync('git rev-parse --verify HEAD');
-    const { stdout } = await execAsync('git diff HEAD --no-color');
+    await execAsync('git rev-parse --verify HEAD', cwd);
+    const { stdout } = await execAsync('git diff HEAD --no-color', cwd);
     return ok(stdout.trim());
   } catch (e: unknown) {
-    // If HEAD doesn't exist (unborn repo), fall back to staged + unstaged
+    // If HEAD doesn't exist (unborn repo), fall back to staged + unstaged.
+    // We're already confirmed inside a work tree (preflight above), so any
+    // further failure here is real and reported as-is.
     const stderr = (e as { stderr?: string }).stderr ?? '';
     if (stderr.includes('HEAD')) {
+      let staged: { stdout: string };
       try {
-        const staged = await execAsync('git diff --cached --no-color');
-        const unstaged = await execAsync('git diff --no-color');
+        staged = await execAsync('git diff --cached --no-color', cwd);
+      } catch (fallbackErr: unknown) {
+        return gitError(fallbackErr, cwd, { cachedCommand: true });
+      }
+      try {
+        const unstaged = await execAsync('git diff --no-color', cwd);
         const combined = [staged.stdout.trim(), unstaged.stdout.trim()].filter(Boolean).join('\n');
         return ok(combined);
       } catch (fallbackErr: unknown) {
-        return gitError(fallbackErr);
+        return gitError(fallbackErr, cwd);
       }
     }
-    return gitError(e);
+    return gitError(e, cwd);
   }
 }
 
-export async function isGitRepo(): Promise<boolean> {
-  try {
-    const { stdout } = await execAsync('git rev-parse --is-inside-work-tree');
-    return stdout.trim() === 'true';
-  } catch {
-    return false;
-  }
+export async function isGitRepo(cwd?: string): Promise<boolean> {
+  const probe = await probeWorkTree(cwd);
+  return probe.kind === 'inside';
 }

--- a/src/utils/resolve-diff.test.ts
+++ b/src/utils/resolve-diff.test.ts
@@ -85,6 +85,20 @@ describe('resolvePrecommitDiff', () => {
       expect(mockGetStagedDiff).not.toHaveBeenCalled();
     });
   });
+
+  describe('cwd threading', () => {
+    it('forwards cwd to getStagedDiff', async () => {
+      mockGetStagedDiff.mockResolvedValue({ ok: true, data: sampleDiff });
+      await resolvePrecommitDiff({ cwd: '/some/repo' });
+      expect(mockGetStagedDiff).toHaveBeenCalledWith('/some/repo');
+    });
+
+    it('passes undefined to getStagedDiff when cwd is omitted (preserves default behavior)', async () => {
+      mockGetStagedDiff.mockResolvedValue({ ok: true, data: sampleDiff });
+      await resolvePrecommitDiff({});
+      expect(mockGetStagedDiff).toHaveBeenCalledWith(undefined);
+    });
+  });
 });
 
 describe('resolveCodeDiff', () => {
@@ -165,6 +179,20 @@ describe('resolveCodeDiff', () => {
         expect(result.error).toBe('auto_diff disabled and no diff provided');
       }
       expect(mockGetWorkingDiff).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('cwd threading', () => {
+    it('forwards cwd to getWorkingDiff', async () => {
+      mockGetWorkingDiff.mockResolvedValue({ ok: true, data: sampleDiff });
+      await resolveCodeDiff({ cwd: '/some/repo' });
+      expect(mockGetWorkingDiff).toHaveBeenCalledWith('/some/repo');
+    });
+
+    it('passes undefined to getWorkingDiff when cwd is omitted (preserves default behavior)', async () => {
+      mockGetWorkingDiff.mockResolvedValue({ ok: true, data: sampleDiff });
+      await resolveCodeDiff({});
+      expect(mockGetWorkingDiff).toHaveBeenCalledWith(undefined);
     });
   });
 });

--- a/src/utils/resolve-diff.ts
+++ b/src/utils/resolve-diff.ts
@@ -8,6 +8,11 @@ export const NO_WORKING_CHANGES = 'NO_WORKING_CHANGES';
 export async function resolvePrecommitDiff(args: {
   diff?: string;
   auto_diff?: boolean;
+  // Repository directory to run auto-capture git commands in. Undefined
+  // (the default) preserves prior behavior — git runs in the server
+  // process's own cwd. Callers are expected to have already validated this
+  // (see utils/cwd.ts) before it reaches here.
+  cwd?: string;
 }): Promise<Result<string>> {
   // Explicit diff takes precedence (including empty string)
   if (args.diff !== undefined) {
@@ -16,7 +21,7 @@ export async function resolvePrecommitDiff(args: {
 
   // auto_diff defaults to true (undefined !== false)
   if (args.auto_diff !== false) {
-    const gitResult = await getStagedDiff();
+    const gitResult = await getStagedDiff(args.cwd);
     if (!gitResult.ok) {
       return gitResult;
     }
@@ -32,6 +37,8 @@ export async function resolvePrecommitDiff(args: {
 export async function resolveCodeDiff(args: {
   diff?: string;
   auto_diff?: boolean;
+  // See resolvePrecommitDiff's cwd for the contract.
+  cwd?: string;
 }): Promise<Result<string>> {
   // Explicit non-empty diff takes precedence
   if (args.diff !== undefined && args.diff.trim() !== '') {
@@ -40,7 +47,7 @@ export async function resolveCodeDiff(args: {
 
   // auto_diff defaults to true (undefined !== false)
   if (args.auto_diff !== false) {
-    const gitResult = await getWorkingDiff();
+    const gitResult = await getWorkingDiff(args.cwd);
     if (!gitResult.ok) {
       return gitResult;
     }


### PR DESCRIPTION

## Summary

When `codex-claude-bridge` runs as an MCP server, it's launched with no explicit working directory (`npx -y codex-claude-bridge@latest`, no `cwd` in the client's server config), so `process.cwd()` is wherever the launching client happened to start its session — often not a git repository at all. Every auto-capture git command (`review_code`'s working diff, `review_precommit`'s staged diff) ran against that inherited directory with no way to point it at the actual repo, so the two most-used tools in the bridge failed with a confusing raw git error the moment the server wasn't launched from inside a work tree.

- **`review_code` and `review_precommit` gain an optional `cwd` parameter** — the repository directory for auto-capture (both tools) and config discovery (`review_precommit` only — see below). Validated (must be an existing directory, resolved to absolute) and threaded through git capture, both provider backends' subprocess/thread spawns, and precommit's per-repo config lookup. `review_plan` is untouched — its flow never calls git or does config discovery.
- **Better, and *safer*, failure mode**: outside a work tree, `git diff --cached` silently falls back to `--no-index` mode and rejects `--cached` as an unknown option, so the old failure was a raw `GIT_ERROR: error: unknown option 'cached'` dump. Auto-capture now preflights with `git rev-parse --is-inside-work-tree` and returns a clean, cwd-naming message *only* when the target genuinely isn't a usable repository — every other preflight failure (a `safe.directory` dubious-ownership refusal, permission errors, a missing git binary, a timeout) surfaces its own real text instead of being misclassified as "not a repo," which would send someone chasing the wrong fix.
- **Default behavior is unchanged.** Omitting `cwd` still uses `process.cwd()` everywhere — zero footprint for existing callers/configs. Per-repo config discovery, when it does run, falls back to the server's own boot-time config on a miss — never to built-in schema defaults, which would have silently discarded a real setting the server loaded at startup.

This PR went through two independent review passes after the initial implementation — a Codex adversarial pass (3 findings, labeled F1–F3 below) and a qa spec/architecture pass (7 more, F4–F10) — both folded into this single commit rather than left as a fix-up trail.

## Root cause

Two independent sites hardcoded the server process's own cwd with no override:

1. `src/utils/git.ts`'s `execAsync()` called `child_process.exec(cmd, { maxBuffer, timeout }, cb)` — no `cwd` in the options object, so node always inherited `process.cwd()`. `getStagedDiff()`/`getWorkingDiff()` had no parameter to override it, and `resolvePrecommitDiff`/`resolveCodeDiff` (`src/utils/resolve-diff.ts`) had nothing to pass down even if they had.
2. `src/backends/gemini.ts`'s `TurnRunner`, wired in `createGeminiBackend`, called `runAgyReview({ ...params, config, cwd: process.cwd() })` — the `cwd: process.cwd()` came *after* the spread, so even if a caller-supplied cwd had been present in `params`, it would have been silently clobbered.

A third site was found only during review (F5, below): `@openai/codex-sdk`'s `ThreadOptions.workingDirectory` was never wired up at all — Codex (the default provider) was reviewing rooted at the server's launch directory with no override in sight, not even a broken one.

Neither of the first two sites had a caller-supplied value to fall back on: `CodeReviewInput`/`PrecommitReviewInput` (`src/backends/backend.ts`) and the `review_code`/`review_precommit` tool schemas had no `cwd` field at all.

## Fix

### Core cwd threading

- `src/utils/cwd.ts` (new): `resolveCwd(cwd)` — validates and resolves an optional caller-supplied `cwd` to an absolute path. `undefined` and blank strings pass through as `undefined` (the default); anything else must name an existing directory or returns a clear `INVALID_INPUT` error rather than crashing or silently redirecting to the server's own cwd. **F3:** uses a single `statSync` in a try/catch (not `existsSync` then `statSync`) — the two-call form left a TOCTOU window where the path could vanish or become inaccessible between calls, and a bare `statSync` throws on failure, which would have escaped this function's Result contract and propagated past both tool handlers' try blocks (they call `resolveCwd` before entering them). The errno → message mapping (ENOENT/ENOTDIR → "does not exist", EACCES → a distinct "not accessible / permission denied", anything else → a generic-but-still-actionable message) lives in the exported `classifyStatError`, unit-tested directly with synthetic errno codes.
- `src/utils/git.ts`: `execAsync`, `getStagedDiff`, `getWorkingDiff` accept an optional `cwd` and forward it to `exec`'s options (this is *the* bug: it never had a `cwd` key at all). `getUnstagedDiff`/`getDiffBetween` are out of scope — neither is on the auto-capture path these two tools use.
- `src/utils/resolve-diff.ts`: `resolvePrecommitDiff`/`resolveCodeDiff` accept `cwd` and pass it to `getStagedDiff`/`getWorkingDiff`.
- `src/backends/backend.ts`: `CodeReviewInput`/`PrecommitReviewInput` gain `cwd?: string` (not `PlanReviewInput` — `review_plan` never touches git or config).
- `src/backends/orchestrator.ts`: `TurnParams` gains `cwd?: string`; `runCodeReview`/`runPrecommitReview` forward `input.cwd` into every `turn()` call (single-chunk and each chunk of a multi-chunk review).
- `src/backends/gemini.ts`: `createGeminiBackend`'s `turn` now does `cwd: params.cwd ?? process.cwd()` — an explicit cwd wins; omitted still falls back exactly as before. `runAgyPrint`'s spawn and the cwd-keyed conversation-id cache (`readConversationId`) already accepted a cwd — they just weren't being given the right one.
- `src/tools/review-code.ts` / `src/tools/review-precommit.ts`: both tools gain a `cwd` input, validate it via `resolveCwd` up front (returning a tool error, not a crash, on an invalid path), and pass the resolved value into diff resolution and the backend call.

### F1 (Codex, major) — preflight no longer misclassifies real errors as "not a repo"

The first cut of the preflight (`isGitRepo()`, boolean-only) collapsed **every** failure into `false` — a `safe.directory` dubious-ownership refusal, a permission error, a missing git binary, a timeout, all surfaced as "not inside a git repository," which is actively wrong advice (the fix for dubious ownership is `git config --global --add safe.directory <path>`, not passing `cwd`).

Fixed with a shared classifier (`probeWorkTree` in `git.ts`) that distinguishes three outcomes: genuinely inside a work tree; genuinely not a repo (rev-parse succeeds with `false` — a bare repo — or fails with git's own `"not a git repository"` message, confirmed live against git 2.39.5); or a real error, whose original text is preserved untouched. `isGitRepo(cwd): Promise<boolean>` keeps its exact prior public contract (now a thin wrapper delegating to the shared classifier — same behavior, same tests, no callers elsewhere in the codebase depend on the distinction it can't make). `checkWorkTreeForCapture`, the new preflight `getStagedDiff`/`getWorkingDiff` call before their real commands, is the one that actually branches on it.

### F2 (Codex, minor) — the --no-index rewrite is narrowed and call-site-scoped

The original `looksLikeNoIndexFallback` matched a bare substring (`"unknown option"` OR `"--no-index"`), which could misfire on an unrelated bad-flag error or version-skew usage text sharing one phrase. `looksLikeCachedNoIndexFallback` now requires **both** "unknown option" naming `cached` **and** `--no-index` context on the same message (verified live: git 2.39.5 actually emits `` error: unknown option `cached' `` followed by a `usage: git diff --no-index ...` block). `gitError()` additionally takes a `cachedCommand` opt-in flag, set **only** at the one call site that just ran `git diff --cached` — every other call site (`git rev-parse --verify HEAD`, the unstaged half of `getWorkingDiff`'s HEAD-less fallback, `getUnstagedDiff`, `getDiffBetween`) omits it, so the rewrite can never fire for a command it doesn't describe, even if that command's stderr happened to be shaped the same way.

### F4 (qa, major) — per-repo config discovery redesigned; the first cut was a trap

The original approach called `loadConfig(cwd)` per call for `review_precommit`'s config-driven `auto_diff` default. Two real bugs: (a) `loadConfig(cwd)`'s "explicit mode" probes **only** `cwd/.reviewbridge.json` — a `cwd` naming a *subdirectory* of a repo would miss that repo's root config entirely, even though the loader already owns a `walkUp()` generator its own implicit-mode cascade uses; (b) on a miss, explicit mode returns **built-in schema defaults** — meaning a user who set `precommit.auto_diff:false` via `RB_CONFIG_PATH` or `$HOME/.reviewbridge.json` would see it silently reset to the schema default (`true`) the instant they passed a `cwd` whose own directory (not tree — directory) had no config file of its own.

Fixed with a new function, `discoverProjectConfig(startDir)` (`src/config/loader.ts`), that reuses the loader's own `walkUp`/`.git`-boundary/`probe` primitives — the *same* algorithm `loadConfig()`'s implicit mode already uses, just anchored at an arbitrary `startDir` instead of `process.cwd()`. It returns `ok(null)` — not a config, not an error — when nothing is found anywhere up the tree, and `review-precommit.ts`'s caller then explicitly falls back to the **server's own boot-time config** (the `config` parameter already in scope), never to schema defaults. `loadConfig()` itself, including its CLI-facing "explicit mode: look only there" contract, is completely unmodified — `discoverProjectConfig` is new and additive, not a change to existing behavior. This only affects the one field `review_precommit` reads per call (`review_standards.precommit.auto_diff`); provider/backend selection, deliberate-mode capability, and copilot instructions stay wired once at server construction, tied to the server's launch directory — making those cwd-aware per call would mean reconstructing the backend per call, out of scope here.

### F5 (qa, factual correction) — Codex reviews were *also* rooted at the server's launch dir, and it's fixable

The first draft of this PR claimed the Codex SDK path had "no cwd usage anywhere" and left it untouched. That was **wrong** — checked only the bundled npm package's own compiled output (which never called it), not the SDK's own exposed API. `@openai/codex-sdk`'s `ThreadOptions` (`node_modules/@openai/codex-sdk/dist/index.d.ts:239-250`) declares `workingDirectory?: string`, and the SDK's compiled command-builder (`dist/index.js`) forwards it as `--cd <dir>` unconditionally whenever set — Codex is the *default* provider (`provider: 'codex'`), so this was reviewing rooted at wherever the server launched from, with zero override available, the entire time.

Investigated resume safety before threading it (mirroring how the codebase already treats `model` specially on resume) rather than assuming it was safe:
- `ThreadOptions` is the identical type for both `startThread`/`resumeThread` — no type-level distinction.
- The compiled command builder adds `--cd <dir>` unconditionally, independent of whether `resume <threadId>` is also appended to the same argv array.
- `codex exec resume --help` doesn't even list `--cd`/`-C` as an option of the `resume` subcommand — it's a top-level `codex exec` flag governing where the whole invocation runs, structurally unlike `model` (a server-side generation parameter the codebase already knows gets reasserted-and-conflicts on resume, per the existing comment referencing `@openai/codex-sdk/dist/index.js:170`).

No live resumed-session test was run against the real API (that would spend real tokens/API budget for a verification step); the above is static analysis of the SDK's actual shipped code plus its CLI's own `--help` text. Threaded uniformly: `baseThreadOpts(config, cwd)` now includes `workingDirectory: cwd`, used by both `startThreadOpts` and `resumeThreadOpts`, with `runReview` passing `params.cwd` through. Omitted cwd → `workingDirectory: undefined` → the SDK never adds `--cd` at all → identical to prior behavior.

### F6 (qa) — real-git integration coverage

`src/utils/git.integration.test.ts` (new): git-inits a real temp repo, stages a file, and asserts `getStagedDiff(repo)` returns the real content from a foreign `process.cwd()` (this test file's own directory) — no mocks, the literal end-to-end scenario the bug report is about — plus the non-repo friendly-message case and `isGitRepo` in both directions. Named per the repo's own `*.integration.test.ts` convention (`server.integration.test.ts`, `storage/session-tracker.integration.test.ts`). CI-safe: `describe.skipIf(!hasGit())` skips cleanly (not a failure) when `git` isn't on PATH.

### F7 (qa, factual correction, one line)

`review_code`'s `cwd` description said "git commands and config discovery run here" — `review_code` does no config discovery (its handler takes no `config` parameter, calls neither `loadConfig` nor `discoverProjectConfig`). Dropped the config-discovery wording there; `review_precommit`'s description was updated separately to describe its actual (post-F4) walk-up behavior.

*(F8 was a local deployment-documentation item — `LOCAL-DEPLOY.md` — not part of this PR; numbering continues from the original review pass rather than being renumbered, so the two lists stay traceable to each other.)*

### F9 (qa) — stderr warning memoization

With per-call config discovery now real, `warnUnknownConfigKeys` (`loader.ts`) could re-probe and re-warn about the *same* on-disk file on every `review_precommit` call that resolves to it. A process-lifetime `Set<string>` (`warnedConfigPaths`) now short-circuits the check after the first time a given resolved path is seen; a different path still warns independently. `resetConfigWarningMemo()` is exported *only* so `loader.test.ts` can clear it between cases (several existing tests intentionally reuse the same config path — module-level state isn't touched by `vi.resetAllMocks()`); production code never calls it.

### F10 (qa) — traced, no code change needed

Asked to confirm a resumed Gemini session (`session_id` passed) whose `cwd` differs from — or omits — the original call's `cwd` can't silently fork a new conversation or shift lock scope mid-session. Traced against the actual code (`src/backends/gemini.ts`), not assumed:

- **The id-capture cache is unreachable on resume.** `const resolvedId = sessionId ?? readConversationId(cwd);` — the `??` short-circuits `readConversationId(cwd)` entirely whenever `sessionId` is truthy. A resumed call always returns the caller's own `sessionId` verbatim; the cwd-keyed cache can never substitute a different id. No fork is possible through this mechanism, by construction, regardless of what `cwd` accompanies a resume.
- **The serialization lock is global, not per-cwd** — correcting a mischaracterization in how this was originally described. `runSerialized`'s own pre-existing comment says so explicitly ("Serialize the run+capture critical section through a process-global chain"); its scope literally cannot vary with `cwd` because it never reads `cwd` at all.
- **Residual, and pre-existing:** a resume *does* spawn the `agy` subprocess in whatever `cwd` that particular call specifies while asking it to continue conversation `sessionId`. If that `cwd` differs from the one the session started in, the review's *content* may be incoherent relative to the conversation's history — the same caller-coherence risk that already existed for passing an unrelated `diff`/`plan` to a resumed session, not a new class of bug (data corruption, identity confusion) introduced by cwd threading.

Both findings are now documented as code comments at the exact lines they concern (`gemini.ts`), not just in this PR body.

### Report-only: command-string safety

Confirmed (grep across every `cwd`-adjacent call site in `git.ts`, `gemini.ts`, `codex.ts`) that `cwd` never reaches an `exec`/`spawn` **command string** at any point — it rides exclusively in options objects (`exec`'s `{ cwd }`, `spawn`'s `{ cwd: opts.cwd }`) or as a separate argv token the SDK's own array-based command builder appends (`--cd <dir>`). No shell-string interpolation surface for it anywhere.

## Compatibility

Every new parameter is optional and defaults to `undefined`, which preserves the exact prior behavior (`process.cwd()`) at every site. No existing config field, tool schema field, or CLI flag changes shape. The CLI is untouched — it already runs git (and, transitively, Codex) from whatever directory the user invokes it in, so it never had this bug.

## Test evidence

Colocated `*.test.ts` per the repo's convention, plus one new `*.integration.test.ts`:

- `src/utils/cwd.test.ts` — `resolveCwd`: undefined/blank passthrough, absolute resolution, missing path, path-is-a-file, real temp dirs. `classifyStatError` (new, F3): ENOENT, ENOTDIR, EACCES, and unrecognized-errno mapping, tested directly with synthetic errno codes rather than via a real permission race (unreliable to reproduce and platform/root-dependent).
- `src/utils/git.test.ts` — the preflight classifier (F1): a genuine dubious-ownership failure and a missing-binary failure both surface their own real text, not the friendly not-a-repo message, on both `getStagedDiff` and `getWorkingDiff`. The narrowed no-index rewrite (F2): the real git 2.39.5 message still triggers it; an unrelated "unknown option" does not; "unknown option ... cached" without `--no-index` context does not; a same-shaped failure on the *unstaged* half of `getWorkingDiff`'s HEAD-less fallback (which never ran `--cached`) is not rewritten, proving the call-site gate. Plus all pre-existing coverage, cwd forwarding, and cwd-naming in messages.
- `src/utils/git.integration.test.ts` (new, F6) — real git, no mocks, described above.
- `src/utils/resolve-diff.test.ts` — cwd forwarded to `getStagedDiff`/`getWorkingDiff`.
- `src/backends/orchestrator.test.ts` — `runCodeReview` forwards `input.cwd` into every `turn()` call, single- and multi-chunk.
- `src/backends/gemini.test.ts` — `reviewCode`/`reviewPrecommit` with an explicit `cwd` spawn `agy` there (not `process.cwd()`); existing no-cwd coverage untouched.
- `src/backends/codex.test.ts` (F5) — `workingDirectory` forwarded on a fresh `startThread` and on a `resumeThread`; omitted cwd leaves it `undefined` (no `--cd` added); `review_plan` never threads it, start or resume.
- `src/config/loader.test.ts` (F4/F9) — `discoverProjectConfig`: exact-directory hit, subdirectory walk-up to a repo-root config (the case `loadConfig(cwd)` misses), `.git`-boundary stop, `ok(null)` on a total miss, malformed-config error. Warning memoization (F9): three loads of the same path warn once; a different path still warns independently.
- `src/tools/review-code.test.ts` / `src/tools/review-precommit.test.ts` — valid cwd resolves and forwards; invalid cwd returns a tool error without calling the diff resolver, `discoverProjectConfig`, or the client; omitted cwd preserves default behavior and never calls `discoverProjectConfig`. `review-precommit.test.ts` additionally (F4): repo config's `auto_diff:false` wins over the server's boot config; an explicit `auto_diff` arg still overrides the repo config; **a total miss (nothing found anywhere up the tree) preserves a non-default BOOT config value — the regression guard for the original F4 bug**; a broken `.reviewbridge.json` found while walking up returns a clear error.

```
npm run typecheck && npm run lint && npx vitest run
```
→ typecheck clean, lint clean, **872 passed, 0 failed** (38 test files; 0 skipped — `git.integration.test.ts`'s skip-if-no-git guard did not trigger on this machine, git is present).

Built-artifact verification (outside the unit suite, no MCP client needed, re-run after every round of fixes against a freshly rebuilt `dist/index.js`):
- A tsup-built re-export of the same source, called directly: `getStagedDiff('<path to a real repo with staged changes>')` returns the actual staged diff (non-empty, correct file paths); `getStagedDiff()` run from a genuinely non-repo directory returns the new clean message naming that directory, not the old raw `unknown option 'cached'` dump; `isGitRepo` sanity-checks both directions; a deeply-nonexistent path resolves cleanly (spawn-level `ENOENT`, not a false "not a repo" claim, and never throws).
- The real built `dist/index.js`, run as an actual MCP server over stdio (`initialize` → `tools/call` for both `review_code` and `review_precommit` with no `cwd`, launched from a non-repo temp directory): both return `isError: true` with the new clean message, confirming the fix through the literal shipped entry point, post-F1–F10. (Deliberately limited to this negative case in verification — it's guaranteed to fail during auto-capture before ever reaching a live Codex/Gemini provider call, so it carries no risk of an unintended real review.)

## Deviations & flags

1. **File-location correction**: the MCP registration is in `~/.claude.json`, not `~/.claude/settings.json` (that file is 261 lines total, no `mcpServers` key). See `LOCAL-DEPLOY.md` (untracked, local-only) for the verified exact edit.
2. **F4's config-walk-up is bounded, not exhaustive**, by design: it makes the one per-call-consumed config field (`precommit.auto_diff`) cwd-aware. Provider/backend selection, deliberate-mode capability, and copilot instructions remain fixed to the server's boot-time config — full per-call reconfiguration would mean reconstructing the backend on every tool call, a materially larger change than this fix's scope.
3. **F5's resume-safety conclusion rests on static analysis** (SDK type declarations, SDK compiled JS, `codex exec --help`/`codex exec resume --help`), not a live resumed-session API call — deliberately avoided spending real API budget on a verification step.
4. **Blank-string `cwd`** (`''`, `'   '`) is normalized to `undefined` semantics rather than erroring or silently resolving to the server's own cwd (`path.resolve('')` would otherwise do the latter) — own design call, documented in `cwd.ts`.
5. **Formatting**: fixed Prettier issues only on lines this PR's diff actually introduces or modifies (verified line-by-line against `git stash`-captured baselines at each round) — left substantial pre-existing Prettier debt elsewhere in touched files untouched, since the repo's own `prepublishOnly` gate doesn't check formatting and reformatting code this PR didn't otherwise touch isn't this PR's job.
6. `LOCAL-DEPLOY.md` and this file are both intentionally left **untracked** — process/deployment notes for the person submitting this, not files that belong in the shipped tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
