### PR TITLE
feat: evidence-aware responding-model metadata and safe review lifecycle (T-038)

### DIFF
--- a/.story/.gitignore
+++ b/.story/.gitignore
@@ -3,3 +3,5 @@ status.json
 sessions/
 federation-cache.json
 channel-inbox/
+servers/
+/telemetry/

--- a/.story/handovers/2026-07-13-01-responding-model-metadata.md
+++ b/.story/handovers/2026-07-13-01-responding-model-metadata.md
@@ -1,0 +1,48 @@
+# T-038 — Evidence-aware responding-model metadata
+
+## Outcome
+
+Implemented and Story-approved. T-038 is complete. No commit, version bump, publication, staging, or push was performed.
+
+Successful plan, code, and precommit responses now expose host-side model contributions and persistence provenance. History stores immutable model snapshots with explicit recorded / legacy_unrecorded / invalid status and bounded cursor pagination.
+
+## Main implementation
+
+- Added optional public `models` and `provenance` contracts while always emitting them from new successful calls.
+- Kept host metadata out of provider-facing structured-output schemas.
+- Added secure, bounded Codex rollout observation with UUIDv7/date candidate validation, no-follow descriptor checks, reverse bounded reads, deadlines, and LRU caching.
+- Added truthful Gemini selected-only evidence and a five-minute single-flight model catalog cache.
+- Added shared lifecycle admission (global 4, per-session 1), explicit routing ownership, memory registry/tombstones, and status integration.
+- Added atomic SQLite migrations, BEGIN IMMEDIATE outcome transactions, bounded busy retry, durable-to-memory fallback, survivor-ID transitions, immutable history snapshots, and a verified reviews(session_id,id) index.
+- Added strict selector/session validation, terminal control sanitization, CLI human/JSON model rendering, MCP descriptions, and README docs.
+- Deliberation now converts rejected reviewer/adjudicator promises to sanitized Results so a successful peer survives and only successful contributors are reported.
+- Lifecycle execution was split into admission, normalization, persistence/provenance, and cleanup phases; unexpected backend exceptions stay inside the Result contract.
+
+## Validation
+
+- `npm test -- --run`: 44 files, 939 tests passed.
+- `npm run lint`: passed.
+- `npm run typecheck`: passed.
+- `npm run build`: passed.
+- `git diff --check`: passed.
+- Two independent focused audits found no remaining lifecycle or deliberation correctness issue.
+- Story CODE_REVIEW round 2: approve, full six-lens coverage, 0 blocking, 0 major, 4 maintainability minors, 1 test suggestion.
+
+## Live acceptance evidence
+
+- Default Codex call reported requested=null, resolved=gpt-5.6-sol, observed=gpt-5.6-sol, evidence=runtime_session_record.
+- Fresh explicit gpt-5.5 call reported matching resolved/observed gpt-5.5.
+- Persistent resume of that gpt-5.5 thread while Sol was default retained resolved=gpt-5.5 and freshly observed gpt-5.6-sol, with one sanitized mismatch warning. This is control-plane evidence, not proof of underlying weights.
+- A live deliberate probe degraded safely to Codex-only because Gemini timed out; automated deliberate/deep tests cover both reviewers and adjudication roles.
+
+## Story state
+
+- T-038: complete.
+- ISS-025 (provider promise rejection discarding a survivor): resolved by this work.
+- ISS-026 remains open as a non-blocking maintainability issue for duplicated long deliberation flows.
+- L-015 records the resolved-vs-observed resume lesson.
+- Snapshot taken before this handover: 2026-07-13T10-05-14-440.json.
+
+## Working tree
+
+Expected implementation changes are uncommitted. Pre-existing untracked `.codex/` and `AGENTS.md` were not modified and must remain untouched.

--- a/.story/handovers/2026-07-13-02-responding-model-metadata-final.md
+++ b/.story/handovers/2026-07-13-02-responding-model-metadata-final.md
@@ -1,0 +1,52 @@
+# T-038 — Final evidence-aware model metadata handover
+
+## Current state
+
+T-038 is complete and the implementation is ready for the next operator to inspect, commit, or publish only when separately authorized. This handover supersedes no prior record; it confirms the final state after the Story-approved implementation documented in `2026-07-13-01-responding-model-metadata.md`.
+
+No commit, staging, branch creation, version bump, push, PR, or package publication has been performed.
+
+## Delivered behavior
+
+- Every new successful plan, code, and precommit response emits host-side `models` and `provenance`.
+- Model contributions distinguish provider, role, requested selector, bridge-resolved label, runtime-observed label, and evidence source.
+- Codex runtime observation is UUIDv7/date constrained, containment checked, no-follow/nonblocking where supported, reverse-read with 8 MiB / 100 ms bounds, and cached with a 256-entry one-hour LRU.
+- Gemini reports the exact bridge-selected model with `observed: null` and uses a five-minute single-flight catalog cache.
+- Single, failover, degraded, deliberate, and deliberate-deep composition reports only successful contributors in deterministic reviewer/adjudicator order.
+- Synthetic no-change results report `models: []` and `persistence: not_recorded`.
+- The shared lifecycle enforces four global active logical reviews and one per session, explicit safe resume routing, registry-backed memory-only sessions, and immediate REVIEW_BUSY rejection.
+- SQLite migrations add `sessions.model_identity_json` and `reviews.models_json` atomically, outcomes use BEGIN IMMEDIATE plus bounded busy retry, and permanent writes degrade successful reviews to honest memory-only provenance.
+- History returns immutable model snapshots, malformed-metadata status, bounded keyset pagination, and uses a verified `reviews(session_id,id)` index.
+- CLI/MCP descriptions, JSON/human rendering, validation, control escaping, and README documentation are updated.
+- Deliberation catches rejected provider promises as sanitized Results so a successful peer and its model contribution survive.
+
+## Validation evidence
+
+- `npm test -- --run`: 44 test files, 939 tests passed.
+- `npm run lint`: passed.
+- `npm run typecheck`: passed.
+- `npm run build`: passed.
+- `git diff --check`: passed.
+- Independent lifecycle and deliberation state audits: no findings.
+- Final Story CODE_REVIEW: approve with full six-lens coverage, 0 blocking, 0 major, 4 maintainability minors, and 1 optional test suggestion.
+
+## Live probes
+
+- Current default: `requested=null`, `resolved=gpt-5.6-sol`, `observed=gpt-5.6-sol`, runtime-session evidence.
+- Fresh explicit thread: matching `resolved` and `observed` `gpt-5.5`.
+- Resume of that 5.5 thread while Sol was the default: retained `resolved=gpt-5.5`, freshly recorded `observed=gpt-5.6-sol`, and emitted one sanitized mismatch warning.
+- Live deliberate mode safely degraded to Codex-only when Gemini timed out; automated tests cover dual-reviewer and deliberate-deep adjudication identities.
+
+These labels are control-plane evidence and are not proof of underlying model weights or internal routing.
+
+## Story records
+
+- T-038: complete.
+- ISS-025: resolved by rejected-promise containment.
+- ISS-026: open, non-blocking maintainability cleanup for duplicated long deliberation flows.
+- L-015: resolved-vs-observed identity lesson.
+- Fresh pre-handover snapshot: `2026-07-13T10-10-19-464.json`.
+
+## Working-tree cautions
+
+All implementation and Story records are uncommitted. Preserve the pre-existing untracked `.codex/` directory and `AGENTS.md`; they were not modified by this work. Review the complete diff line by line before any future commit, per repository rules.

--- a/.story/handovers/2026-09-03-01-external-feedback-triage-worktree-capture.md
+++ b/.story/handovers/2026-09-03-01-external-feedback-triage-worktree-capture.md
@@ -1,0 +1,60 @@
+# Handover — External usage feedback triaged into ISS-027 / ISS-028; no code changed
+
+## TL;DR
+
+A context-load session that turned into intake. Three external usage reports arrived mid-session from a peer Claude session (`care2talk-9e`) relaying feedback from three Care2Talk seats after a night of heavy bridge use. Two were technical claims; I verified both against the code at `a066fba` and filed them as **ISS-027** (high) and **ISS-028** (medium). A third was an operational heads-up, later corrected by the sender, recorded as note **N-004**.
+
+**No code was written, no tests were run, nothing was committed.** The inherited uncommitted T-038 working tree is untouched and still needs its review.
+
+## What was reported and what was verified
+
+### ISS-027 — auto-capture runs in the server's spawn cwd, not the caller's worktree (high)
+
+Two seats independently, hours apart, hit a false `"No staged changes found"` while a full staged diff sat in their git worktree. `care2talk-39` was in `~/Developer/ReactNative`; `c2t-design-71` was in `~/Developer/c2t-design/.claude/worktrees/t027-package-readiness`. Both burned a review call and diagnosed it from scratch. Reported against both `codex-bridge` and `codex-bridge-local`. Workaround is passing the diff explicitly.
+
+I did not reproduce it, and neither did the reporting session — this is two independent seat accounts plus a code read. The code read is unambiguous:
+
+- Every capture in `src/utils/git.ts` (lines 29, 38, 53, 64, 71-72) calls `execAsync` with **no `cwd` option**, so each git command runs in the directory the client spawned the stdio server in.
+- No MCP tool accepts a `cwd` / `repo_path` parameter, and a stdio server has no way to learn the caller's current directory.
+- So a session that moves into a worktree after spawn captures the *main checkout's* index. `review_precommit` returns the empty-result path (`src/utils/resolve-diff.ts:24` → `src/tools/review-precommit.ts:70`), and `review_code` with `auto_diff` returns `"No changes found to review."` (`src/tools/review-code.ts:87`).
+
+Fix direction recorded on the issue: accept an optional `cwd`/`repo_path` tool parameter, validate it is an existing directory inside a git work tree, thread it into the `execAsync` calls via `resolve-diff`, and have the CLI default it to `process.cwd()`. Not designed further — see Decision needed below.
+
+### ISS-028 — empty results are silent; name the capture directory (medium)
+
+The reporting session argued this matters more than the bug itself, and I agree with the reasoning. `"No staged changes found"` is indistinguishable from a legitimate empty result and names no directory, so users have no reason to doubt the tool: they check their own git state first, find changes, and only then suspect the bridge. That is why the worktree bug cost two full diagnoses rather than one shrug.
+
+Proposed as the **first** change, ahead of the ISS-027 plumbing: report the absolute directory the git command actually ran in on every auto-captured result, and say so explicitly when it differs from a caller-supplied cwd. Roughly ten lines, no behavior change, and it self-diagnoses whatever the next variant of this class turns out to be.
+
+### N-004 — npx orphan heads-up (corrected) plus positive signal
+
+Original report: a disk cleanup removed most of `~/.npm/_npx`; two running `codex-claude-bridge` processes were executing from deleted directories, alive only on open file descriptors, and a restart would end review capability until npx re-downloaded.
+
+**The sender corrected this before it reached a decision, and the corrected version is what N-004 records.** Reading the config rather than reasoning about it shows two separate servers: `codex-bridge` launches via `npx -y codex-claude-bridge` and does re-download after a restart (a delay and a network dependency), while `codex-bridge-local` launches as `node <repo>/dist/index.js`, was never in the npx cache, exposes the same five tools, and survives a restart with no network. Do not carry the original "permanent loss" framing forward.
+
+Left as a note, not an issue: nothing is broken and this is arguably npx behaving as designed given our documented `npx -y codex-claude-bridge@latest` install recipe. Open question if anyone wants it — should the bridge defend against its own install vanishing (README note, or a startup log of the resolved install path)?
+
+Positive signal from the same report, kept because a feedback record of only complaints is a bad sample. The reviews found three genuine defects that passing test suites had missed: two React Native layout composition errors (the second found while reviewing the fix for the first) and an iOS codegen digest that skipped regeneration when its outputs had been deleted. Two other rounds came back clean and the seats stopped rather than fishing. In one case a seat rejected a suggestion with a reason — declining to default `NODE_BINARY` to `node` in an Xcode script phase, since a wrong Node would silently produce codegen — and the reviewer agreed on the next round.
+
+## State
+
+- `main` = `a066fba`. **Nothing committed this session.**
+- The T-038 evidence-aware model-metadata implementation from the previous two sessions is **still uncommitted** across ~55 tracked files, along with its Story records. It was Story-approved with 939 tests green but has NOT had the mandatory line-by-line pre-commit diff review.
+- Untracked and pre-existing, both must stay untouched: `AGENTS.md` (a corrupted find-and-replace of CLAUDE.md — rewrite properly or delete, do not commit as-is) and `.codex/config.toml` (pending a decision on whether to version it).
+- Ledger changes this session: ISS-027 created, ISS-028 created, N-004 created then updated with the correction. Snapshot `2026-09-04T00-42-20-209.json` taken before this handover.
+- Open issues now 7: ISS-018, ISS-020, ISS-022, ISS-024, ISS-026, ISS-027, ISS-028.
+
+## Decision needed
+
+**ISS-027's fix shape is not settled.** An optional `cwd` parameter on the tools is the obvious route, but it is a caller-supplied path handed to a subprocess, so it wants the same scrutiny ISS-022 flagged for runtime-reloadable `codex_path`. Alternatives worth weighing: have the CLI always pass its own cwd (cheap, fixes the CLI path only), or walk up from a supplied path to the git root. Worth a `review_plan` round before implementing.
+
+Note the interaction with ISS-018, which is the same class of bug on a different surface: a cwd-relative `reviews.db` makes the cross-provider guard fail open when the CLI runs outside the server's cwd. ISS-018, ISS-022 and ISS-027 are three faces of one root cause — **the server's spawn-time environment silently standing in for the caller's**. A fix for one should probably be designed knowing about the other two.
+
+## What's next
+
+Nothing is in flight; pick freely.
+
+1. **ISS-028** — ~10 lines, no behavior change, makes the ISS-027 class of failure self-diagnosing. Cheapest real win.
+2. **Review and commit T-038** — the largest outstanding debt. Requires reading the full diff line by line per repository rules before any commit.
+3. **ISS-027** — plan first, ideally against the ISS-018 / ISS-022 shared root cause.
+4. **T-033** remains the phase-order next ticket (plan-finding agreement matching, needs live two-provider plan data).

--- a/.story/issues/ISS-025.json
+++ b/.story/issues/ISS-025.json
@@ -1,0 +1,31 @@
+{
+  "components": [
+    "review-lenses"
+  ],
+  "createdBy": "review-lenses:error-handling",
+  "dedupeKey": "review-lenses:df3cb20b2fb5062a24797436eedeb3363046487e2d95f7e5479d8dea29c09b55",
+  "discoveredDate": "2026-07-13",
+  "displayId": "ISS-025",
+  "id": "ISS-025",
+  "impact": "If either provider rejects its promise instead of returning a Result, this Promise.all rejects immediately, so the following ra.ok/rb.ok degradation logic never runs and a successful contributor is discarded. I checked the resume and code paths and found the same unguarded pattern at lines 556, 641, and 684; adjudication at line 421 can likewise erase already-successful main reviews when an optional cross-review rejects. I also checked the lifecycle tests and confirmed backend rejection is an explicitly supported failure scenario, so the ReviewBackend type cannot guarantee these promises never reject.",
+  "location": [
+    "src/backends/deliberation.ts:601"
+  ],
+  "phase": null,
+  "relatedTickets": [
+    "T-038"
+  ],
+  "resolution": "Resolved in T-038 by wrapping all deliberation reviewer and adjudicator provider calls in a rejection-to-Result boundary. Rejected peers now degrade safely with a sanitized UNKNOWN_ERROR while successful results and model contributions are preserved.",
+  "resolvedDate": "2026-07-13",
+  "severity": "high",
+  "sourceRefs": [
+    {
+      "contentHash": "4675a15ea3e27afd5395914e8147729a9b7bd1cbc3550a3c000edd433af5faf4",
+      "path": "src/backends/deliberation.ts",
+      "reviewId": "lens-mrj0adky",
+      "startLine": 601
+    }
+  ],
+  "status": "resolved",
+  "title": "[pre-existing] [graceful-degradation] If either provider rejects its promise instead of returning "
+}

--- a/.story/issues/ISS-026.json
+++ b/.story/issues/ISS-026.json
@@ -1,0 +1,28 @@
+{
+  "components": [
+    "review-lenses"
+  ],
+  "createdBy": "review-lenses:clean-code",
+  "dedupeKey": "review-lenses:f6e7fa10fc00c85fcf264e4d10b67861aeadd36844ba122a0acd4afec088c770",
+  "discoveredDate": "2026-07-13",
+  "id": "ISS-026",
+  "impact": "`deliberatePlan` spans 89 lines and `deliberateCode` spans 84 lines, and both repeat owner resolution, resume-model validation, parallel provider invocation, primary/secondary remapping, degradation, and both-failed handling. A future resume-routing fix must be applied twice or plan and code reviews can drift. I read both complete functions plus `ownerLeafFor`, the combine helpers, and adjudication helpers; no shared executor currently centralizes this flow.",
+  "location": [
+    "src/backends/deliberation.ts:549"
+  ],
+  "phase": null,
+  "relatedTickets": [],
+  "resolution": null,
+  "resolvedDate": null,
+  "severity": "medium",
+  "sourceRefs": [
+    {
+      "contentHash": "285fee811496c7e1f457caa00f5971d360a08770be5236852bb4491bbe94c928",
+      "path": "src/backends/deliberation.ts",
+      "reviewId": "lens-mrj1j8mw",
+      "startLine": 549
+    }
+  ],
+  "status": "open",
+  "title": "[pre-existing] [long-function] `deliberatePlan` spans 89 lines and `deliberateCode` spans 8"
+}

--- a/.story/issues/ISS-027.json
+++ b/.story/issues/ISS-027.json
@@ -1,0 +1,35 @@
+{
+  "components": [
+    "utils/git",
+    "utils/resolve-diff",
+    "tools/review-precommit",
+    "tools/review-code"
+  ],
+  "createdBy": "external-review:care2talk-9e (two independent seat reports; code-verified in this session)",
+  "dedupeKey": "care2talk-9e-2026-09-03:worktree-capture-cwd",
+  "discoveredDate": "2026-09-04",
+  "id": "ISS-027",
+  "impact": "Every git capture in src/utils/git.ts calls execAsync with no cwd option, so `git diff --cached` / `git diff HEAD` run in whatever directory the client spawned the stdio server in. None of the MCP tools (review_code auto_diff, review_precommit) accept a cwd/repo path, and a stdio server has no way to learn the caller's current directory. A session that later moves into a git worktree (e.g. `.claude/worktrees/<name>`) therefore captures the main checkout's index: review_precommit returns ready_to_commit with warning \"No staged changes found\" while a full staged diff exists in the worktree, and review_code auto_diff reports \"No changes found to review\". Reported independently by two external seats hours apart (care2talk-39 in ~/Developer/ReactNative, c2t-design-71 in a c2t-design worktree); each burned a review call and a from-scratch diagnosis. Affects both codex-bridge and codex-bridge-local. Workaround: pass the diff explicitly. Fix direction: accept an optional `cwd` (or `repo_path`) tool parameter validated as an existing directory inside a git work tree, thread it through resolve-diff/git helpers as execAsync's cwd, and have the CLI default it to process.cwd(). See ISS-028 for the cheaper first step of naming the capture directory in the result.",
+  "location": [
+    "src/utils/git.ts:29",
+    "src/utils/git.ts:64",
+    "src/utils/resolve-diff.ts:24"
+  ],
+  "phase": null,
+  "relatedTickets": [],
+  "resolution": null,
+  "resolvedDate": null,
+  "severity": "high",
+  "sourceRefs": [
+    {
+      "contentHash": "5d2233a4cce57d6b3027a38164cf7842a387d4baf1e1d67fcf207a6b741d42c4",
+      "endLine": 79,
+      "path": "src/utils/git.ts",
+      "reviewId": "care2talk-9e-2026-09-03",
+      "revision": "a066fba339b032c0bd20f8bc3737bbaa404bb6b9",
+      "startLine": 29
+    }
+  ],
+  "status": "open",
+  "title": "Git auto-capture runs in the MCP server's spawn cwd, not the caller's worktree; worktree sessions get a false \"No staged changes found\""
+}

--- a/.story/issues/ISS-028.json
+++ b/.story/issues/ISS-028.json
@@ -1,0 +1,35 @@
+{
+  "components": [
+    "tools/review-precommit",
+    "tools/review-code",
+    "utils/resolve-diff",
+    "cli/formatter"
+  ],
+  "createdBy": "external-review:care2talk-9e (design suggestion; code-verified in this session)",
+  "dedupeKey": "care2talk-9e-2026-09-03:capture-dir-disclosure",
+  "discoveredDate": "2026-09-04",
+  "id": "ISS-028",
+  "impact": "\"No staged changes found\" (src/tools/review-precommit.ts:70, src/utils/resolve-diff.ts:24) and \"No changes found to review.\" (src/tools/review-code.ts:87) are indistinguishable from a legitimate empty result and name no directory. When the capture ran somewhere other than where the user is working (ISS-027), the user has no reason to doubt the tool, checks their own git state first, and only then suspects the bridge; that is why the worktree bug cost two full diagnoses instead of one. Independent of the capture fix, every auto-captured result (empty or not) should report the absolute directory the git command ran in, e.g. `captured_from: /Users/.../c2t-design`, and the empty-result summary should say \"No staged changes found in <dir>\". When a caller-supplied cwd exists and differs from the server cwd, say so explicitly. This is self-diagnosing and also protects against the next variant of the same class. Suggested as the FIRST change, ahead of the full cwd plumbing, since it is ~10 lines and no behavior change.",
+  "location": [
+    "src/tools/review-precommit.ts:70",
+    "src/tools/review-code.ts:87",
+    "src/utils/resolve-diff.ts:24"
+  ],
+  "phase": null,
+  "relatedTickets": [],
+  "resolution": null,
+  "resolvedDate": null,
+  "severity": "medium",
+  "sourceRefs": [
+    {
+      "contentHash": "7cb10c8d49967b3489a5d572164287cc705548100d044dbb30fb5d772aacd8c1",
+      "endLine": 72,
+      "path": "src/tools/review-precommit.ts",
+      "reviewId": "care2talk-9e-2026-09-03",
+      "revision": "a066fba339b032c0bd20f8bc3737bbaa404bb6b9",
+      "startLine": 61
+    }
+  ],
+  "status": "open",
+  "title": "Empty auto-capture results are silent: name the directory the capture ran in and flag when it is not the caller's cwd"
+}

--- a/.story/issues/ISS-029.json
+++ b/.story/issues/ISS-029.json
@@ -1,0 +1,30 @@
+{
+  "components": [
+    "backends/gemini"
+  ],
+  "createdBy": "external-review:care2talk-9e (three reproductions from seat care2talk-a6; code-verified in this session)",
+  "dedupeKey": "care2talk-9e-2026-09-03:agy-print-swallows-sandbox",
+  "discoveredDate": "2026-09-04",
+  "id": "ISS-029",
+  "impact": "runAgyPrint builds `['--print', '--sandbox', '--model', model]` (src/backends/gemini.ts:131) and spawns agy with that argv (no shell, so our own array is not concatenating anything). agy's parser treats `--print` as accepting an OPTIONAL positional prompt, so it consumes the following token and the run dies with `--print took \"--sandbox\" as its prompt`. The real prompt is piped via stdin (gemini.ts:212), so `--print` should never receive a positional at all. Reported from three consecutive review_code calls in session care2talk-a6 against care2talk-core, same error every round; that seat has the session ids. Fix candidates: order `--sandbox` before `--print`, put `--print` last in the array, or use an explicit `--print=` form if agy supports it. MUST be live-validated against the real agy CLI, not just a mocked-spawn unit test: L-011 records that a mocked spawn cannot catch agy argument-handling behavior, and L-012 records that agy silently ignores bad input rather than erroring. Consequence today is that every Gemini review fails, which means deliberate mode degrades to Codex-only every time on this machine (see ISS-030).",
+  "location": [
+    "src/backends/gemini.ts:131"
+  ],
+  "phase": null,
+  "relatedTickets": [],
+  "resolution": null,
+  "resolvedDate": null,
+  "severity": "high",
+  "sourceRefs": [
+    {
+      "contentHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "endLine": 131,
+      "path": "src/backends/gemini.ts",
+      "reviewId": "care2talk-9e-2026-09-03",
+      "revision": "a066fba339b032c0bd20f8bc3737bbaa404bb6b9",
+      "startLine": 131
+    }
+  ],
+  "status": "open",
+  "title": "agy invocation: `--print` swallows `--sandbox` as its positional prompt, failing every Gemini review"
+}

--- a/.story/issues/ISS-030.json
+++ b/.story/issues/ISS-030.json
@@ -1,0 +1,34 @@
+{
+  "components": [
+    "backends/deliberation",
+    "cli/formatter",
+    "review/types"
+  ],
+  "createdBy": "external-review:care2talk-9e (design report; code-verified and narrowed in this session)",
+  "dedupeKey": "care2talk-9e-2026-09-03:silent-deliberation-degradation",
+  "discoveredDate": "2026-09-04",
+  "id": "ISS-030",
+  "impact": "When `deliberate: true` is requested and one provider fails, degradeCode/degradePlan (src/backends/deliberation.ts:285-322) DO record it structurally: `deliberation.agreement: 'degraded'` plus a `degraded: { failed, reason }` block (schema at src/review/types.ts:92,109). So the claim that degradation is only a log line is wrong. The real gap is rendering and prominence. src/cli/formatter.ts contains no reference to `degraded` or `review_mode` at all, so the human CLI output does not surface it; an MCP caller gets a normal verdict whose degradation is a nested field it has no reason to read. Net effect at the call site is the same failure the reporter describes: a change reviewed ONCE is counted as reviewed twice independently, and the caller proceeds believing it got an adversarial second opinion. This is materially worse than a hard failure, which gets handled, and it is the instrument-failure shape this project already has lessons about (a tool reporting success at something it did not do). Reported as decision-affecting: the reporter escalated single -> deliberate precisely because a first clean round on a subtle change warranted a reviewer that could disagree, and never got one. Fix direction: render degradation prominently in the CLI formatter, mirror it into a top-level result field rather than only a nested deliberation block, and consider whether a requested-but-unachieved deliberation should be a hard error or require explicit caller opt-in to the weaker mode. Note review_mode already names the composition that ran (types.ts:133,145,157) but is not rendered either.",
+  "location": [
+    "src/backends/deliberation.ts:285",
+    "src/cli/formatter.ts",
+    "src/review/types.ts:92"
+  ],
+  "phase": null,
+  "relatedTickets": [],
+  "resolution": null,
+  "resolvedDate": null,
+  "severity": "high",
+  "sourceRefs": [
+    {
+      "contentHash": "865cc420124503ab999a80dcb11ff6a24e69342e34e456122d225b53711b5e8c",
+      "endLine": 322,
+      "path": "src/backends/deliberation.ts",
+      "reviewId": "care2talk-9e-2026-09-03",
+      "revision": "a066fba339b032c0bd20f8bc3737bbaa404bb6b9",
+      "startLine": 285
+    }
+  ],
+  "status": "open",
+  "title": "Deliberation degradation is recorded structurally but never rendered: a one-provider result reads as successful deliberation"
+}

--- a/.story/issues/ISS-031.json
+++ b/.story/issues/ISS-031.json
@@ -1,0 +1,32 @@
+{
+  "components": [
+    "backends/codex",
+    "review/types",
+    "tools/review-status",
+    "tools/review-history"
+  ],
+  "createdBy": "runnerkit-17 (peer Claude session) via triage",
+  "dedupeKey": "runnerkit-feedback-2026-09-04:1",
+  "discoveredDate": "2026-09-05",
+  "id": "ISS-031",
+  "impact": "An operator cannot tell from a result which Codex CLI/SDK build produced it. The `models` array (requested/resolved/observed) from T-038 answers the \"which model ran\" half but is still uncommitted and unpublished, so users on the npx-published 1.6.0 see only provider + review_mode. Remaining gap after T-038 ships: add the bundled/resolved Codex CLI version (and SDK pin) to `provenance` on every result, and to review_status and review_history rows, so model-availability errors can be correlated with the binary that produced them.",
+  "location": [],
+  "phase": null,
+  "relatedTickets": [
+    "T-038"
+  ],
+  "resolution": null,
+  "resolvedDate": null,
+  "severity": "low",
+  "sourceRefs": [
+    {
+      "contentHash": "bc2aeea90ab0b53ef1d4321e4988f8cfdf308268dfea204ff9ccbdb39cf729c5",
+      "path": "src/backends/codex.ts",
+      "reviewId": "runnerkit-feedback-2026-09-04",
+      "revision": "a066fba339b032c0bd20f8bc3737bbaa404bb6b9",
+      "startLine": 168
+    }
+  ],
+  "status": "open",
+  "title": "Result metadata omits the Codex CLI/SDK version; peer feedback also confirms `models` is not visible from the published 1.6.0 server"
+}

--- a/.story/issues/ISS-032.json
+++ b/.story/issues/ISS-032.json
@@ -1,0 +1,37 @@
+{
+  "components": [
+    "backends/orchestrator",
+    "utils/chunking",
+    "tools/review-code"
+  ],
+  "createdBy": "runnerkit-17 (peer Claude session) via triage",
+  "dedupeKey": "runnerkit-feedback-2026-09-04:2",
+  "discoveredDate": "2026-09-05",
+  "id": "ISS-032",
+  "impact": "Verified at a066fba: `mergeCodeResults` in src/backends/orchestrator.ts:117 builds `summary` as `results.map(r => r.summary).join(' ')`, so a ~35 KB diff split into 3 chunks by `max_chunk_tokens` (default 8000, src/config/types.ts:67) returns a summary that is three stitched per-chunk verdict paragraphs (peer saw \"The overall verdict remains deferred…\" repeated three times). Chunking is also invisible to the caller: `chunks_reviewed` is the only hint, the MCP/CLI schemas do not describe that chunk boundaries follow files, and there is no per-call `max_chunk_tokens` parameter, only the .reviewbridge.json field. Fix direction: synthesize one summary (prefix with \"Reviewed in N file-boundary chunks\" and keep the worst-verdict chunk's summary, or run a cheap merge turn), document chunking in the tool descriptions, and accept `max_chunk_tokens` as an optional per-call parameter. Related: ISS-020 (cross-chunk blindness).",
+  "location": [],
+  "phase": null,
+  "relatedTickets": [],
+  "resolution": null,
+  "resolvedDate": null,
+  "severity": "medium",
+  "sourceRefs": [
+    {
+      "contentHash": "e604a79aa5c04bafff82988b77f6356d7af1b887c0d878eb1f1ab66ed0fd7e32",
+      "endLine": 120,
+      "path": "src/backends/orchestrator.ts",
+      "reviewId": "runnerkit-feedback-2026-09-04",
+      "revision": "a066fba339b032c0bd20f8bc3737bbaa404bb6b9",
+      "startLine": 105
+    },
+    {
+      "contentHash": "e03d87010a65648709b2f00d643f2d5dc251f12d6a5a4ebce5f461a0fa4fee2b",
+      "path": "src/config/types.ts",
+      "reviewId": "runnerkit-feedback-2026-09-04",
+      "revision": "a066fba339b032c0bd20f8bc3737bbaa404bb6b9",
+      "startLine": 67
+    }
+  ],
+  "status": "open",
+  "title": "Chunked code reviews concatenate per-chunk summaries verbatim and expose no per-call chunk control"
+}

--- a/.story/issues/ISS-033.json
+++ b/.story/issues/ISS-033.json
@@ -1,0 +1,29 @@
+{
+  "components": [
+    "backends/codex",
+    "utils/errors"
+  ],
+  "createdBy": "runnerkit-17 (peer Claude session) via triage",
+  "dedupeKey": "runnerkit-feedback-2026-09-04:3",
+  "discoveredDate": "2026-09-05",
+  "id": "ISS-033",
+  "impact": "Verified at a066fba: neither src/backends/codex.ts nor src/utils/errors.ts matches the Codex \"requires a newer version of Codex\" error, so it falls to the generic path with no tip about the installed vs required CLI (L-013 documents that the effective CLI is the SDK-pinned bundle, not PATH, which is exactly the fact the user needs). Unverified peer report from before the 0.153.4 bump: on both codex-bridge and codex-bridge-local every model override, including \"latest\" and \"gpt-5.5\", failed with the gpt-6-astra version error. \"latest\" resolving to the default is by design, but \"gpt-5.5\" failing that way is unexplained and needs a repro: candidates are a session_id resume (model stripped on resume per L-010), or a Codex-internal background call (ISS-003 class) surfacing the internal model. Fix direction: classify the message as a new VERSION_ERROR (or MODEL_ERROR subtype) that reports the bundled CLI version, the codex_path override if any, and the SDK pin, and tips \"upgrade codex-claude-bridge\" rather than \"change model\"; then reproduce the override claim.",
+  "location": [],
+  "phase": null,
+  "relatedTickets": [],
+  "resolution": null,
+  "resolvedDate": null,
+  "severity": "medium",
+  "sourceRefs": [
+    {
+      "contentHash": "ce9e1d918b24ce35185433599bdd9e8de6064c7dc20702de9c3fd87aa23b7d56",
+      "endLine": 110,
+      "path": "src/backends/codex.ts",
+      "reviewId": "runnerkit-feedback-2026-09-04",
+      "revision": "a066fba339b032c0bd20f8bc3737bbaa404bb6b9",
+      "startLine": 90
+    }
+  ],
+  "status": "open",
+  "title": "\"requires a newer version of Codex\" is unclassified: error names neither installed nor required CLI version, and reportedly fired for non-default model overrides"
+}

--- a/.story/issues/ISS-034.json
+++ b/.story/issues/ISS-034.json
@@ -1,0 +1,32 @@
+{
+  "components": [
+    "tools/review-status",
+    "review/lifecycle",
+    "server"
+  ],
+  "createdBy": "runnerkit-17 (peer Claude session) via triage",
+  "dedupeKey": "runnerkit-feedback-2026-09-04:4",
+  "discoveredDate": "2026-09-05",
+  "id": "ISS-034",
+  "impact": "All three review tools block until the provider returns (timeout_seconds default, up to 600 s here). Peer reports reviews routinely exceed the MCP client's ~120 s foreground window and get backgrounded by the client. review_status exists but only reports on a review the same call started, so there is no supported \"start, get session_id immediately, poll review_status, fetch result\" flow. Fix direction: add an optional `wait: false` (or `mode: \"poll\"`) parameter on review_plan/review_code/review_precommit that admits the review through the T-038 lifecycle registry, returns `{status: in_progress, session_id}` at once, and lets review_status return the completed result from the registry/history once done. Interacts with the T-038 lifecycle admission (4 global, 1 per session) and the SQLite outcome path.",
+  "location": [],
+  "phase": null,
+  "relatedTickets": [
+    "T-038"
+  ],
+  "resolution": null,
+  "resolvedDate": null,
+  "severity": "medium",
+  "sourceRefs": [
+    {
+      "contentHash": "727804cb9d34259d90349abb79b1f3f5a5924799ab6c46ef797259176a869c06",
+      "endLine": 56,
+      "path": "src/tools/review-status.ts",
+      "reviewId": "runnerkit-feedback-2026-09-04",
+      "revision": "a066fba339b032c0bd20f8bc3737bbaa404bb6b9",
+      "startLine": 20
+    }
+  ],
+  "status": "open",
+  "title": "No non-blocking review start: long reviews exceed the MCP client's foreground window and review_status cannot recover a result the client abandoned"
+}

--- a/.story/lessons/L-015.json
+++ b/.story/lessons/L-015.json
@@ -1,0 +1,19 @@
+{
+  "content": "On resumed Codex reviews, retain the bridge's prior resolved identity but always prefer a fresh runtime-session observation for `observed`; never replace either with the current default. A mismatch is meaningful control-plane evidence and should be reported once without changing the review verdict.",
+  "context": "T-038 live acceptance resumed a thread created with gpt-5.5 while gpt-5.6-sol was the default: the bridge correctly retained resolved=gpt-5.5 while the rollout recorded observed=gpt-5.6-sol.",
+  "createdDate": "2026-07-13",
+  "id": "L-015",
+  "lastValidated": "2026-07-13",
+  "reinforcements": 0,
+  "source": "review",
+  "status": "active",
+  "supersedes": null,
+  "tags": [
+    "models",
+    "codex-sdk",
+    "observability",
+    "sessions"
+  ],
+  "title": "Treat Codex resolved and observed models as separate evidence",
+  "updatedDate": "2026-07-13"
+}

--- a/.story/notes/N-004.json
+++ b/.story/notes/N-004.json
@@ -1,0 +1,14 @@
+{
+  "content": "Relayed from a peer session (care2talk-9e) after a night of heavy bridge use across three seats.\n\nOperational heads-up (not filed as an issue), CORRECTED by the sender: a disk cleanup removed most of ~/.npm/_npx. Two running `codex-bridge` (npx-launched) processes are executing from deleted cache directories and die on the next restart, after which `npx -y codex-claude-bridge` re-downloads on first use. That is a delay and a network dependency, not a loss of review coverage: `codex-bridge-local` launches as `node <repo>/dist/index.js`, was never in the npx cache, exposes the same five tools, and survives a restart with no network. Original message overstated this as a permanent loss; do not carry that forward. Open question remains whether the bridge should defend against a cleared npx cache at all (e.g. README note, or a startup log of the resolved install path). No action decided.\n\nWhat worked (positive signal worth keeping): reviews found three real defects that passing test suites missed — two React Native layout composition errors (second found on review of the fix for the first) and an iOS codegen digest that skipped regeneration after outputs were deleted. Two clean rounds ended without fishing. A seat argued a reviewer suggestion down with a reason (not defaulting NODE_BINARY to `node` in an Xcode script phase) and the reviewer agreed next round.\n\nRelated issues filed from the same report: ISS-027 (worktree capture cwd bug), ISS-028 (name the capture directory).",
+  "createdDate": "2026-09-04",
+  "displayId": "N-004",
+  "id": "N-004",
+  "status": "active",
+  "tags": [
+    "external-feedback",
+    "npx",
+    "ops"
+  ],
+  "title": "External usage report 2026-09-03 (care2talk seats): npx orphan heads-up and what worked",
+  "updatedDate": "2026-09-03"
+}

--- a/.story/tickets/T-038.json
+++ b/.story/tickets/T-038.json
@@ -1,0 +1,13 @@
+{
+  "blockedBy": [],
+  "completedDate": "2026-07-13",
+  "createdDate": "2026-07-13",
+  "description": "Expose requested, resolved, and runtime-observed model identity on successful plan/code/precommit responses and history; preserve host-only schema boundaries; add durable model snapshots, honest Gemini selected-only evidence, bounded Codex rollout observation, lifecycle admission/routing safeguards, history pagination, CLI/docs, and TDD coverage. Persistence failures preserve successful reviews with memory_only provenance. Do not publish or version-bump as part of this ticket.",
+  "displayId": "T-038",
+  "id": "T-038",
+  "order": 10,
+  "phase": "model-currency",
+  "status": "complete",
+  "title": "Report evidence-aware responding model metadata",
+  "type": "feature"
+}

--- a/README.md
+++ b/README.md
@@ -60,21 +60,54 @@ Once set up, Claude Code gains five new tools:
 - **`review_status`** — Check whether a review is still in progress, completed, or failed.
 - **`review_history`** — Look up past reviews by session or count.
 
-All tools return structured JSON that Claude Code can act on directly.
+All successful review calls return structured JSON with `models[]` (the providers/models that
+contributed) and `provenance` (whether the result was durably recorded, memory-only, or synthetic).
+
+### Responding-model evidence
+
+Each `models[]` entry reports:
+
+```json
+{
+  "provider": "codex",
+  "role": "review",
+  "requested": null,
+  "resolved": "gpt-5.6-sol",
+  "observed": "gpt-5.6-sol",
+  "evidence": "runtime_session_record"
+}
+```
+
+- `requested` is the per-call/config selector considered for the turn. It is `null` for provider
+  defaults and Codex resumes where no model override is applied.
+- `resolved` is the concrete label selected or retained by the bridge.
+- `observed` is a runtime-recorded label when one is available. Codex can read this from its local
+  session record; Gemini currently reports `null` because `agy` has no equivalent observation.
+- `role` distinguishes normal review turns from deliberate-deep adjudication turns.
+- `evidence` says whether identity came from a runtime session record, bridge selection, or was
+  unavailable.
+
+This is control-plane evidence about the model labels selected and recorded by the clients. It is
+not cryptographic proof of underlying weights or an audit of a provider's internal routing.
+`models[]` lists successful contributors, not every provider that received input, so it is not a
+data-egress audit.
 
 ## Usage (MCP)
 
 In Claude Code, just describe what you want reviewed. Claude Code will pick the right tool:
 
 **Plan review:**
+
 > "Review this implementation plan before I start coding."
 > "Check my plan for security issues and scalability risks."
 
 **Code review:**
+
 > "Review the changes I just made." (Claude Code runs `git diff` and passes it)
 > "Review this diff for bugs and security issues."
 
 **Pre-commit check:**
+
 > "Run a pre-commit check on my staged changes."
 > "Check if these changes are safe to commit."
 
@@ -116,30 +149,30 @@ Add `--json` to any command for raw JSON output. Use `--help` to see all options
 
 Send an implementation plan for architectural/feasibility review.
 
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `plan` | string | yes | The implementation plan to review |
-| `context` | string | no | Project context and constraints |
-| `focus` | string[] | no | Review focus areas (e.g. `["architecture", "security"]`) |
-| `depth` | `"quick"` \| `"thorough"` | no | Review depth |
-| `session_id` | string | no | Continue from a previous review session |
-| `model` | string | no | Override the model for this call (e.g. `"gpt-5.5"` or `"latest"`). With Codex this can't be combined with `session_id` (a resumed thread keeps its model); Gemini allows changing model on a resumed session. |
+| Parameter    | Type                      | Required | Description                                                                                                                                                                                                                                                                 |
+| ------------ | ------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `plan`       | string                    | yes      | The implementation plan to review                                                                                                                                                                                                                                           |
+| `context`    | string                    | no       | Project context and constraints                                                                                                                                                                                                                                             |
+| `focus`      | string[]                  | no       | Review focus areas (e.g. `["architecture", "security"]`)                                                                                                                                                                                                                    |
+| `depth`      | `"quick"` \| `"thorough"` | no       | Review depth                                                                                                                                                                                                                                                                |
+| `session_id` | string                    | no       | Continue from a previous review session                                                                                                                                                                                                                                     |
+| `model`      | string                    | no       | Override the model for this call (e.g. `"gpt-5.5"` or `"latest"`). With Codex this can't be combined with `session_id`; the bridge retains the prior resolved identity and reports any different runtime-observed label. Gemini allows changing model on a resumed session. |
 
-Returns: `{ verdict, summary, findings[], session_id }`
+Returns: `{ verdict, summary, findings[], session_id, models[], provenance }`
 
 ### `review_code`
 
 Send a code diff for code review.
 
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `diff` | string | yes | Git diff to review |
-| `context` | string | no | Intent of the changes |
-| `session_id` | string | no | Continue from previous review (e.g. plan review session) |
-| `criteria` | string[] | no | Review criteria (e.g. `["bugs", "security", "performance"]`) |
-| `model` | string | no | Override the model for this call (e.g. `"gpt-5.5"` or `"latest"`). With Codex this can't be combined with `session_id` (a resumed thread keeps its model); Gemini allows changing model on a resumed session. |
+| Parameter    | Type     | Required | Description                                                                                                                                                                                                                                    |
+| ------------ | -------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `diff`       | string   | yes      | Git diff to review                                                                                                                                                                                                                             |
+| `context`    | string   | no       | Intent of the changes                                                                                                                                                                                                                          |
+| `session_id` | string   | no       | Continue from previous review (e.g. plan review session)                                                                                                                                                                                       |
+| `criteria`   | string[] | no       | Review criteria (e.g. `["bugs", "security", "performance"]`)                                                                                                                                                                                   |
+| `model`      | string   | no       | Override the model for this call (e.g. `"gpt-5.5"` or `"latest"`). With Codex this can't be combined with `session_id`; compare `resolved` and `observed` to see what the runtime recorded. Gemini allows changing model on a resumed session. |
 
-Returns: `{ verdict, summary, findings[], session_id }`
+Returns: `{ verdict, summary, findings[], session_id, models[], provenance }`
 
 Findings include `file` and `line` references when available.
 
@@ -147,23 +180,23 @@ Findings include `file` and `line` references when available.
 
 Quick pre-commit sanity check. Auto-captures staged git changes by default.
 
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `auto_diff` | boolean | no | Auto-capture `git diff --staged` (default: `true`) |
-| `diff` | string | no | Explicit diff instead of auto-capture |
-| `session_id` | string | no | Continue from previous review |
-| `checklist` | string[] | no | Custom pre-commit checks |
-| `model` | string | no | Override the model for this call (e.g. `"gpt-5.5"` or `"latest"`). With Codex this can't be combined with `session_id` (a resumed thread keeps its model); Gemini allows changing model on a resumed session. |
+| Parameter    | Type     | Required | Description                                                                                                                                                                                                                                    |
+| ------------ | -------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `auto_diff`  | boolean  | no       | Auto-capture `git diff --staged` (default: `true`)                                                                                                                                                                                             |
+| `diff`       | string   | no       | Explicit diff instead of auto-capture                                                                                                                                                                                                          |
+| `session_id` | string   | no       | Continue from previous review                                                                                                                                                                                                                  |
+| `checklist`  | string[] | no       | Custom pre-commit checks                                                                                                                                                                                                                       |
+| `model`      | string   | no       | Override the model for this call (e.g. `"gpt-5.5"` or `"latest"`). With Codex this can't be combined with `session_id`; compare `resolved` and `observed` to see what the runtime recorded. Gemini allows changing model on a resumed session. |
 
-Returns: `{ ready_to_commit, blockers[], warnings[], session_id }`
+Returns: `{ ready_to_commit, blockers[], warnings[], session_id, models[], provenance }`
 
 ### `review_status`
 
 Check status of a review session.
 
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `session_id` | string | yes | Session ID to check |
+| Parameter    | Type   | Required | Description         |
+| ------------ | ------ | -------- | ------------------- |
+| `session_id` | string | yes      | Session ID to check |
 
 Returns: `{ status, session_id, elapsed_seconds }`
 
@@ -171,12 +204,16 @@ Returns: `{ status, session_id, elapsed_seconds }`
 
 Query past reviews.
 
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `session_id` | string | no | Query reviews for a specific session |
-| `last_n` | number | no | Return last N reviews (default: 10) |
+| Parameter    | Type   | Required | Description                                                        |
+| ------------ | ------ | -------- | ------------------------------------------------------------------ |
+| `session_id` | string | no       | Query reviews for a specific session                               |
+| `last_n`     | number | no       | Return 1–100 reviews (default: 10 recent; 100 for a session)       |
+| `cursor`     | string | no       | Decimal row cursor returned as `next_cursor` by the preceding page |
 
-Returns: `{ reviews[] }` with `session_id`, `type`, `verdict`, `summary`, `timestamp` per entry.
+Returns: `{ reviews[], next_cursor }`. Recent pages are newest-first; session pages are oldest-first.
+Each entry includes `models` plus `model_metadata_status` (`recorded`, `legacy_unrecorded`, or
+`invalid`). Legacy rows are never backfilled from today's defaults, and malformed stored metadata
+is returned as `models: null`.
 
 ## Configuration
 
@@ -237,20 +274,20 @@ The CLI's `--config <dir>` flag is an explicit override: it looks only at `<dir>
 
 **Codex** — default `gpt-5.6-sol`. If Sol has not reached your account yet, pin `gpt-5.5`:
 
-| Model | Description |
-|-------|-------------|
-| `gpt-5.6-sol` | Latest flagship agentic coding model (default) |
-| `gpt-5.5` | Previous flagship. Use while Sol is still rolling out to your account. |
+| Model         | Description                                                            |
+| ------------- | ---------------------------------------------------------------------- |
+| `gpt-5.6-sol` | Latest flagship agentic coding model (default)                         |
+| `gpt-5.5`     | Previous flagship. Use while Sol is still rolling out to your account. |
 
 **Gemini** — default resolves to the latest Flash via `agy models`. Effort is part of the model name:
 
-| Model | Description |
-|-------|-------------|
+| Model                       | Description                |
+| --------------------------- | -------------------------- |
 | `Gemini 3.5 Flash (Medium)` | Default — fast review line |
-| `Gemini 3.5 Flash (High)` | Higher effort |
-| `Gemini 3.1 Pro (High)` | Heavier reasoning line |
+| `Gemini 3.5 Flash (High)`   | Higher effort              |
+| `Gemini 3.1 Pro (High)`     | Heavier reasoning line     |
 
-`"latest"` resolves to the newest Flash for Gemini, or the SDK-pinned flagship for Codex. These are the models we document and recommend; the `model` field, the `model` tool parameter, and the `--model` CLI flag accept any string and forward it as-is, so you can run others. For Gemini, an unrecognized model triggers a non-blocking stderr warning (agy may silently run a different one) — run `agy models` to see the live list.
+`"latest"` resolves to the newest Flash for Gemini, or the SDK-pinned flagship for Codex. These are the models we document and recommend; the `model` field, the `model` tool parameter, and the `--model` CLI flag accept any trimmed, control-free selector up to 200 characters, so you can run others. For Gemini, an unrecognized model triggers a non-blocking stderr warning (agy may silently run a different one) — run `agy models` to see the live list.
 
 ### Provider failover
 
@@ -279,21 +316,36 @@ The result keeps the usual shape (a merged `verdict`/`findings`, worst-verdict w
 ```json
 {
   "verdict": "reject",
-  "findings": [ /* deduped union of both providers */ ],
+  "findings": [
+    /* deduped union of both providers */
+  ],
   "deliberation": {
     "providers": ["codex", "gemini"],
-    "verdicts": [ { "provider": "codex", "verdict": "request_changes" }, { "provider": "gemini", "verdict": "reject" } ],
-    "agreement": "conflict",                 // agree | mixed | conflict
-    "agreed":    [ /* findings BOTH flagged — high confidence */ ],
-    "divergent": [ { "provider": "gemini", "finding": { /* only one flagged */ } } ]
+    "verdicts": [
+      { "provider": "codex", "verdict": "request_changes" },
+      { "provider": "gemini", "verdict": "reject" }
+    ],
+    "agreement": "conflict", // agree | mixed | conflict
+    "agreed": [
+      /* findings BOTH flagged — high confidence */
+    ],
+    "divergent": [
+      {
+        "provider": "gemini",
+        "finding": {
+          /* only one flagged */
+        }
+      }
+    ]
   }
 }
 ```
 
 Notes:
+
 - **Cost/egress:** deliberation always runs both providers and sends the diff to both vendors — best for high-stakes reviews, not every precommit. `review_precommit` stays failover under this mode.
 - **Degrades gracefully:** if one provider is out of usage, you get the other's review with `deliberation.degraded` set and `deliberation.agreement: "degraded"` (it subsumes failover).
-- **Resumed sessions deliberate too:** passing a `session_id` resumes the review on the provider that owns that session while the *other* provider reviews fresh, then the two are combined — so plan→code lifecycles keep deliberating instead of silently dropping to one provider. The combined result keeps the resumed session's id.
+- **Resumed sessions deliberate too:** passing a `session_id` resumes the review on the provider that owns that session while the _other_ provider reviews fresh, then the two are combined — so plan→code lifecycles keep deliberating instead of silently dropping to one provider. The combined result keeps the resumed session's id.
 - **Per-call toggle:** `review_plan`/`review_code` accept a `deliberate` boolean (CLI: `--deliberate` / `--no-deliberate`) that overrides the configured mode for a single call — `true` forces deliberation, `false` forces single-provider failover. Requesting `deliberate: true` under `"mode": "single"` returns an error (no second provider).
 - **`review_mode` on every result:** every review result carries a `review_mode` field (`single` / `failover` / `deliberate` / `deliberate-deep`) naming the composition that actually ran, so the absence of a `deliberation` block is never ambiguous.
 
@@ -318,8 +370,9 @@ Each divergent item gains an optional `adjudication` (the `agreed` findings and 
 ```
 
 Notes:
-- **`verdict`** is `confirmed` (a real issue), `disputed` (a false positive here), or `unsure` (can't tell from the change). `by` is the provider that adjudicated — always the one that did *not* raise the finding.
-- **Top-level `verdict` is not folded back:** under deliberate-deep the result's `verdict` still reflects both providers' *independent* reviews (worst-of-both). The per-finding `adjudication`s are advisory input for **your** synthesis — the bridge does not recompute the verdict from them (ISS-015). A `reject` resting on findings the other provider `disputed` still reports `reject`; it's up to you to weigh the adjudications.
+
+- **`verdict`** is `confirmed` (a real issue), `disputed` (a false positive here), or `unsure` (can't tell from the change). `by` is the provider that adjudicated — always the one that did _not_ raise the finding.
+- **Top-level `verdict` is not folded back:** under deliberate-deep the result's `verdict` still reflects both providers' _independent_ reviews (worst-of-both). The per-finding `adjudication`s are advisory input for **your** synthesis — the bridge does not recompute the verdict from them (ISS-015). A `reject` resting on findings the other provider `disputed` still reports `reject`; it's up to you to weigh the adjudications.
 - **Cost:** adds up to two more provider calls per review (one per side that has divergent findings). Skipped entirely when there's nothing divergent. The cross-review subject is sliced to just the files the divergent findings touch, so it stays small even on large diffs.
 - **Best-effort:** if a provider is out of usage or errors during the cross-review round, its side is simply left un-adjudicated and reported in `deliberation.cross_review_failures` — the deliberation result still returns.
 
@@ -333,21 +386,29 @@ export REVIEW_BRIDGE_DB=~/.review-bridge.db
 
 Defaults to `reviews.db` in the current directory. Set to `:memory:` for ephemeral storage.
 
+Review execution is admitted before large inputs enter a provider: at most four logical reviews may
+run globally and only one may run for a given `session_id`. Excess work returns `REVIEW_BUSY`
+immediately. If durable outcome recording fails after a provider succeeds, the successful review is
+still returned with `provenance.persistence: "memory_only"` and a sanitized warning. Synthetic
+no-change/no-staged results use `not_recorded` and do not create or mutate sessions.
+
 ## Troubleshooting
 
 Error codes are provider-neutral. With `fallback` on (default), many of these auto-recover by retrying on the other provider — the messages below apply when there's no second provider set up or `fallback` is off.
 
-| Error | Fix |
-|-------|-----|
-| `AUTH_ERROR` (Codex) | Run `codex login`, or set `OPENAI_API_KEY`. Check that `~/.codex/auth.json` exists. |
-| `AUTH_ERROR: agy is not authenticated` (Gemini) | Run `agy` once to sign in with your Google account (AI Pro), then retry. |
-| `CONFIG_ERROR: 'agy' ... not found on PATH` (Gemini) | Install the Antigravity `agy` CLI and sign in, or set `"provider": "codex"`. |
-| `MODEL_ERROR: Model "X" is not supported` | Try a different model, switch `"provider"`, or (Codex) use API-key auth. For Gemini, run `agy models` for valid ids. |
+| Error                                                     | Fix                                                                                                                                                                                                                                                                                                                                                                         |
+| --------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `AUTH_ERROR` (Codex)                                      | Run `codex login`, or set `OPENAI_API_KEY`. Check that `~/.codex/auth.json` exists.                                                                                                                                                                                                                                                                                         |
+| `AUTH_ERROR: agy is not authenticated` (Gemini)           | Run `agy` once to sign in with your Google account (AI Pro), then retry.                                                                                                                                                                                                                                                                                                    |
+| `CONFIG_ERROR: 'agy' ... not found on PATH` (Gemini)      | Install the Antigravity `agy` CLI and sign in, or set `"provider": "codex"`.                                                                                                                                                                                                                                                                                                |
+| `MODEL_ERROR: Model "X" is not supported`                 | Try a different model, switch `"provider"`, or (Codex) use API-key auth. For Gemini, run `agy models` for valid ids.                                                                                                                                                                                                                                                        |
 | `PROVIDER_UNAVAILABLE: The codex binary could not be run` | On macOS, XProtect can false-positively quarantine the SDK's **bundled** codex binary. The bridge auto-discovers a working system codex (PATH, `~/.local/bin`, `/opt/homebrew/bin`, `/usr/local/bin`) and retries; the stderr log names the binary it picked. If nothing is found, install the Codex CLI (`codex login` machine) or set `"codex_path"` to a working binary. |
-| `RATE_LIMITED` (rate limit or usage cap) | Wait and retry, or rely on failover to the other provider. |
-| `NETWORK_ERROR` | Check your internet connection. |
-| `PROVIDER_MISMATCH` | The `session_id` was created by a different provider. Start a new session, or switch `"provider"` back to continue it. |
-| `REVIEW_TIMEOUT: review timed out` | Increase `"timeout_seconds"` in `.reviewbridge.json` (default: 300). |
+| `RATE_LIMITED` (rate limit or usage cap)                  | Wait and retry, or rely on failover to the other provider.                                                                                                                                                                                                                                                                                                                  |
+| `NETWORK_ERROR`                                           | Check your internet connection.                                                                                                                                                                                                                                                                                                                                             |
+| `PROVIDER_MISMATCH`                                       | The `session_id` was created by a different provider. Start a new session, or switch `"provider"` back to continue it.                                                                                                                                                                                                                                                      |
+| `REVIEW_BUSY`                                             | Four reviews are already active, or this session already has a review in progress. Retry after the active call finishes.                                                                                                                                                                                                                                                    |
+| `SESSION_ROUTING_UNAVAILABLE`                             | Resume ownership could not be read safely. Restore durable storage or start a fresh review without `session_id`; the bridge will not guess a provider.                                                                                                                                                                                                                      |
+| `REVIEW_TIMEOUT: review timed out`                        | Increase `"timeout_seconds"` in `.reviewbridge.json` (default: 300).                                                                                                                                                                                                                                                                                                        |
 
 ## Architecture
 
@@ -386,13 +447,13 @@ npm test
 npm run build
 ```
 
-| Command | Description |
-|---------|-------------|
-| `npm test` | Run tests (Vitest) |
-| `npm run build` | Bundle with tsup |
-| `npm run typecheck` | Type checking |
-| `npm run lint` | ESLint |
-| `npm run format` | Prettier |
+| Command             | Description        |
+| ------------------- | ------------------ |
+| `npm test`          | Run tests (Vitest) |
+| `npm run build`     | Bundle with tsup   |
+| `npm run typecheck` | Type checking      |
+| `npm run lint`      | ESLint             |
+| `npm run format`    | Prettier           |
 
 ## License
 

--- a/src/backends/backend.ts
+++ b/src/backends/backend.ts
@@ -68,10 +68,13 @@ export interface ReviewBackend {
   // (membership check) and by resume routing to find a session's owning leaf.
   providers: readonly ReviewProvider[];
   // Whether a resumed session may change model. False for Codex (its SDK
-  // reasserts --model on resume); true for Gemini. The tool layer gates the
-  // session_id+model conflict rejection on this so it isn't a Codex-only rule
-  // leaking onto every provider.
+  // reasserts --model on resume); true for Gemini. Leaf orchestration and the
+  // lifecycle's pre-admission validation both consult this capability.
   allowsModelOverrideOnResume: boolean;
+  // Composites may serve leaves with different resume capabilities. Resolve
+  // against the session's owning provider instead of treating the configured
+  // primary's flag as representative of every leaf.
+  allowsModelOverrideOnResumeFor?(provider: ReviewProvider): boolean;
   reviewPlan(input: PlanReviewInput): Promise<Result<PlanReviewResult>>;
   reviewCode(input: CodeReviewInput): Promise<Result<CodeReviewResult>>;
   reviewPrecommit(input: PrecommitReviewInput): Promise<Result<PrecommitResult>>;
@@ -79,4 +82,22 @@ export interface ReviewBackend {
   // (deliberate-deep's cross-review round). Leaf backends implement it; composites
   // don't — the deliberation composite calls it on its underlying leaves.
   crossReview?(input: CrossReviewInput): Promise<Result<CrossReviewResult>>;
+}
+
+// Resolve a resume capability for one concrete provider. Leaves only expose the
+// legacy scalar flag; composites provide the owner-aware callback above.
+export function canOverrideModelOnResume(
+  backend: ReviewBackend,
+  provider: ReviewProvider,
+): boolean {
+  if (!backend.providers.includes(provider)) return false;
+  if (backend.allowsModelOverrideOnResumeFor) {
+    return backend.allowsModelOverrideOnResumeFor(provider);
+  }
+  // The scalar is authoritative for a leaf (and for a composite's presented
+  // primary). A hand-built multi-provider backend without an owner-aware
+  // callback fails closed for non-primary owners.
+  return provider === backend.provider || backend.providers.length === 1
+    ? backend.allowsModelOverrideOnResume
+    : false;
 }

--- a/src/backends/codex-session-observer.test.ts
+++ b/src/backends/codex-session-observer.test.ts
@@ -1,0 +1,355 @@
+import { execFile, spawnSync } from 'node:child_process';
+import { mkdtemp, mkdir, open, readFile, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  createCodexSessionObserver,
+  type CodexSessionObserverOptions,
+} from './codex-session-observer.js';
+
+const execFileAsync = promisify(execFile);
+const HAS_MKFIFO = spawnSync('mkfifo', []).error === undefined;
+const SESSION_ID = '019f5a26-4fef-7e41-ba94-07c09465cd50';
+const SECOND_SESSION_ID = '019f5a26-4ff0-7e41-ba94-07c09465cd51';
+const SESSION_TIME = Number.parseInt(SESSION_ID.replaceAll('-', '').slice(0, 12), 16);
+
+const temporaryHomes: string[] = [];
+
+function pad(value: number): string {
+  return String(value).padStart(2, '0');
+}
+
+function localParts(timestamp = SESSION_TIME): {
+  date: string;
+  time: string;
+  year: string;
+  month: string;
+  day: string;
+} {
+  const date = new Date(timestamp);
+  const year = String(date.getFullYear());
+  const month = pad(date.getMonth() + 1);
+  const day = pad(date.getDate());
+  return {
+    date: `${year}-${month}-${day}`,
+    time: `${pad(date.getHours())}-${pad(date.getMinutes())}-${pad(date.getSeconds())}`,
+    year,
+    month,
+    day,
+  };
+}
+
+async function makeHome(): Promise<string> {
+  const home = await mkdtemp(join(tmpdir(), 'codex-observer-'));
+  temporaryHomes.push(home);
+  return home;
+}
+
+async function activePath(home: string, sessionId = SESSION_ID, dayOffset = 0): Promise<string> {
+  const timestamp = Number.parseInt(sessionId.replaceAll('-', '').slice(0, 12), 16);
+  const shifted = new Date(timestamp);
+  shifted.setDate(shifted.getDate() + dayOffset);
+  const directoryParts = localParts(shifted.getTime());
+  const filenameParts = localParts(timestamp);
+  const directory = join(
+    home,
+    'sessions',
+    directoryParts.year,
+    directoryParts.month,
+    directoryParts.day,
+  );
+  await mkdir(directory, { recursive: true });
+  return join(directory, `rollout-${filenameParts.date}T${filenameParts.time}-${sessionId}.jsonl`);
+}
+
+async function archivedPath(home: string, sessionId = SESSION_ID): Promise<string> {
+  const timestamp = Number.parseInt(sessionId.replaceAll('-', '').slice(0, 12), 16);
+  const parts = localParts(timestamp);
+  const directory = join(home, 'archived_sessions');
+  await mkdir(directory, { recursive: true });
+  return join(directory, `rollout-${parts.date}T${parts.time}-${sessionId}.jsonl`);
+}
+
+function turnContext(model: string): string {
+  return JSON.stringify({ type: 'turn_context', payload: { model } });
+}
+
+function threadSettings(model: string): string {
+  return JSON.stringify({
+    type: 'event_msg',
+    payload: { type: 'thread_settings_applied', thread_settings: { model } },
+  });
+}
+
+function observer(home: string, options: Partial<CodexSessionObserverOptions> = {}) {
+  return createCodexSessionObserver({ codexHome: home, ...options });
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryHomes.splice(0).map((home) => rm(home, { recursive: true, force: true })),
+  );
+});
+
+describe('createCodexSessionObserver', () => {
+  it('rejects non-UUIDv7 input without throwing', async () => {
+    const home = await makeHome();
+    await expect(observer(home).observe('../not-a-session')).resolves.toBeUndefined();
+  });
+
+  it('reads the latest valid turn-context model from the derived active-session date', async () => {
+    const home = await makeHome();
+    const file = await activePath(home);
+    await writeFile(
+      file,
+      [
+        threadSettings('settings-fallback'),
+        turnContext('gpt-5.5'),
+        turnContext('gpt-5.6-sol'),
+      ].join('\n'),
+    );
+
+    await expect(observer(home).observe(SESSION_ID)).resolves.toEqual({
+      model: 'gpt-5.6-sol',
+      source: 'turn_context',
+    });
+  });
+
+  it('checks adjacent local-date directories', async () => {
+    const home = await makeHome();
+    const file = await activePath(home, SESSION_ID, -1);
+    await writeFile(file, turnContext('adjacent-date-model'));
+
+    await expect(observer(home).observe(SESSION_ID)).resolves.toMatchObject({
+      model: 'adjacent-date-model',
+    });
+  });
+
+  it('checks the exact archived rollout candidate', async () => {
+    const home = await makeHome();
+    const file = await archivedPath(home);
+    await writeFile(file, turnContext('archived-model'));
+
+    await expect(observer(home).observe(SESSION_ID)).resolves.toEqual({
+      model: 'archived-model',
+      source: 'turn_context',
+    });
+  });
+
+  it('uses thread_settings_applied only when no valid turn context exists', async () => {
+    const home = await makeHome();
+    const file = await activePath(home);
+    await writeFile(
+      file,
+      [
+        threadSettings('settings-fallback'),
+        turnContext('bad\nmodel'),
+        turnContext('x'.repeat(201)),
+      ].join('\n'),
+    );
+
+    await expect(observer(home).observe(SESSION_ID)).resolves.toEqual({
+      model: 'settings-fallback',
+      source: 'thread_settings_applied',
+    });
+  });
+
+  it('rejects symlinks and candidates whose canonical parent escapes CODEX_HOME', async () => {
+    const home = await makeHome();
+    const outside = await makeHome();
+    const outsideFile = await activePath(outside);
+    await writeFile(outsideFile, turnContext('must-not-read'));
+
+    const linkPath = await activePath(home);
+    await symlink(outsideFile, linkPath);
+    await expect(observer(home).observe(SESSION_ID)).resolves.toBeUndefined();
+
+    await rm(join(home, 'sessions'), { recursive: true });
+    await symlink(join(outside, 'sessions'), join(home, 'sessions'));
+    await expect(observer(home).observe(SESSION_ID)).resolves.toBeUndefined();
+  });
+
+  it('rejects directories without treating them as rollout files', async () => {
+    const home = await makeHome();
+    const file = await activePath(home);
+    await mkdir(file);
+    await expect(observer(home).observe(SESSION_ID)).resolves.toBeUndefined();
+  });
+
+  it.skipIf(!HAS_MKFIFO)('rejects FIFOs without blocking', async () => {
+    const home = await makeHome();
+    const file = await activePath(home);
+    await execFileAsync('mkfifo', [file]);
+    await expect(observer(home).observe(SESSION_ID)).resolves.toBeUndefined();
+  });
+
+  it('reverse-reads in bounded blocks and does not inspect content beyond maxBytes', async () => {
+    const home = await makeHome();
+    const file = await activePath(home);
+    await writeFile(file, `${turnContext('too-old')}\n${'x'.repeat(512)}\n`);
+
+    await expect(
+      observer(home, { blockSizeBytes: 32, maxReadBytes: 128 }).observe(SESSION_ID),
+    ).resolves.toBeUndefined();
+
+    await writeFile(file, `${'x'.repeat(512)}\n${turnContext('near-the-end')}\n`);
+    await expect(
+      observer(home, { blockSizeBytes: 32, maxReadBytes: 128 }).observe(SESSION_ID),
+    ).resolves.toMatchObject({ model: 'near-the-end' });
+  });
+
+  it('keeps a genuinely sparse rollout outside the default eight-MiB window unavailable', async () => {
+    const home = await makeHome();
+    const file = await activePath(home);
+    const sparseHandle = await open(file, 'w');
+    await sparseHandle.write(`${turnContext('outside-window')}\n`, 0, 'utf8');
+    await sparseHandle.truncate(1024 * 1024 * 1024);
+    await sparseHandle.close();
+    let readBytes = 0;
+
+    await expect(
+      observer(home, {
+        maxDurationMs: 5_000,
+        openFile: async (path, flags) => {
+          const handle = await open(path, flags);
+          return {
+            stat: (options) => handle.stat(options),
+            read: async (buffer, offset, length, position) => {
+              const result = await handle.read(buffer, offset, length, position);
+              readBytes += result.bytesRead;
+              return result;
+            },
+            close: () => handle.close(),
+          };
+        },
+      }).observe(SESSION_ID),
+    ).resolves.toBeUndefined();
+    expect(readBytes).toBe(8 * 1024 * 1024);
+  });
+
+  it('skips pathological giant JSONL records instead of parsing them', async () => {
+    const home = await makeHome();
+    const file = await activePath(home);
+    const pathological = JSON.stringify({
+      type: 'turn_context',
+      payload: { model: 'pathological-latest' },
+      padding: 'x'.repeat(256 * 1024),
+    });
+    await writeFile(file, `${turnContext('bounded-record')}\n${pathological}\n`);
+
+    await expect(observer(home).observe(SESSION_ID)).resolves.toEqual({
+      model: 'bounded-record',
+      source: 'turn_context',
+    });
+  });
+
+  it('bounds caller latency, closes a handle opened after expiry, and avoids stale cache writes', async () => {
+    const home = await makeHome();
+    const file = await activePath(home);
+    await writeFile(file, turnContext('model-a'));
+
+    let releaseOpen: (() => void) | undefined;
+    const openGate = new Promise<void>((resolve) => {
+      releaseOpen = resolve;
+    });
+    let openedHandle: Awaited<ReturnType<typeof open>> | undefined;
+    let fireDeadline: (() => void) | undefined;
+    const instance = observer(home, {
+      openFile: async (path, flags) => {
+        openedHandle = await open(path, flags);
+        await openGate;
+        return openedHandle;
+      },
+      scheduleTimeout: (callback) => {
+        fireDeadline = callback;
+        return { cancel: () => undefined };
+      },
+    });
+
+    const pending = instance.observe(SESSION_ID);
+    await vi.waitFor(() => expect(openedHandle).toBeDefined());
+    expect(fireDeadline).toBeDefined();
+    fireDeadline?.();
+    await expect(pending).resolves.toBeUndefined();
+
+    await writeFile(file, turnContext('model-b'));
+    releaseOpen?.();
+    await vi.waitFor(async () => {
+      await expect(openedHandle?.stat()).rejects.toThrow();
+    });
+
+    await expect(instance.observe(SESSION_ID)).resolves.toEqual({
+      model: 'model-b',
+      source: 'turn_context',
+    });
+  });
+
+  it('stops scanning when the injected time budget expires', async () => {
+    const home = await makeHome();
+    const file = await activePath(home);
+    await writeFile(file, `${turnContext('too-slow')}\n${'x'.repeat(256)}\n`);
+    let calls = 0;
+
+    await expect(
+      observer(home, {
+        blockSizeBytes: 16,
+        maxDurationMs: 100,
+        now: () => (calls++ === 0 ? 1_000 : 1_101),
+      }).observe(SESSION_ID),
+    ).resolves.toBeUndefined();
+  });
+
+  it('caches by session, path, inode, and size, then refreshes when size changes', async () => {
+    const home = await makeHome();
+    const file = await activePath(home);
+    await writeFile(file, turnContext('model-a'));
+    const instance = observer(home);
+
+    await expect(instance.observe(SESSION_ID)).resolves.toMatchObject({ model: 'model-a' });
+    const original = await readFile(file, 'utf8');
+    await writeFile(file, original.replace('model-a', 'model-b'));
+    await expect(instance.observe(SESSION_ID)).resolves.toMatchObject({ model: 'model-a' });
+
+    await writeFile(file, `${turnContext('model-b-longer')}\n`);
+    await expect(instance.observe(SESSION_ID)).resolves.toMatchObject({ model: 'model-b-longer' });
+  });
+
+  it('expires cached observations', async () => {
+    const home = await makeHome();
+    let now = 1_000;
+    const instance = observer(home, { cacheMaxEntries: 1, cacheTtlMs: 100, now: () => now });
+    const first = await activePath(home);
+    await writeFile(first, turnContext('first-a'));
+    await expect(instance.observe(SESSION_ID)).resolves.toMatchObject({ model: 'first-a' });
+
+    await writeFile(first, turnContext('first-b'));
+    now = 1_101;
+    await expect(instance.observe(SESSION_ID)).resolves.toMatchObject({ model: 'first-b' });
+  });
+
+  it('evicts the least-recently-used observation at the configured capacity', async () => {
+    const home = await makeHome();
+    const instance = observer(home, { cacheMaxEntries: 1 });
+    const first = await activePath(home);
+    const second = await activePath(home, SECOND_SESSION_ID);
+    await writeFile(first, turnContext('first-a'));
+    await writeFile(second, turnContext('second'));
+
+    await expect(instance.observe(SESSION_ID)).resolves.toMatchObject({ model: 'first-a' });
+    await expect(instance.observe(SECOND_SESSION_ID)).resolves.toMatchObject({ model: 'second' });
+    await writeFile(first, turnContext('first-b'));
+    await expect(instance.observe(SESSION_ID)).resolves.toMatchObject({ model: 'first-b' });
+  });
+
+  it('fails open when CODEX_HOME does not exist or a rollout is malformed', async () => {
+    const home = await makeHome();
+    const missing = join(home, 'missing');
+    await expect(observer(missing).observe(SESSION_ID)).resolves.toBeUndefined();
+
+    const file = await activePath(home);
+    await writeFile(file, '{definitely-not-json}\n');
+    await expect(observer(home).observe(SESSION_ID)).resolves.toBeUndefined();
+  });
+});

--- a/src/backends/codex-session-observer.ts
+++ b/src/backends/codex-session-observer.ts
@@ -1,0 +1,531 @@
+import { constants, type BigIntStats } from 'node:fs';
+import { lstat, open, realpath } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { isAbsolute, join, relative, sep } from 'node:path';
+
+const UUID_V7_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const DEFAULT_BLOCK_SIZE_BYTES = 64 * 1024;
+const DEFAULT_MAX_READ_BYTES = 8 * 1024 * 1024;
+const DEFAULT_MAX_DURATION_MS = 100;
+const DEFAULT_CACHE_MAX_ENTRIES = 256;
+const DEFAULT_CACHE_TTL_MS = 60 * 60 * 1000;
+const MAX_RECORD_BYTES = 64 * 1024;
+
+export interface CodexSessionObservation {
+  model: string;
+  source: 'turn_context' | 'thread_settings_applied';
+}
+
+export interface CodexSessionObserverOptions {
+  codexHome?: string;
+  blockSizeBytes?: number;
+  maxReadBytes?: number;
+  maxDurationMs?: number;
+  cacheMaxEntries?: number;
+  cacheTtlMs?: number;
+  now?: () => number;
+  openFile?: (path: string, flags: number) => Promise<CodexSessionObserverFileHandle>;
+  scheduleTimeout?: (callback: () => void, delayMs: number) => CodexSessionObserverTimer;
+}
+
+export interface CodexSessionObserverFileHandle {
+  stat(options: { bigint: true }): Promise<BigIntStats>;
+  read(
+    buffer: Buffer,
+    offset: number,
+    length: number,
+    position: number,
+  ): Promise<{ bytesRead: number }>;
+  close(): Promise<void>;
+}
+
+export interface CodexSessionObserverTimer {
+  cancel(): void;
+}
+
+export interface CodexSessionObserver {
+  observe(sessionId: string): Promise<CodexSessionObservation | undefined>;
+  clearCache(): void;
+}
+
+interface NormalizedOptions {
+  codexHome: string;
+  blockSizeBytes: number;
+  maxReadBytes: number;
+  maxDurationMs: number;
+  cacheMaxEntries: number;
+  cacheTtlMs: number;
+  now: () => number;
+  openFile: (path: string, flags: number) => Promise<CodexSessionObserverFileHandle>;
+  scheduleTimeout: (callback: () => void, delayMs: number) => CodexSessionObserverTimer;
+}
+
+interface CacheEntry {
+  observation: CodexSessionObservation | undefined;
+  expiresAt: number;
+}
+
+interface SafeCandidate {
+  path: string;
+  size: number;
+  device: bigint;
+  inode: bigint;
+  handle: CodexSessionObserverFileHandle;
+}
+
+function positiveInteger(value: number | undefined, fallback: number): number {
+  return value !== undefined && Number.isSafeInteger(value) && value > 0 ? value : fallback;
+}
+
+function normalizeOptions(options: CodexSessionObserverOptions): NormalizedOptions {
+  return {
+    codexHome: options.codexHome ?? process.env.CODEX_HOME ?? join(homedir(), '.codex'),
+    blockSizeBytes: positiveInteger(options.blockSizeBytes, DEFAULT_BLOCK_SIZE_BYTES),
+    maxReadBytes: positiveInteger(options.maxReadBytes, DEFAULT_MAX_READ_BYTES),
+    maxDurationMs: positiveInteger(options.maxDurationMs, DEFAULT_MAX_DURATION_MS),
+    cacheMaxEntries: positiveInteger(options.cacheMaxEntries, DEFAULT_CACHE_MAX_ENTRIES),
+    cacheTtlMs: positiveInteger(options.cacheTtlMs, DEFAULT_CACHE_TTL_MS),
+    now: options.now ?? Date.now,
+    openFile: options.openFile ?? open,
+    scheduleTimeout:
+      options.scheduleTimeout ??
+      ((callback, delayMs) => {
+        const timer = setTimeout(callback, delayMs);
+        return { cancel: () => clearTimeout(timer) };
+      }),
+  };
+}
+
+function isWithin(root: string, candidate: string): boolean {
+  const pathFromRoot = relative(root, candidate);
+  return (
+    pathFromRoot === '' ||
+    (!isAbsolute(pathFromRoot) && pathFromRoot !== '..' && !pathFromRoot.startsWith(`..${sep}`))
+  );
+}
+
+function pad(value: number): string {
+  return String(value).padStart(2, '0');
+}
+
+function sessionTimestamp(sessionId: string): number | undefined {
+  if (!UUID_V7_PATTERN.test(sessionId)) return undefined;
+  const timestamp = Number.parseInt(sessionId.replaceAll('-', '').slice(0, 12), 16);
+  return Number.isSafeInteger(timestamp) ? timestamp : undefined;
+}
+
+function rolloutFilename(sessionId: string, timestamp: number): string {
+  const date = new Date(timestamp);
+  return (
+    `rollout-${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}` +
+    `T${pad(date.getHours())}-${pad(date.getMinutes())}-${pad(date.getSeconds())}-${sessionId}.jsonl`
+  );
+}
+
+function activeDirectories(codexHome: string, timestamp: number): string[] {
+  return [0, -1, 1].map((dayOffset) => {
+    const date = new Date(timestamp);
+    date.setDate(date.getDate() + dayOffset);
+    return join(
+      codexHome,
+      'sessions',
+      String(date.getFullYear()),
+      pad(date.getMonth() + 1),
+      pad(date.getDate()),
+    );
+  });
+}
+
+function isExpired(options: NormalizedOptions, startedAt: number): boolean {
+  return options.now() - startedAt >= options.maxDurationMs;
+}
+
+async function canonicalDirectoryWithin(
+  root: string,
+  directory: string,
+): Promise<string | undefined> {
+  try {
+    const canonical = await realpath(directory);
+    return isWithin(root, canonical) ? canonical : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function findCandidatePath(
+  root: string,
+  sessionId: string,
+  timestamp: number,
+  isCancelled: () => boolean,
+): Promise<string | undefined> {
+  const filename = rolloutFilename(sessionId, timestamp);
+  for (const directory of activeDirectories(root, timestamp)) {
+    if (isCancelled()) return undefined;
+    const canonicalDirectory = await canonicalDirectoryWithin(root, directory);
+    if (isCancelled()) return undefined;
+    if (!canonicalDirectory) continue;
+    const activeCandidate = join(canonicalDirectory, filename);
+    try {
+      await lstat(activeCandidate);
+      if (isCancelled()) return undefined;
+      return activeCandidate;
+    } catch {
+      // A missing or unreadable exact candidate is simply unavailable.
+    }
+  }
+
+  if (isCancelled()) return undefined;
+  const archiveDirectory = await canonicalDirectoryWithin(root, join(root, 'archived_sessions'));
+  if (isCancelled()) return undefined;
+  if (!archiveDirectory) return undefined;
+  const archivedCandidate = join(archiveDirectory, filename);
+  try {
+    await lstat(archivedCandidate);
+    if (isCancelled()) return undefined;
+    return archivedCandidate;
+  } catch {
+    return undefined;
+  }
+}
+
+function sameIdentity(
+  left: { dev: bigint | number; ino: bigint | number },
+  right: { dev: bigint | number; ino: bigint | number },
+): boolean {
+  return BigInt(left.dev) === BigInt(right.dev) && BigInt(left.ino) === BigInt(right.ino);
+}
+
+async function openSafeCandidate(
+  root: string,
+  candidate: string,
+  options: NormalizedOptions,
+  isCancelled: () => boolean,
+): Promise<SafeCandidate | undefined> {
+  let before;
+  try {
+    before = await lstat(candidate, { bigint: true });
+  } catch {
+    return undefined;
+  }
+  if (isCancelled()) return undefined;
+  if (before.isSymbolicLink() || !before.isFile()) return undefined;
+
+  const noFollow = constants.O_NOFOLLOW ?? 0;
+  const nonBlocking = constants.O_NONBLOCK ?? 0;
+  let handle: CodexSessionObserverFileHandle | undefined;
+  try {
+    handle = await options.openFile(candidate, constants.O_RDONLY | noFollow | nonBlocking);
+    if (isCancelled()) {
+      await handle.close();
+      return undefined;
+    }
+    const descriptor = await handle.stat({ bigint: true });
+    if (isCancelled()) {
+      await handle.close();
+      return undefined;
+    }
+    if (!descriptor.isFile() || !sameIdentity(before, descriptor)) {
+      await handle.close();
+      return undefined;
+    }
+
+    const canonicalCandidate = await realpath(candidate);
+    if (isCancelled()) {
+      await handle.close();
+      return undefined;
+    }
+    const after = await lstat(candidate, { bigint: true });
+    if (isCancelled()) {
+      await handle.close();
+      return undefined;
+    }
+    if (
+      !isWithin(root, canonicalCandidate) ||
+      after.isSymbolicLink() ||
+      !after.isFile() ||
+      !sameIdentity(descriptor, after)
+    ) {
+      await handle.close();
+      return undefined;
+    }
+
+    return {
+      path: canonicalCandidate,
+      size: Number(descriptor.size),
+      device: descriptor.dev,
+      inode: descriptor.ino,
+      handle,
+    };
+  } catch {
+    if (handle) {
+      try {
+        await handle.close();
+      } catch {
+        // The observer fails open, including when cleanup races with a file removal.
+      }
+    }
+    return undefined;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function containsControlCharacter(value: string): boolean {
+  for (const character of value) {
+    const codePoint = character.codePointAt(0);
+    if (
+      codePoint !== undefined &&
+      (codePoint <= 0x1f || codePoint === 0x7f || (codePoint >= 0x80 && codePoint <= 0x9f))
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function validModel(value: unknown): string | undefined {
+  if (
+    typeof value !== 'string' ||
+    value.length < 1 ||
+    value.length > 200 ||
+    containsControlCharacter(value)
+  ) {
+    return undefined;
+  }
+  return value;
+}
+
+function inspectRecord(line: string): CodexSessionObservation | undefined {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(line) as unknown;
+  } catch {
+    return undefined;
+  }
+  if (!isRecord(parsed)) return undefined;
+
+  if (parsed.type === 'turn_context' && isRecord(parsed.payload)) {
+    const model = validModel(parsed.payload.model);
+    return model ? { model, source: 'turn_context' } : undefined;
+  }
+
+  if (parsed.type === 'thread_settings_applied' && isRecord(parsed.thread_settings)) {
+    const model = validModel(parsed.thread_settings.model);
+    return model ? { model, source: 'thread_settings_applied' } : undefined;
+  }
+
+  if (
+    parsed.type === 'event_msg' &&
+    isRecord(parsed.payload) &&
+    parsed.payload.type === 'thread_settings_applied' &&
+    isRecord(parsed.payload.thread_settings)
+  ) {
+    const model = validModel(parsed.payload.thread_settings.model);
+    return model ? { model, source: 'thread_settings_applied' } : undefined;
+  }
+  return undefined;
+}
+
+function inspectCompleteLines(
+  bytes: Buffer,
+  fallback: CodexSessionObservation | undefined,
+  isCancelled: () => boolean,
+): {
+  turnContext?: CodexSessionObservation;
+  fallback?: CodexSessionObservation;
+  cancelled?: true;
+} {
+  let latestFallback = fallback;
+  let lineEnd = bytes.length;
+  while (lineEnd > 0) {
+    if (isCancelled()) return { fallback: latestFallback, cancelled: true };
+    const newlineIndex = bytes.lastIndexOf(0x0a, lineEnd - 1);
+    const lineStart = newlineIndex + 1;
+    const contentEnd = lineEnd > lineStart && bytes[lineEnd - 1] === 0x0d ? lineEnd - 1 : lineEnd;
+    const lineLength = contentEnd - lineStart;
+    let observation: CodexSessionObservation | undefined;
+    if (lineLength > 0 && lineLength <= MAX_RECORD_BYTES) {
+      observation = inspectRecord(bytes.toString('utf8', lineStart, contentEnd));
+      if (isCancelled()) return { fallback: latestFallback, cancelled: true };
+    }
+    if (observation) {
+      if (observation.source === 'turn_context')
+        return { turnContext: observation, fallback: latestFallback };
+      latestFallback ??= observation;
+    }
+
+    if (newlineIndex < 0) break;
+    lineEnd = newlineIndex;
+  }
+  return { fallback: latestFallback };
+}
+
+async function readObservation(
+  candidate: SafeCandidate,
+  options: NormalizedOptions,
+  isCancelled: () => boolean,
+): Promise<CodexSessionObservation | undefined> {
+  let position = candidate.size;
+  let bytesReadTotal = 0;
+  // Newest blocks are read first. Keep fragments as separate buffers until a
+  // newline is found so one very large JSONL record cannot trigger quadratic
+  // copying while the bounded window is scanned backwards.
+  let carryParts: Buffer[] = [];
+  let fallback: CodexSessionObservation | undefined;
+
+  while (position > 0 && bytesReadTotal < options.maxReadBytes) {
+    if (isCancelled()) return undefined;
+    const length = Math.min(
+      options.blockSizeBytes,
+      position,
+      options.maxReadBytes - bytesReadTotal,
+    );
+    const start = position - length;
+    const block = Buffer.allocUnsafe(length);
+    let filled = 0;
+    while (filled < length) {
+      if (isCancelled()) return undefined;
+      const result = await candidate.handle.read(block, filled, length - filled, start + filled);
+      if (isCancelled()) return undefined;
+      if (result.bytesRead === 0) return undefined;
+      filled += result.bytesRead;
+    }
+
+    bytesReadTotal += filled;
+    position = start;
+    carryParts.unshift(block);
+
+    if (start === 0) {
+      const combined = Buffer.concat(carryParts);
+      const inspected = inspectCompleteLines(combined, fallback, isCancelled);
+      if (inspected.cancelled) return undefined;
+      return inspected.turnContext ?? inspected.fallback;
+    }
+
+    if (block.indexOf(0x0a) === -1) continue;
+
+    const combined = Buffer.concat(carryParts);
+    const firstNewline = combined.indexOf(0x0a);
+    carryParts = [combined.subarray(0, firstNewline)];
+    const inspected = inspectCompleteLines(
+      combined.subarray(firstNewline + 1),
+      fallback,
+      isCancelled,
+    );
+    if (inspected.cancelled) return undefined;
+    if (inspected.turnContext) return inspected.turnContext;
+    fallback = inspected.fallback;
+  }
+
+  // A settings record is useful only if it was fully contained in the bounded
+  // scan. A partial leading line is deliberately ignored.
+  return isCancelled() ? undefined : fallback;
+}
+
+function cacheKey(sessionId: string, candidate: SafeCandidate): string {
+  return `${sessionId}\0${candidate.path}\0${candidate.device}:${candidate.inode}:${candidate.size}`;
+}
+
+export function createCodexSessionObserver(
+  rawOptions: CodexSessionObserverOptions = {},
+): CodexSessionObserver {
+  const options = normalizeOptions(rawOptions);
+  const cache = new Map<string, CacheEntry>();
+
+  function readCache(key: string, now: number): CacheEntry | undefined {
+    const entry = cache.get(key);
+    if (!entry) return undefined;
+    if (entry.expiresAt <= now) {
+      cache.delete(key);
+      return undefined;
+    }
+    cache.delete(key);
+    cache.set(key, entry);
+    return entry;
+  }
+
+  function writeCache(
+    key: string,
+    observation: CodexSessionObservation | undefined,
+    now: number,
+  ): void {
+    cache.delete(key);
+    cache.set(key, { observation, expiresAt: now + options.cacheTtlMs });
+    while (cache.size > options.cacheMaxEntries) {
+      const oldest = cache.keys().next().value as string | undefined;
+      if (oldest === undefined) break;
+      cache.delete(oldest);
+    }
+  }
+
+  return {
+    async observe(sessionId: string): Promise<CodexSessionObservation | undefined> {
+      const timestamp = sessionTimestamp(sessionId);
+      if (timestamp === undefined) return undefined;
+
+      const startedAt = options.now();
+      let deadlineReached = false;
+      let resolveDeadline: (observation: undefined) => void = () => undefined;
+      const deadline = new Promise<undefined>((resolve) => {
+        resolveDeadline = resolve;
+      });
+      const timer = options.scheduleTimeout(() => {
+        deadlineReached = true;
+        resolveDeadline(undefined);
+      }, options.maxDurationMs);
+      const isCancelled = (): boolean => {
+        if (deadlineReached) return true;
+        if (!isExpired(options, startedAt)) return false;
+        deadlineReached = true;
+        return true;
+      };
+
+      const operation = (async (): Promise<CodexSessionObservation | undefined> => {
+        let candidate: SafeCandidate | undefined;
+        try {
+          const root = await realpath(options.codexHome);
+          if (isCancelled()) return undefined;
+          const candidatePath = await findCandidatePath(root, sessionId, timestamp, isCancelled);
+          if (!candidatePath || isCancelled()) return undefined;
+          candidate = await openSafeCandidate(root, candidatePath, options, isCancelled);
+          if (
+            !candidate ||
+            isCancelled() ||
+            !Number.isSafeInteger(candidate.size) ||
+            candidate.size < 0
+          )
+            return undefined;
+
+          const key = cacheKey(sessionId, candidate);
+          const cached = readCache(key, startedAt);
+          if (cached) return isCancelled() ? undefined : cached.observation;
+          const observation = await readObservation(candidate, options, isCancelled);
+          if (isCancelled()) return undefined;
+          writeCache(key, observation, startedAt);
+          return observation;
+        } catch {
+          return undefined;
+        } finally {
+          if (candidate) {
+            try {
+              await candidate.handle.close();
+            } catch {
+              // Observation is strictly best-effort and must never fail a review.
+            }
+          }
+        }
+      })();
+
+      try {
+        return await Promise.race([operation, deadline]);
+      } finally {
+        timer.cancel();
+      }
+    },
+    clearCache(): void {
+      cache.clear();
+    },
+  };
+}

--- a/src/backends/codex.test.ts
+++ b/src/backends/codex.test.ts
@@ -85,13 +85,31 @@ const config: ReviewBridgeConfig = { ...DEFAULT_CONFIG };
 const validPlanResponse = {
   verdict: 'approve',
   summary: 'Plan looks solid',
-  findings: [{ severity: 'minor', category: 'style', description: 'Consider renaming', file: null, line: null, suggestion: null }],
+  findings: [
+    {
+      severity: 'minor',
+      category: 'style',
+      description: 'Consider renaming',
+      file: null,
+      line: null,
+      suggestion: null,
+    },
+  ],
 };
 
 const validCodeResponse = {
   verdict: 'request_changes',
   summary: 'Issues found',
-  findings: [{ severity: 'critical', category: 'bug', description: 'Null pointer', file: null, line: null, suggestion: null }],
+  findings: [
+    {
+      severity: 'critical',
+      category: 'bug',
+      description: 'Null pointer',
+      file: null,
+      line: null,
+      suggestion: null,
+    },
+  ],
 };
 
 const validPrecommitResponse = {
@@ -267,7 +285,9 @@ describe('looksLikeDiff', () => {
   });
 
   it('rejects plain prose', () => {
-    expect(looksLikeDiff('This is a summary of my changes to the authentication system.')).toBe(false);
+    expect(looksLikeDiff('This is a summary of my changes to the authentication system.')).toBe(
+      false,
+    );
   });
 
   it('rejects prose that mentions diff --git without hunks', () => {
@@ -289,7 +309,9 @@ describe('looksLikeDiff', () => {
   // ISS-005: hunk-less-but-valid git diffs must be accepted.
   it('accepts a rename-only diff (no hunks, no ---/+++)', () => {
     expect(
-      looksLikeDiff('diff --git a/old.js b/new.js\nsimilarity index 100%\nrename from old.js\nrename to new.js'),
+      looksLikeDiff(
+        'diff --git a/old.js b/new.js\nsimilarity index 100%\nrename from old.js\nrename to new.js',
+      ),
     ).toBe(true);
   });
 
@@ -302,7 +324,11 @@ describe('looksLikeDiff', () => {
   });
 
   it('accepts a binary diff (GIT binary patch)', () => {
-    expect(looksLikeDiff('diff --git a/img.png b/img.png\nindex abc..def 100644\nGIT binary patch\nzcmV')).toBe(true);
+    expect(
+      looksLikeDiff(
+        'diff --git a/img.png b/img.png\nindex abc..def 100644\nGIT binary patch\nzcmV',
+      ),
+    ).toBe(true);
   });
 
   it('accepts a mixed rename + content diff', () => {
@@ -313,22 +339,32 @@ describe('looksLikeDiff', () => {
   });
 
   it('accepts a mode-only change diff', () => {
-    expect(looksLikeDiff('diff --git a/run.sh b/run.sh\nold mode 100644\nnew mode 100755')).toBe(true);
+    expect(looksLikeDiff('diff --git a/run.sh b/run.sh\nold mode 100644\nnew mode 100755')).toBe(
+      true,
+    );
   });
 
   it('accepts a copy-only diff', () => {
     expect(
-      looksLikeDiff('diff --git a/orig.js b/copy.js\nsimilarity index 100%\ncopy from orig.js\ncopy to copy.js'),
+      looksLikeDiff(
+        'diff --git a/orig.js b/copy.js\nsimilarity index 100%\ncopy from orig.js\ncopy to copy.js',
+      ),
     ).toBe(true);
   });
 
   it('accepts an empty-file creation diff', () => {
-    expect(looksLikeDiff('diff --git a/empty.txt b/empty.txt\nnew file mode 100644\nindex 0000000..e69de29')).toBe(true);
+    expect(
+      looksLikeDiff(
+        'diff --git a/empty.txt b/empty.txt\nnew file mode 100644\nindex 0000000..e69de29',
+      ),
+    ).toBe(true);
   });
 
   it('accepts an empty-file deletion diff', () => {
     expect(
-      looksLikeDiff('diff --git a/empty.txt b/empty.txt\ndeleted file mode 100644\nindex e69de29..0000000'),
+      looksLikeDiff(
+        'diff --git a/empty.txt b/empty.txt\ndeleted file mode 100644\nindex e69de29..0000000',
+      ),
     ).toBe(true);
   });
 
@@ -417,7 +453,9 @@ describe('codex binary override (codex_path)', () => {
 
 describe('provider unavailable (binary missing / killed / quarantined)', () => {
   it('classifies a constructor "unable to locate codex" as PROVIDER_UNAVAILABLE', async () => {
-    mockConstructorThrow = new Error('Unable to locate Codex CLI binaries. Ensure @openai/codex is installed.');
+    mockConstructorThrow = new Error(
+      'Unable to locate Codex CLI binaries. Ensure @openai/codex is installed.',
+    );
     const res = await createCodexBackend(config).reviewPlan({ plan: 'x' });
     expect(res.ok).toBe(false);
     if (!res.ok) expect(res.error).toContain(ErrorCode.PROVIDER_UNAVAILABLE);
@@ -663,6 +701,51 @@ describe('session management', () => {
       expect(result.data.session_id).toBe('fallback_id');
     }
   });
+
+  it.each([
+    ['empty', ''],
+    ['surrounding whitespace', ' thread-id '],
+    ['control characters', 'thread\nforged'],
+    ['more than 256 characters', 'x'.repeat(257)],
+  ])('rejects a fresh provider thread id with %s', async (_case, providerId) => {
+    mockThreadId = providerId;
+    mockRun.mockResolvedValue({ finalResponse: JSON.stringify(validPlanResponse) });
+
+    const result = await createCodexBackend(config).reviewPlan({ plan: 'plan' });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain(ErrorCode.RESPONSE_PARSE_ERROR);
+      expect(result.error).toContain('invalid session ID');
+      expect(result).not.toHaveProperty('session_id');
+    }
+  });
+
+  it.each([
+    ['empty', ''],
+    ['surrounding whitespace', ' thread-id '],
+    ['control characters', 'thread\u0085forged'],
+    ['more than 256 characters', 'x'.repeat(257)],
+  ])(
+    'rejects a resumed session id with %s before calling the provider',
+    async (_case, sessionId) => {
+      mockRun.mockResolvedValue({ finalResponse: JSON.stringify(validPlanResponse) });
+
+      const result = await createCodexBackend(config).reviewPlan({
+        plan: 'plan',
+        session_id: sessionId,
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toContain(ErrorCode.INVALID_INPUT);
+        expect(result.error).toContain('invalid session ID');
+        expect(result).not.toHaveProperty('session_id');
+      }
+      expect(mockResumeThread).not.toHaveBeenCalled();
+      expect(mockRun).not.toHaveBeenCalled();
+    },
+  );
 });
 
 describe('runtime errors', () => {
@@ -793,7 +876,9 @@ describe('error classification', () => {
 
   it('surfaces ChatGPT-account fallback tip recommending a different model + the Gemini backend', async () => {
     mockRun.mockRejectedValue(
-      new Error(`The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account.`),
+      new Error(
+        `The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account.`,
+      ),
     );
 
     const client = createCodexBackend(config);
@@ -905,7 +990,9 @@ describe('error classification', () => {
   });
 
   it('does NOT match when "model" and "not supported" are in different sentences', async () => {
-    mockRun.mockRejectedValue(new Error('The current model works fine. However, the operation is not supported.'));
+    mockRun.mockRejectedValue(
+      new Error('The current model works fine. However, the operation is not supported.'),
+    );
 
     const client = createCodexBackend(config);
     const result = await client.reviewPlan({ plan: 'plan' });
@@ -1004,9 +1091,7 @@ describe('per-call model override (T-011)', () => {
     await client.reviewPlan({ plan: 'plan', model: 'gpt-5.4' });
 
     expect(mockStartThread).toHaveBeenCalledOnce();
-    expect(mockStartThread).toHaveBeenCalledWith(
-      expect.objectContaining({ model: 'gpt-5.4' }),
-    );
+    expect(mockStartThread).toHaveBeenCalledWith(expect.objectContaining({ model: 'gpt-5.4' }));
   });
 
   it('reviewCode forwards override to startThread on single-chunk path', async () => {
@@ -1018,9 +1103,7 @@ describe('per-call model override (T-011)', () => {
       model: 'gpt-5.4',
     });
 
-    expect(mockStartThread).toHaveBeenCalledWith(
-      expect.objectContaining({ model: 'gpt-5.4' }),
-    );
+    expect(mockStartThread).toHaveBeenCalledWith(expect.objectContaining({ model: 'gpt-5.4' }));
   });
 
   it('reviewPrecommit forwards override to startThread on single-chunk path', async () => {
@@ -1032,9 +1115,7 @@ describe('per-call model override (T-011)', () => {
       model: 'gpt-5.4',
     });
 
-    expect(mockStartThread).toHaveBeenCalledWith(
-      expect.objectContaining({ model: 'gpt-5.4' }),
-    );
+    expect(mockStartThread).toHaveBeenCalledWith(expect.objectContaining({ model: 'gpt-5.4' }));
   });
 
   it('uses config.model when set and no per-call override is given', async () => {
@@ -1043,9 +1124,7 @@ describe('per-call model override (T-011)', () => {
     const client = createCodexBackend({ ...config, model: 'gpt-5.4' });
     await client.reviewPlan({ plan: 'plan' });
 
-    expect(mockStartThread).toHaveBeenCalledWith(
-      expect.objectContaining({ model: 'gpt-5.4' }),
-    );
+    expect(mockStartThread).toHaveBeenCalledWith(expect.objectContaining({ model: 'gpt-5.4' }));
   });
 
   it('falls back to the backend default model when neither override nor config.model is set', async () => {
@@ -1055,9 +1134,7 @@ describe('per-call model override (T-011)', () => {
     await client.reviewPlan({ plan: 'plan' });
 
     // codex resolves its own default — the schema no longer supplies one.
-    expect(mockStartThread).toHaveBeenCalledWith(
-      expect.objectContaining({ model: 'gpt-5.6-sol' }),
-    );
+    expect(mockStartThread).toHaveBeenCalledWith(expect.objectContaining({ model: 'gpt-5.6-sol' }));
   });
 
   it('rejects session_id + model combination with INVALID_INPUT', async () => {
@@ -1094,9 +1171,7 @@ describe('per-call model override (T-011)', () => {
 
     // Chunk 1: startThread with the override
     expect(mockStartThread).toHaveBeenCalledOnce();
-    expect(mockStartThread).toHaveBeenCalledWith(
-      expect.objectContaining({ model: 'gpt-5.4' }),
-    );
+    expect(mockStartThread).toHaveBeenCalledWith(expect.objectContaining({ model: 'gpt-5.4' }));
     // Chunk 2: resumeThread is called WITHOUT any `model` field. The SDK
     // would otherwise forward `--model` to the CLI and reassert a model
     // on a resumed thread — breaking the "inherit" guarantee. The resumed
@@ -1125,9 +1200,7 @@ describe('per-call model override (T-011)', () => {
     });
 
     expect(mockStartThread).toHaveBeenCalledOnce();
-    expect(mockStartThread).toHaveBeenCalledWith(
-      expect.objectContaining({ model: 'gpt-5.4' }),
-    );
+    expect(mockStartThread).toHaveBeenCalledWith(expect.objectContaining({ model: 'gpt-5.4' }));
     expect(mockResumeThread).toHaveBeenCalledOnce();
     expect(mockResumeThread).toHaveBeenCalledWith(
       'thread_abc123',
@@ -1201,7 +1274,9 @@ describe('config flows to prompts', () => {
       },
       precommit: {
         auto_diff: true,
-        block_on: ['critical', 'major'] as Array<'critical' | 'major' | 'minor' | 'suggestion' | 'nitpick'>,
+        block_on: ['critical', 'major'] as Array<
+          'critical' | 'major' | 'minor' | 'suggestion' | 'nitpick'
+        >,
       },
     },
   };
@@ -1309,15 +1384,27 @@ describe('constructor failure', () => {
 });
 
 describe('chunking', () => {
-  const makeCodeResponse = (verdict: string, findings: Array<{ severity: string; category: string; file: string | null; line: number | null }> = [], summary = 'chunk summary') =>
+  const makeCodeResponse = (
+    verdict: string,
+    findings: Array<{
+      severity: string;
+      category: string;
+      file: string | null;
+      line: number | null;
+    }> = [],
+    summary = 'chunk summary',
+  ) =>
     JSON.stringify({
       verdict,
       summary,
       findings: findings.map((f) => ({ ...f, description: 'desc', suggestion: null })),
     });
 
-  const makePrecommitResponse = (ready: boolean, blockers: string[] = [], warnings: string[] = []) =>
-    JSON.stringify({ ready_to_commit: ready, blockers, warnings });
+  const makePrecommitResponse = (
+    ready: boolean,
+    blockers: string[] = [],
+    warnings: string[] = [],
+  ) => JSON.stringify({ ready_to_commit: ready, blockers, warnings });
 
   it('small diff (under threshold) uses single startThread, no chunks_reviewed', async () => {
     mockChunkDiff.mockReturnValue(['small diff']);
@@ -1339,10 +1426,20 @@ describe('chunking', () => {
     const thread2Id = 'thread_chunk2';
 
     mockStartThread.mockImplementation(() => {
-      return { run: mockRun, get id() { return thread1Id; } };
+      return {
+        run: mockRun,
+        get id() {
+          return thread1Id;
+        },
+      };
     });
     mockResumeThread.mockImplementation(() => {
-      return { run: mockRun, get id() { return thread2Id; } };
+      return {
+        run: mockRun,
+        get id() {
+          return thread2Id;
+        },
+      };
     });
 
     mockRun.mockResolvedValue({ finalResponse: makeCodeResponse('approve') });
@@ -1498,7 +1595,9 @@ describe('chunking', () => {
       expect(result.data.verdict).toBe('approve');
       expect(result.data.summary).toBe('No changes to review.');
       expect(result.data.chunks_reviewed).toBeUndefined();
-      expect(result.data.session_id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+      expect(result.data.session_id).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+      );
     }
     expect(mockStartThread).not.toHaveBeenCalled();
     expect(mockResumeThread).not.toHaveBeenCalled();
@@ -1546,7 +1645,9 @@ describe('chunking', () => {
       expect(result.data.blockers).toEqual([]);
       expect(result.data.warnings).toEqual([]);
       expect(result.data.chunks_reviewed).toBeUndefined();
-      expect(result.data.session_id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+      expect(result.data.session_id).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+      );
     }
     expect(mockStartThread).not.toHaveBeenCalled();
   });
@@ -1591,8 +1692,18 @@ describe('chunking', () => {
   it('multi-chunk reviewCode: chunk 2 timeout returns the chunk-1 thread id on the error', async () => {
     mockChunkDiff.mockReturnValue(['chunk1', 'chunk2']);
     const thread1Id = 'thread_partial_failure';
-    mockStartThread.mockImplementation(() => ({ run: mockRun, get id() { return thread1Id; } }));
-    mockResumeThread.mockImplementation(() => ({ run: mockRun, get id() { return thread1Id; } }));
+    mockStartThread.mockImplementation(() => ({
+      run: mockRun,
+      get id() {
+        return thread1Id;
+      },
+    }));
+    mockResumeThread.mockImplementation(() => ({
+      run: mockRun,
+      get id() {
+        return thread1Id;
+      },
+    }));
 
     mockRun
       .mockResolvedValueOnce({ finalResponse: makeCodeResponse('approve') })
@@ -1611,8 +1722,18 @@ describe('chunking', () => {
   it('multi-chunk reviewPrecommit: chunk 2 timeout returns the chunk-1 thread id on the error', async () => {
     mockChunkDiff.mockReturnValue(['chunk1', 'chunk2']);
     const thread1Id = 'thread_pre_partial_failure';
-    mockStartThread.mockImplementation(() => ({ run: mockRun, get id() { return thread1Id; } }));
-    mockResumeThread.mockImplementation(() => ({ run: mockRun, get id() { return thread1Id; } }));
+    mockStartThread.mockImplementation(() => ({
+      run: mockRun,
+      get id() {
+        return thread1Id;
+      },
+    }));
+    mockResumeThread.mockImplementation(() => ({
+      run: mockRun,
+      get id() {
+        return thread1Id;
+      },
+    }));
 
     const validPrecommit = { ready_to_commit: true, blockers: [], warnings: [] };
     mockRun
@@ -1620,7 +1741,9 @@ describe('chunking', () => {
       .mockRejectedValueOnce(new DOMException('aborted', 'AbortError'));
 
     const client = createCodexBackend(config);
-    const result = await client.reviewPrecommit({ diff: 'diff --git a/f b/f\n--- a/f\n+++ b/f\n@@ -1 +1 @@\n-old\n+new' });
+    const result = await client.reviewPrecommit({
+      diff: 'diff --git a/f b/f\n--- a/f\n+++ b/f\n@@ -1 +1 @@\n-old\n+new',
+    });
 
     expect(result.ok).toBe(false);
     if (!result.ok) {

--- a/src/backends/codex.ts
+++ b/src/backends/codex.ts
@@ -8,6 +8,7 @@ import type {
   CodeReviewResult,
   PrecommitResult,
   CrossReviewResult,
+  ModelIdentity,
 } from '../review/types.js';
 import { RECOMMENDED_MODELS, type ReviewBridgeConfig } from '../config/types.js';
 import { estimateTokens } from '../utils/chunking.js';
@@ -21,6 +22,14 @@ import {
   type TurnParams,
   type TurnRunner,
 } from './orchestrator.js';
+import { createCodexSessionObserver } from './codex-session-observer.js';
+import { escapeTerminalControls } from '../utils/terminal.js';
+import { SessionIdSchema } from '../utils/input-validation.js';
+
+export interface CodexBackendDependencies {
+  lookupSessionModel?: (sessionId: string) => ModelIdentity | null;
+  observeSessionModel?: (sessionId: string) => Promise<string | undefined>;
+}
 
 function isAbortError(e: unknown): boolean {
   if (e instanceof Error) {
@@ -140,7 +149,11 @@ export function classifyError(
   }
 
   // Network
-  if (lower.includes('fetch failed') || lower.includes('econnrefused') || lower.includes('enotfound')) {
+  if (
+    lower.includes('fetch failed') ||
+    lower.includes('econnrefused') ||
+    lower.includes('enotfound')
+  ) {
     return {
       code: ErrorCode.NETWORK_ERROR,
       message: 'Could not reach OpenAI API. Check your internet connection.',
@@ -159,10 +172,10 @@ const CODEX_DEFAULT_MODEL = RECOMMENDED_MODELS.codex[0];
 // resolves a concrete model for every start — see startThreadOpts), while the
 // resume path deliberately omits it. The SDK forwards `--model` to `codex exec`
 // unconditionally whenever the field is present (see
-// @openai/codex-sdk/dist/index.js:170), which would reassert a model on resume
-// and either break a thread created with an override or fail auth on
-// ChatGPT-tier Codex if the new model isn't available there. A resumed thread
-// keeps whatever model it was started with.
+// @openai/codex-sdk/dist/index.js:170), which would turn a resume into an
+// explicit model override and may fail auth on ChatGPT-tier Codex. The bridge
+// retains the prior resolved identity separately and reports any different
+// runtime-observed label instead of hiding the mismatch.
 function baseThreadOpts(config: ReviewBridgeConfig) {
   return {
     sandboxMode: 'read-only' as const,
@@ -187,13 +200,36 @@ function resumeThreadOpts(config: ReviewBridgeConfig) {
 async function runReview<T extends Record<string, unknown>>(
   params: TurnParams & { codex: Codex; config: ReviewBridgeConfig },
 ): Promise<Result<T & { session_id: string }>> {
-  const { codex, config, prompt, responseSchema, sessionId, model, resolvedModel } = params;
+  const {
+    codex,
+    config,
+    prompt,
+    responseSchema,
+    sessionId: rawSessionId,
+    model,
+    resolvedModel,
+  } = params;
+  let sessionId: string | undefined;
+  if (rawSessionId !== undefined) {
+    const parsedSessionId = SessionIdSchema.safeParse(rawSessionId);
+    if (!parsedSessionId.success) {
+      return err(`${ErrorCode.INVALID_INPUT}: invalid session ID`);
+    }
+    sessionId = parsedSessionId.data;
+  }
+  const startModel = model ?? resolvedModel;
+  if (!sessionId && !startModel) {
+    return err(`${ErrorCode.MODEL_ERROR}: no model was resolved for a fresh Codex session`);
+  }
 
   let thread;
   try {
-    thread = sessionId
-      ? codex.resumeThread(sessionId, resumeThreadOpts(config))
-      : codex.startThread(startThreadOpts(config, model ?? resolvedModel));
+    if (sessionId) {
+      thread = codex.resumeThread(sessionId, resumeThreadOpts(config));
+    } else {
+      if (!startModel) return err(`${ErrorCode.MODEL_ERROR}: no model was resolved`);
+      thread = codex.startThread(startThreadOpts(config, startModel));
+    }
   } catch (e: unknown) {
     if (sessionId) {
       const msg = e instanceof Error ? e.message : String(e);
@@ -224,8 +260,8 @@ async function runReview<T extends Record<string, unknown>>(
         const tokenEst = estimateTokens(prompt);
         return err(
           `${ErrorCode.REVIEW_TIMEOUT}: review timed out after ${config.timeout_seconds}s ` +
-          `(prompt ~${tokenEst} tokens). ` +
-          `Try: increase timeout_seconds in .reviewbridge.json, reduce diff size, or check input format.`,
+            `(prompt ~${tokenEst} tokens). ` +
+            `Try: increase timeout_seconds in .reviewbridge.json, reduce diff size, or check input format.`,
         );
       }
       const classified = classifyError(e, { model: resolvedModel });
@@ -247,12 +283,18 @@ async function runReview<T extends Record<string, unknown>>(
     }
 
     const resolvedId = thread.id ?? sessionId;
-    if (!resolvedId) {
+    if (resolvedId === undefined || resolvedId === null) {
       return err(`${ErrorCode.RESPONSE_PARSE_ERROR}: missing session ID after successful review`);
+    }
+    const parsedSessionId = SessionIdSchema.safeParse(resolvedId);
+    if (!parsedSessionId.success) {
+      return err(
+        `${ErrorCode.RESPONSE_PARSE_ERROR}: provider returned an invalid session ID after successful review`,
+      );
     }
     // Single cast justified: safeParse validated result.data matches the schema
     const validated = result.data as T;
-    return ok({ ...validated, session_id: resolvedId });
+    return ok({ ...validated, session_id: parsedSessionId.data });
   }
 
   return err(`${ErrorCode.RESPONSE_PARSE_ERROR}: ${lastError}`);
@@ -261,6 +303,7 @@ async function runReview<T extends Record<string, unknown>>(
 export function createCodexBackend(
   config: ReviewBridgeConfig,
   copilotInstructions?: CopilotInstructions,
+  runtime: CodexBackendDependencies = {},
 ): ReviewBackend {
   // Point the SDK at an explicit codex binary when configured (config.codex_path,
   // then the CODEX_PATH env). Escape hatch for a missing/unusable bundled binary
@@ -303,7 +346,7 @@ export function createCodexBackend(
         codex = new Codex({ codexPathOverride: found });
         console.error(
           `[codex-bridge] bundled codex binary is unusable (macOS XProtect may have quarantined it); ` +
-            `using discovered ${found}. Pin it explicitly with "codex_path" in .reviewbridge.json to silence this.`,
+            `using discovered ${escapeTerminalControls(found)}. Pin it explicitly with "codex_path" in .reviewbridge.json to silence this.`,
         );
         return 'recovered';
       } catch {
@@ -326,10 +369,13 @@ export function createCodexBackend(
     }
     return result;
   };
-  // Codex's SDK reasserts --model on resume, so the model cannot change
-  // mid-session: reject session_id + model and omit the model on resumed chunks.
+  // Codex's SDK reasserts --model when supplied on resume, so callers cannot
+  // request a model change mid-session. Omit it and let evidence metadata expose
+  // whether the runtime actually retained or changed the recorded label.
+  const sessionObserver = createCodexSessionObserver();
   const deps = {
     config,
+    provider: 'codex' as const,
     copilotInstructions,
     allowsModelOverrideOnResume: false,
     // 'latest' (and unset) → the latest model the SDK-PINNED binary supports. We
@@ -338,6 +384,10 @@ export function createCodexBackend(
     // moves. An explicit pin is forwarded unchanged (L-006).
     resolveModel: async (requested: string | undefined) =>
       requested && requested !== 'latest' ? requested : CODEX_DEFAULT_MODEL,
+    lookupSessionModel: runtime.lookupSessionModel,
+    observeSessionModel:
+      runtime.observeSessionModel ??
+      (async (sessionId: string) => (await sessionObserver.observe(sessionId))?.model),
     // One Codex thread per review: chunks 2..N resume chunk 1's thread.
     resumesAcrossChunks: true,
   };

--- a/src/backends/composite.test.ts
+++ b/src/backends/composite.test.ts
@@ -3,10 +3,12 @@ import { resolveMode, createCompositeBackend, withSingleMode } from './composite
 import { ok } from '../utils/errors.js';
 import { ErrorCode } from '../utils/errors.js';
 import { DEFAULT_CONFIG } from '../config/types.js';
-import type { ReviewBackend } from './backend.js';
+import { canOverrideModelOnResume, type ReviewBackend } from './backend.js';
 import type { ReviewProvider } from '../config/types.js';
 
-type Methods = Partial<Pick<ReviewBackend, 'reviewPlan' | 'reviewCode' | 'reviewPrecommit' | 'crossReview'>>;
+type Methods = Partial<
+  Pick<ReviewBackend, 'reviewPlan' | 'reviewCode' | 'reviewPrecommit' | 'crossReview'>
+>;
 function backend(provider: ReviewProvider, methods: Methods = {}): ReviewBackend {
   return {
     provider,
@@ -61,7 +63,10 @@ describe('createCompositeBackend — per-call dispatch + review_mode stamping', 
   it('deliberate:true on a failover config runs deliberation and stamps review_mode:deliberate', async () => {
     const p = backend('codex');
     const s = backend('gemini');
-    const res = await createCompositeBackend(p, s, cfg({ mode: 'failover' })).reviewCode({ diff: DIFF, deliberate: true });
+    const res = await createCompositeBackend(p, s, cfg({ mode: 'failover' })).reviewCode({
+      diff: DIFF,
+      deliberate: true,
+    });
     expect(res.ok).toBe(true);
     if (!res.ok) return;
     expect(res.data.review_mode).toBe('deliberate');
@@ -72,7 +77,10 @@ describe('createCompositeBackend — per-call dispatch + review_mode stamping', 
   it('deliberate:false on a deliberate config runs failover and stamps review_mode:failover', async () => {
     const p = backend('codex');
     const s = backend('gemini');
-    const res = await createCompositeBackend(p, s, cfg({ mode: 'deliberate' })).reviewCode({ diff: DIFF, deliberate: false });
+    const res = await createCompositeBackend(p, s, cfg({ mode: 'deliberate' })).reviewCode({
+      diff: DIFF,
+      deliberate: false,
+    });
     expect(res.ok).toBe(true);
     if (!res.ok) return;
     expect(res.data.review_mode).toBe('failover');
@@ -81,24 +89,58 @@ describe('createCompositeBackend — per-call dispatch + review_mode stamping', 
   });
 
   it('no toggle uses the config mode (deliberate-deep stamps deliberate-deep)', async () => {
-    const res = await createCompositeBackend(backend('codex'), backend('gemini'), cfg({ mode: 'deliberate-deep' })).reviewCode({ diff: DIFF });
+    const res = await createCompositeBackend(
+      backend('codex'),
+      backend('gemini'),
+      cfg({ mode: 'deliberate-deep' }),
+    ).reviewCode({ diff: DIFF });
     expect(res.ok && res.data.review_mode).toBe('deliberate-deep');
   });
 
   it('reviewPlan stamps the mode too', async () => {
-    const res = await createCompositeBackend(backend('codex'), backend('gemini'), cfg({ mode: 'failover' })).reviewPlan({ plan: 'p' });
+    const res = await createCompositeBackend(
+      backend('codex'),
+      backend('gemini'),
+      cfg({ mode: 'failover' }),
+    ).reviewPlan({ plan: 'p' });
     expect(res.ok && res.data.review_mode).toBe('failover');
   });
 
   it('reviewPrecommit always runs failover and stamps failover', async () => {
-    const res = await createCompositeBackend(backend('codex'), backend('gemini'), cfg({ mode: 'deliberate' })).reviewPrecommit({ diff: DIFF });
+    const res = await createCompositeBackend(
+      backend('codex'),
+      backend('gemini'),
+      cfg({ mode: 'deliberate' }),
+    ).reviewPrecommit({ diff: DIFF });
     expect(res.ok && res.data.review_mode).toBe('failover');
   });
 
   it('exposes both providers on the composite', () => {
-    const c = createCompositeBackend(backend('codex'), backend('gemini'), cfg({ mode: 'failover' }));
+    const c = createCompositeBackend(
+      backend('codex'),
+      backend('gemini'),
+      cfg({ mode: 'failover' }),
+    );
     expect(c.providers).toEqual(['codex', 'gemini']);
     expect(c.provider).toBe('codex');
+  });
+
+  it('exposes each owning leaf model-override capability independent of primary order', () => {
+    const codexPrimary = createCompositeBackend(
+      backend('codex'),
+      backend('gemini'),
+      cfg({ mode: 'failover' }),
+    );
+    const geminiPrimary = createCompositeBackend(
+      backend('gemini'),
+      backend('codex'),
+      cfg({ mode: 'failover' }),
+    );
+
+    expect(canOverrideModelOnResume(codexPrimary, 'codex')).toBe(false);
+    expect(canOverrideModelOnResume(codexPrimary, 'gemini')).toBe(true);
+    expect(canOverrideModelOnResume(geminiPrimary, 'codex')).toBe(false);
+    expect(canOverrideModelOnResume(geminiPrimary, 'gemini')).toBe(true);
   });
 });
 
@@ -142,14 +184,22 @@ describe('withSingleMode', () => {
 describe('createCompositeBackend — defensive single-mode handling', () => {
   it('runs the primary and stamps single when the config is single', async () => {
     const s = backend('gemini');
-    const res = await createCompositeBackend(backend('codex'), s, cfg({ mode: 'single' })).reviewCode({ diff: DIFF });
+    const res = await createCompositeBackend(
+      backend('codex'),
+      s,
+      cfg({ mode: 'single' }),
+    ).reviewCode({ diff: DIFF });
     expect(res.ok && res.data.review_mode).toBe('single');
     expect(res.ok && res.data.provider).toBe('codex'); // ISS-023
     expect(s.reviewCode).not.toHaveBeenCalled(); // no second provider
   });
 
   it('rejects deliberate:true under a single config with INVALID_INPUT', async () => {
-    const res = await createCompositeBackend(backend('codex'), backend('gemini'), cfg({ mode: 'single' })).reviewPlan({ plan: 'p', deliberate: true });
+    const res = await createCompositeBackend(
+      backend('codex'),
+      backend('gemini'),
+      cfg({ mode: 'single' }),
+    ).reviewPlan({ plan: 'p', deliberate: true });
     expect(res.ok).toBe(false);
     if (!res.ok) expect(res.error).toContain(ErrorCode.INVALID_INPUT);
   });

--- a/src/backends/composite.ts
+++ b/src/backends/composite.ts
@@ -11,6 +11,20 @@ import type {
   CodeReviewInput,
   PrecommitReviewInput,
 } from './backend.js';
+import { canOverrideModelOnResume } from './backend.js';
+
+function ownerOverrideCapability(
+  primary: ReviewBackend,
+  secondary: ReviewBackend,
+  provider: ReviewProvider,
+): boolean {
+  const owner = primary.providers.includes(provider)
+    ? primary
+    : secondary.providers.includes(provider)
+      ? secondary
+      : null;
+  return owner ? canOverrideModelOnResume(owner, provider) : false;
+}
 
 // The mode a review actually runs in. 'single-deliberate-conflict' is a sentinel
 // the single-mode decorator turns into an INVALID_INPUT error (deliberation asked
@@ -26,7 +40,9 @@ export type EffectiveMode =
 type ReviewMode = 'single' | 'failover' | 'deliberate' | 'deliberate-deep';
 
 // Config-level mode, before any per-call override.
-function configMode(config: ReviewBridgeConfig): 'single' | 'failover' | 'deliberate' | 'deliberate-deep' {
+function configMode(
+  config: ReviewBridgeConfig,
+): 'single' | 'failover' | 'deliberate' | 'deliberate-deep' {
   return config.mode ?? (config.fallback ? 'failover' : 'single');
 }
 
@@ -74,6 +90,7 @@ export function withSingleMode(primary: ReviewBackend): ReviewBackend {
     provider: primary.provider,
     providers: primary.providers,
     allowsModelOverrideOnResume: primary.allowsModelOverrideOnResume,
+    allowsModelOverrideOnResumeFor: (provider) => canOverrideModelOnResume(primary, provider),
     reviewPlan: async (input: PlanReviewInput) => {
       if (input.deliberate === true) return err<PlanReviewResult>(singleModeConflictError());
       return stamp('single', await primary.reviewPlan(input), primary.provider);
@@ -104,29 +121,64 @@ export function createCompositeBackend(
     provider: primary.provider,
     providers: [...primary.providers, ...secondary.providers],
     allowsModelOverrideOnResume: primary.allowsModelOverrideOnResume,
+    allowsModelOverrideOnResumeFor: (provider) =>
+      ownerOverrideCapability(primary, secondary, provider),
     reviewPlan: async (input: PlanReviewInput) => {
       const mode = resolveMode(cfgMode, input.deliberate);
       // cfgMode is never 'single' when this composite is built (createBackend
       // returns withSingleMode instead), but handle those returns defensively so
       // the exported factory is correct in isolation.
-      if (mode === 'single-deliberate-conflict') return err<PlanReviewResult>(singleModeConflictError());
-      if (mode === 'single') return stamp('single', await primary.reviewPlan(input), primary.provider);
+      if (mode === 'single-deliberate-conflict')
+        return err<PlanReviewResult>(singleModeConflictError());
+      if (mode === 'single')
+        return stamp('single', await primary.reviewPlan(input), primary.provider);
       if (mode === 'deliberate' || mode === 'deliberate-deep') {
-        return stamp(mode, await deliberatePlan(primary, secondary, input, mode === 'deliberate-deep', lookup, config.max_chunk_tokens));
+        return stamp(
+          mode,
+          await deliberatePlan(
+            primary,
+            secondary,
+            input,
+            mode === 'deliberate-deep',
+            lookup,
+            config.max_chunk_tokens,
+          ),
+        );
       }
-      return stamp('failover', await withFailover(primary, secondary, input, (b, i) => b.reviewPlan(i), lookup));
+      return stamp(
+        'failover',
+        await withFailover(primary, secondary, input, (b, i) => b.reviewPlan(i), lookup),
+      );
     },
     reviewCode: async (input: CodeReviewInput) => {
       const mode = resolveMode(cfgMode, input.deliberate);
-      if (mode === 'single-deliberate-conflict') return err<CodeReviewResult>(singleModeConflictError());
-      if (mode === 'single') return stamp('single', await primary.reviewCode(input), primary.provider);
+      if (mode === 'single-deliberate-conflict')
+        return err<CodeReviewResult>(singleModeConflictError());
+      if (mode === 'single')
+        return stamp('single', await primary.reviewCode(input), primary.provider);
       if (mode === 'deliberate' || mode === 'deliberate-deep') {
-        return stamp(mode, await deliberateCode(primary, secondary, input, mode === 'deliberate-deep', lookup, config.max_chunk_tokens));
+        return stamp(
+          mode,
+          await deliberateCode(
+            primary,
+            secondary,
+            input,
+            mode === 'deliberate-deep',
+            lookup,
+            config.max_chunk_tokens,
+          ),
+        );
       }
-      return stamp('failover', await withFailover(primary, secondary, input, (b, i) => b.reviewCode(i), lookup));
+      return stamp(
+        'failover',
+        await withFailover(primary, secondary, input, (b, i) => b.reviewCode(i), lookup),
+      );
     },
     // Precommit is always failover — it runs constantly and is latency-sensitive.
     reviewPrecommit: async (input: PrecommitReviewInput) =>
-      stamp('failover', await withFailover(primary, secondary, input, (b, i) => b.reviewPrecommit(i), lookup)),
+      stamp(
+        'failover',
+        await withFailover(primary, secondary, input, (b, i) => b.reviewPrecommit(i), lookup),
+      ),
   };
 }

--- a/src/backends/deliberation.test.ts
+++ b/src/backends/deliberation.test.ts
@@ -36,12 +36,31 @@ const codeResult = (verdict: string, findings: ReturnType<typeof f>[], session_i
   findings,
   session_id,
 });
+const model = (provider: ReviewProvider, role: 'review' | 'adjudication' = 'review') => ({
+  provider,
+  role,
+  requested: null,
+  resolved: provider === 'codex' ? 'gpt-5.6-sol' : 'Gemini 3.5 Flash (High)',
+  observed: provider === 'codex' ? 'gpt-5.6-sol' : null,
+  evidence:
+    provider === 'codex' ? ('runtime_session_record' as const) : ('bridge_selection' as const),
+});
 const DIFF = 'diff --git a/f b/f\n@@ -1 +1 @@\n-a\n+b';
+const REJECTED_PROVIDER_ERROR = `${ErrorCode.UNKNOWN_ERROR}: provider call failed unexpectedly`;
+const PRIVATE_REJECTION = new Error(
+  'provider exploded at /Users/alice/private/reviewer.ts\nsecret=super-secret',
+);
 
 describe('computeAgreement', () => {
   it('splits findings into agreed (both flagged) and divergent (one flagged / keyless)', () => {
-    const a = { provider: 'codex' as const, findings: [f('a.ts', 1, 'security', 'major'), f(null, null, 'style', 'minor')] };
-    const b = { provider: 'gemini' as const, findings: [f('a.ts', 1, 'security', 'critical'), f('b.ts', 2, 'perf', 'major')] };
+    const a = {
+      provider: 'codex' as const,
+      findings: [f('a.ts', 1, 'security', 'major'), f(null, null, 'style', 'minor')],
+    };
+    const b = {
+      provider: 'gemini' as const,
+      findings: [f('a.ts', 1, 'security', 'critical'), f('b.ts', 2, 'perf', 'major')],
+    };
 
     const { agreed, divergent } = computeAgreement(a, b, rank);
 
@@ -57,7 +76,10 @@ describe('computeAgreement', () => {
     // Surfaced by deliberating on this feature's own code: same-key dupes from one
     // provider must collapse to the higher severity, not the last-seen.
     const { agreed, divergent } = computeAgreement(
-      { provider: 'codex', findings: [f('a.ts', 1, 'security', 'minor'), f('a.ts', 1, 'security', 'critical')] },
+      {
+        provider: 'codex',
+        findings: [f('a.ts', 1, 'security', 'minor'), f('a.ts', 1, 'security', 'critical')],
+      },
       { provider: 'gemini', findings: [] },
       rank,
     );
@@ -113,7 +135,10 @@ describe('computeAgreement', () => {
     const { agreed, divergent } = computeAgreement(
       {
         provider: 'codex',
-        findings: [f('payment.js', 17, 'security', 'critical'), f('payment.js', 17, 'error handling', 'major')],
+        findings: [
+          f('payment.js', 17, 'security', 'critical'),
+          f('payment.js', 17, 'error handling', 'major'),
+        ],
       },
       { provider: 'gemini', findings: [f('payment.js', 17, 'Security', 'critical')] },
       rank,
@@ -138,7 +163,10 @@ describe('computeAgreement', () => {
       },
       {
         provider: 'gemini',
-        findings: [f('payment.js', 17, 'security', 'critical'), f('payment.js', 17, 'error handling', 'major')],
+        findings: [
+          f('payment.js', 17, 'security', 'critical'),
+          f('payment.js', 17, 'error handling', 'major'),
+        ],
       },
       rank,
     );
@@ -190,11 +218,29 @@ describe('computeAgreement', () => {
 });
 
 describe('createDeliberationBackend', () => {
+  it('orders and preserves both successful reviewer model identities', async () => {
+    const primaryResult = { ...codeResult('approve', [], 'cdx'), models: [model('codex')] };
+    const secondaryResult = { ...codeResult('approve', [], 'gem'), models: [model('gemini')] };
+    const primary = backend('codex', {
+      reviewCode: vi.fn().mockResolvedValue(ok(primaryResult)),
+    });
+    const secondary = backend('gemini', {
+      reviewCode: vi.fn().mockResolvedValue(ok(secondaryResult)),
+    });
+
+    const res = await createDeliberationBackend(primary, secondary).reviewCode({ diff: DIFF });
+
+    expect(res.ok && res.data.models).toEqual([model('codex'), model('gemini')]);
+  });
   it('both agree → agreement "agree", agreed populated, divergent empty, verdicts per provider', async () => {
     const shared = [f('a.ts', 1, 'security', 'major')];
-    const primary = backend('codex', { reviewCode: vi.fn().mockResolvedValue(ok(codeResult('approve', shared, 'cdx'))) });
+    const primary = backend('codex', {
+      reviewCode: vi.fn().mockResolvedValue(ok(codeResult('approve', shared, 'cdx'))),
+    });
     const secondary = backend('gemini', {
-      reviewCode: vi.fn().mockResolvedValue(ok(codeResult('approve', [f('a.ts', 1, 'security', 'major')], 'gem'))),
+      reviewCode: vi
+        .fn()
+        .mockResolvedValue(ok(codeResult('approve', [f('a.ts', 1, 'security', 'major')], 'gem'))),
     });
 
     const res = await createDeliberationBackend(primary, secondary).reviewCode({ diff: DIFF });
@@ -214,10 +260,28 @@ describe('createDeliberationBackend', () => {
 
   it('partial overlap → agreement "mixed", one-sided findings are divergent', async () => {
     const primary = backend('codex', {
-      reviewCode: vi.fn().mockResolvedValue(ok(codeResult('request_changes', [f('a.ts', 1, 'security', 'critical'), f('a.ts', 5, 'bugs', 'major')]))),
+      reviewCode: vi
+        .fn()
+        .mockResolvedValue(
+          ok(
+            codeResult('request_changes', [
+              f('a.ts', 1, 'security', 'critical'),
+              f('a.ts', 5, 'bugs', 'major'),
+            ]),
+          ),
+        ),
     });
     const secondary = backend('gemini', {
-      reviewCode: vi.fn().mockResolvedValue(ok(codeResult('request_changes', [f('a.ts', 1, 'security', 'critical'), f('b.ts', 2, 'perf', 'minor')]))),
+      reviewCode: vi
+        .fn()
+        .mockResolvedValue(
+          ok(
+            codeResult('request_changes', [
+              f('a.ts', 1, 'security', 'critical'),
+              f('b.ts', 2, 'perf', 'minor'),
+            ]),
+          ),
+        ),
     });
 
     const res = await createDeliberationBackend(primary, secondary).reviewCode({ diff: DIFF });
@@ -233,8 +297,12 @@ describe('createDeliberationBackend', () => {
   });
 
   it('conflicting verdicts → agreement "conflict"; top-level verdict is the worst', async () => {
-    const primary = backend('codex', { reviewCode: vi.fn().mockResolvedValue(ok(codeResult('approve', []))) });
-    const secondary = backend('gemini', { reviewCode: vi.fn().mockResolvedValue(ok(codeResult('reject', []))) });
+    const primary = backend('codex', {
+      reviewCode: vi.fn().mockResolvedValue(ok(codeResult('approve', []))),
+    });
+    const secondary = backend('gemini', {
+      reviewCode: vi.fn().mockResolvedValue(ok(codeResult('reject', []))),
+    });
 
     const res = await createDeliberationBackend(primary, secondary).reviewCode({ diff: DIFF });
 
@@ -248,15 +316,24 @@ describe('createDeliberationBackend', () => {
   it('runs both providers in parallel (both review methods called once)', async () => {
     const pReview = vi.fn().mockResolvedValue(ok(codeResult('approve', [])));
     const sReview = vi.fn().mockResolvedValue(ok(codeResult('approve', [])));
-    await createDeliberationBackend(backend('codex', { reviewCode: pReview }), backend('gemini', { reviewCode: sReview })).reviewCode({ diff: DIFF });
+    await createDeliberationBackend(
+      backend('codex', { reviewCode: pReview }),
+      backend('gemini', { reviewCode: sReview }),
+    ).reviewCode({ diff: DIFF });
     expect(pReview).toHaveBeenCalledOnce();
     expect(sReview).toHaveBeenCalledOnce();
     expect(sReview).toHaveBeenCalledWith(expect.objectContaining({ model: undefined })); // secondary model cleared
   });
 
   it('degrades to the survivor + a `degraded` marker when one provider fails', async () => {
-    const primary = backend('codex', { reviewCode: vi.fn().mockResolvedValue(err(`${ErrorCode.RATE_LIMITED}: out of usage`)) });
-    const secondary = backend('gemini', { reviewCode: vi.fn().mockResolvedValue(ok(codeResult('reject', [f('a.ts', 1, 'security', 'critical')], 'gem'))) });
+    const primary = backend('codex', {
+      reviewCode: vi.fn().mockResolvedValue(err(`${ErrorCode.RATE_LIMITED}: out of usage`)),
+    });
+    const secondary = backend('gemini', {
+      reviewCode: vi
+        .fn()
+        .mockResolvedValue(ok(codeResult('reject', [f('a.ts', 1, 'security', 'critical')], 'gem'))),
+    });
 
     const res = await createDeliberationBackend(primary, secondary).reviewCode({ diff: DIFF });
 
@@ -264,16 +341,140 @@ describe('createDeliberationBackend', () => {
     if (res.ok) {
       expect(res.data.provider).toBe('gemini'); // survivor
       expect(res.data.verdict).toBe('reject');
-      expect(res.data.deliberation?.degraded).toEqual({ failed: 'codex', reason: expect.stringContaining('RATE_LIMITED') });
+      expect(res.data.deliberation?.degraded).toEqual({
+        failed: 'codex',
+        reason: expect.stringContaining('RATE_LIMITED'),
+      });
       expect(res.data.deliberation?.providers).toEqual(['gemini']);
       // ISS-016: a single-provider degraded result must NOT claim 'agree'.
       expect(res.data.deliberation?.agreement).toBe('degraded');
     }
   });
 
+  it('fresh code: sanitizes a rejected reviewer promise and preserves the successful peer', async () => {
+    const survivor = {
+      ...codeResult('approve', [], 'codex-session'),
+      models: [model('codex')],
+    };
+    const primary = backend('codex', {
+      reviewCode: vi.fn().mockResolvedValue(ok(survivor)),
+    });
+    const secondary = backend('gemini', {
+      reviewCode: vi.fn().mockRejectedValue(PRIVATE_REJECTION),
+    });
+
+    const result = await createDeliberationBackend(primary, secondary).reviewCode({ diff: DIFF });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.session_id).toBe('codex-session');
+    expect(result.data.models).toEqual([model('codex')]);
+    expect(result.data.deliberation?.degraded).toEqual({
+      failed: 'gemini',
+      reason: REJECTED_PROVIDER_ERROR,
+    });
+    expect(result.data.deliberation?.degraded?.reason).not.toContain('/Users/alice');
+    expect(result.data.deliberation?.degraded?.reason).not.toContain('super-secret');
+  });
+
+  it('resumed code: sanitizes a rejected owner promise and preserves the fresh peer', async () => {
+    const primary = backend('codex', {
+      reviewCode: vi.fn().mockRejectedValue(PRIVATE_REJECTION),
+    });
+    const survivor = {
+      ...codeResult('approve', [], 'gemini-fresh'),
+      models: [model('gemini')],
+    };
+    const secondary = backend('gemini', {
+      reviewCode: vi.fn().mockResolvedValue(ok(survivor)),
+    });
+
+    const result = await createDeliberationBackend(primary, secondary).reviewCode({
+      diff: DIFF,
+      session_id: 'codex-resumed',
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.session_id).toBe('gemini-fresh');
+    expect(result.data.models).toEqual([model('gemini')]);
+    expect(result.data.deliberation?.degraded).toEqual({
+      failed: 'codex',
+      reason: REJECTED_PROVIDER_ERROR,
+    });
+    expect(result.data.deliberation?.degraded?.reason).not.toContain('/Users/alice');
+    expect(result.data.deliberation?.degraded?.reason).not.toContain('super-secret');
+  });
+
+  it('fresh plan: sanitizes a rejected reviewer promise and preserves the successful peer', async () => {
+    const survivor = {
+      verdict: 'approve' as const,
+      summary: 'safe plan',
+      findings: [],
+      session_id: 'gemini-plan',
+      models: [model('gemini')],
+    };
+    const primary = backend('codex', {
+      reviewPlan: vi.fn().mockRejectedValue(PRIVATE_REJECTION),
+    });
+    const secondary = backend('gemini', {
+      reviewPlan: vi.fn().mockResolvedValue(ok(survivor)),
+    });
+
+    const result = await createDeliberationBackend(primary, secondary).reviewPlan({ plan: 'plan' });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.session_id).toBe('gemini-plan');
+    expect(result.data.models).toEqual([model('gemini')]);
+    expect(result.data.deliberation?.degraded).toEqual({
+      failed: 'codex',
+      reason: REJECTED_PROVIDER_ERROR,
+    });
+    expect(result.data.deliberation?.degraded?.reason).not.toContain('/Users/alice');
+    expect(result.data.deliberation?.degraded?.reason).not.toContain('super-secret');
+  });
+
+  it('resumed plan: sanitizes a rejected fresh-peer promise and preserves the owner', async () => {
+    const primary = backend('codex', {
+      reviewPlan: vi.fn().mockRejectedValue(PRIVATE_REJECTION),
+    });
+    const survivor = {
+      verdict: 'approve' as const,
+      summary: 'owner plan',
+      findings: [],
+      session_id: 'gemini-resumed',
+      models: [model('gemini')],
+    };
+    const secondary = backend('gemini', {
+      reviewPlan: vi.fn().mockResolvedValue(ok(survivor)),
+    });
+    const lookup = vi.fn().mockReturnValue({ status: 'found', value: 'gemini' });
+
+    const result = await createDeliberationBackend(primary, secondary, { lookup }).reviewPlan({
+      plan: 'plan',
+      session_id: 'gemini-resumed',
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.session_id).toBe('gemini-resumed');
+    expect(result.data.models).toEqual([model('gemini')]);
+    expect(result.data.deliberation?.degraded).toEqual({
+      failed: 'codex',
+      reason: REJECTED_PROVIDER_ERROR,
+    });
+    expect(result.data.deliberation?.degraded?.reason).not.toContain('/Users/alice');
+    expect(result.data.deliberation?.degraded?.reason).not.toContain('super-secret');
+  });
+
   it('returns a combined error when both providers fail', async () => {
-    const primary = backend('codex', { reviewCode: vi.fn().mockResolvedValue(err(`${ErrorCode.RATE_LIMITED}: usage`)) });
-    const secondary = backend('gemini', { reviewCode: vi.fn().mockResolvedValue(err(`${ErrorCode.AUTH_ERROR}: not signed in`)) });
+    const primary = backend('codex', {
+      reviewCode: vi.fn().mockResolvedValue(err(`${ErrorCode.RATE_LIMITED}: usage`)),
+    });
+    const secondary = backend('gemini', {
+      reviewCode: vi.fn().mockResolvedValue(err(`${ErrorCode.AUTH_ERROR}: not signed in`)),
+    });
 
     const res = await createDeliberationBackend(primary, secondary).reviewCode({ diff: DIFF });
 
@@ -315,19 +516,101 @@ describe('createDeliberationBackend', () => {
     const sReview = vi.fn().mockResolvedValue(ok(codeResult('approve', [], 'gemini-sess')));
     const primary = backend('codex', { reviewCode: pReview });
     const secondary = backend('gemini', { reviewCode: sReview });
-    const lookup = vi.fn().mockReturnValue('gemini');
+    const lookup = vi.fn().mockReturnValue({ status: 'found', value: 'gemini' });
 
     const res = await createDeliberationBackend(primary, secondary, { lookup }).reviewCode({
       diff: DIFF,
       session_id: 'gemini-sess',
+      model: 'Gemini 3.1 Pro (High)',
     });
 
     expect(lookup).toHaveBeenCalledWith('gemini-sess');
-    expect(sReview).toHaveBeenCalledWith(expect.objectContaining({ session_id: 'gemini-sess' })); // owner resumes
-    expect(pReview).toHaveBeenCalledWith(expect.objectContaining({ session_id: undefined })); // primary fresh
+    expect(sReview).toHaveBeenCalledWith(
+      expect.objectContaining({
+        session_id: 'gemini-sess',
+        model: 'Gemini 3.1 Pro (High)',
+      }),
+    ); // owner resumes with its override
+    expect(pReview).toHaveBeenCalledWith(
+      expect.objectContaining({ session_id: undefined, model: undefined }),
+    ); // primary fresh on its own default
     expect(res.ok && res.data.provider).toBe('codex'); // composite presents as primary
     expect(res.ok && res.data.session_id).toBe('gemini-sess'); // combined = resumed owner session
     expect(res.ok && res.data.deliberation).toBeDefined();
+  });
+
+  it('deliberate plan resume applies the model override to a secondary owner, not the fresh primary', async () => {
+    const primaryReview = vi.fn().mockResolvedValue(
+      ok({
+        verdict: 'approve' as const,
+        summary: 'fresh',
+        findings: [],
+        session_id: 'codex-fresh',
+      }),
+    );
+    const secondaryReview = vi.fn().mockResolvedValue(
+      ok({
+        verdict: 'approve' as const,
+        summary: 'owner',
+        findings: [],
+        session_id: 'gemini-sess',
+      }),
+    );
+    const lookup = vi.fn().mockReturnValue({ status: 'found', value: 'gemini' });
+
+    await createDeliberationBackend(
+      backend('codex', { reviewPlan: primaryReview }),
+      backend('gemini', { reviewPlan: secondaryReview }),
+      { lookup },
+    ).reviewPlan({
+      plan: 'plan',
+      session_id: 'gemini-sess',
+      model: 'Gemini 3.1 Pro (High)',
+    });
+
+    expect(secondaryReview).toHaveBeenCalledWith(
+      expect.objectContaining({
+        session_id: 'gemini-sess',
+        model: 'Gemini 3.1 Pro (High)',
+      }),
+    );
+    expect(primaryReview).toHaveBeenCalledWith(
+      expect.objectContaining({ session_id: undefined, model: undefined }),
+    );
+  });
+
+  it('rejects a model override for a resumed Codex owner before either reviewer runs', async () => {
+    const primaryReview = vi.fn();
+    const secondaryReview = vi.fn();
+    const lookup = vi.fn().mockReturnValue({ status: 'found', value: 'codex' });
+
+    const result = await createDeliberationBackend(
+      backend('codex', { reviewCode: primaryReview }),
+      backend('gemini', { reviewCode: secondaryReview }),
+      { lookup },
+    ).reviewCode({ diff: DIFF, session_id: 'codex-session', model: 'gpt-5.5' });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain('Cannot change model on a resumed session');
+    expect(primaryReview).not.toHaveBeenCalled();
+    expect(secondaryReview).not.toHaveBeenCalled();
+  });
+
+  it('does not call either reviewer when resume ownership is unavailable', async () => {
+    const pReview = vi.fn();
+    const sReview = vi.fn();
+    const lookup = vi.fn().mockReturnValue({ status: 'unavailable' });
+
+    const res = await createDeliberationBackend(
+      backend('codex', { reviewCode: pReview }),
+      backend('gemini', { reviewCode: sReview }),
+      { lookup },
+    ).reviewCode({ diff: DIFF, session_id: 'unknown-owner' });
+
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toMatch(/^SESSION_ROUTING_UNAVAILABLE:/);
+    expect(pReview).not.toHaveBeenCalled();
+    expect(sReview).not.toHaveBeenCalled();
   });
 
   it('deliberate-on-resume: if the owner fails, degrade to the fresh other leaf with its NEW session id', async () => {
@@ -339,13 +622,19 @@ describe('createDeliberationBackend', () => {
     const primary = backend('codex', { reviewCode: pReview });
     const secondary = backend('gemini', { reviewCode: sReview });
 
-    const res = await createDeliberationBackend(primary, secondary).reviewCode({ diff: DIFF, session_id: 'codex-sess' });
+    const res = await createDeliberationBackend(primary, secondary).reviewCode({
+      diff: DIFF,
+      session_id: 'codex-sess',
+    });
 
     expect(res.ok).toBe(true);
     if (!res.ok) return;
     expect(res.data.provider).toBe('gemini'); // survivor
     expect(res.data.session_id).toBe('gem-fresh'); // fresh NEW session, not the dead 'codex-sess'
-    expect(res.data.deliberation?.degraded).toEqual({ failed: 'codex', reason: expect.stringContaining('RATE_LIMITED') });
+    expect(res.data.deliberation?.degraded).toEqual({
+      failed: 'codex',
+      reason: expect.stringContaining('RATE_LIMITED'),
+    });
     expect(res.data.deliberation?.agreement).toBe('degraded');
   });
 
@@ -353,11 +642,18 @@ describe('createDeliberationBackend', () => {
     // Owner is the secondary (gemini) via lookup; both fail. The combined error
     // must still be primary-led and name gemini as the "also failed" side — not
     // swap them by owner/other order.
-    const primary = backend('codex', { reviewCode: vi.fn().mockResolvedValue(err(`${ErrorCode.AUTH_ERROR}: codex not signed in`)) });
-    const secondary = backend('gemini', { reviewCode: vi.fn().mockResolvedValue(err(`${ErrorCode.RATE_LIMITED}: gemini out of usage`)) });
-    const lookup = vi.fn().mockReturnValue('gemini');
+    const primary = backend('codex', {
+      reviewCode: vi.fn().mockResolvedValue(err(`${ErrorCode.AUTH_ERROR}: codex not signed in`)),
+    });
+    const secondary = backend('gemini', {
+      reviewCode: vi.fn().mockResolvedValue(err(`${ErrorCode.RATE_LIMITED}: gemini out of usage`)),
+    });
+    const lookup = vi.fn().mockReturnValue({ status: 'found', value: 'gemini' });
 
-    const res = await createDeliberationBackend(primary, secondary, { lookup }).reviewCode({ diff: DIFF, session_id: 'gemini-sess' });
+    const res = await createDeliberationBackend(primary, secondary, { lookup }).reviewCode({
+      diff: DIFF,
+      session_id: 'gemini-sess',
+    });
 
     expect(res.ok).toBe(false);
     if (!res.ok) {
@@ -371,13 +667,21 @@ describe('createDeliberationBackend', () => {
     const pre = { ready_to_commit: true, blockers: [], warnings: [], session_id: 'p' };
     const sPre = vi.fn();
     const primary = backend('codex', { reviewPrecommit: vi.fn().mockResolvedValue(ok(pre)) });
-    const res = await createDeliberationBackend(primary, backend('gemini', { reviewPrecommit: sPre })).reviewPrecommit({ diff: DIFF });
+    const res = await createDeliberationBackend(
+      primary,
+      backend('gemini', { reviewPrecommit: sPre }),
+    ).reviewPrecommit({ diff: DIFF });
     expect(res.ok).toBe(true);
     expect(sPre).not.toHaveBeenCalled(); // primary succeeded → no second call (failover semantics)
   });
 
   it('reviewPlan deliberates too', async () => {
-    const planA = { verdict: 'revise', summary: 's', findings: [f('p.ts', 1, 'feasibility', 'major')], session_id: 'a' };
+    const planA = {
+      verdict: 'revise',
+      summary: 's',
+      findings: [f('p.ts', 1, 'feasibility', 'major')],
+      session_id: 'a',
+    };
     const planB = { verdict: 'approve', summary: 's', findings: [], session_id: 'b' };
     const res = await createDeliberationBackend(
       backend('codex', { reviewPlan: vi.fn().mockResolvedValue(ok(planA)) }),
@@ -395,26 +699,89 @@ describe('createDeliberationBackend', () => {
 // A mixed code review where each provider flags one one-sided (divergent) finding:
 //   divergent[0] = codex's a.ts:5:bugs  (judged by the gemini secondary)
 //   divergent[1] = gemini's b.ts:2:perf (judged by the codex primary)
-const cross = (verdict: string, reason: string) => ({ adjudications: [{ index: 0, verdict, reason }] });
+const cross = (verdict: string, reason: string) => ({
+  adjudications: [{ index: 0, verdict, reason }],
+});
 function mixedPair(pMethods: Methods = {}, sMethods: Methods = {}) {
   const primary = backend('codex', {
-    reviewCode: vi.fn().mockResolvedValue(ok(codeResult('request_changes', [f('a.ts', 1, 'security', 'critical'), f('a.ts', 5, 'bugs', 'major')]))),
+    reviewCode: vi
+      .fn()
+      .mockResolvedValue(
+        ok(
+          codeResult('request_changes', [
+            f('a.ts', 1, 'security', 'critical'),
+            f('a.ts', 5, 'bugs', 'major'),
+          ]),
+        ),
+      ),
     ...pMethods,
   });
   const secondary = backend('gemini', {
-    reviewCode: vi.fn().mockResolvedValue(ok(codeResult('request_changes', [f('a.ts', 1, 'security', 'critical'), f('b.ts', 2, 'perf', 'minor')]))),
+    reviewCode: vi
+      .fn()
+      .mockResolvedValue(
+        ok(
+          codeResult('request_changes', [
+            f('a.ts', 1, 'security', 'critical'),
+            f('b.ts', 2, 'perf', 'minor'),
+          ]),
+        ),
+      ),
     ...sMethods,
   });
   return { primary, secondary };
 }
 
 describe('createDeliberationBackend — deliberate-deep (cross-review round)', () => {
-  it('adjudicates each provider\'s divergent findings with the OTHER provider', async () => {
+  it('appends successful adjudication identities after reviewer identities in provider order', async () => {
+    const primaryReview = {
+      ...codeResult('request_changes', [f('a.ts', 5, 'bugs', 'major')], 'cdx'),
+      models: [model('codex')],
+    };
+    const secondaryReview = {
+      ...codeResult('request_changes', [f('b.ts', 2, 'perf', 'minor')], 'gem'),
+      models: [model('gemini')],
+    };
+    const primary = backend('codex', {
+      reviewCode: vi.fn().mockResolvedValue(ok(primaryReview)),
+      crossReview: vi
+        .fn()
+        .mockResolvedValue(
+          ok({ ...cross('confirmed', 'real'), models: [model('codex', 'adjudication')] }),
+        ),
+    });
+    const secondary = backend('gemini', {
+      reviewCode: vi.fn().mockResolvedValue(ok(secondaryReview)),
+      crossReview: vi
+        .fn()
+        .mockResolvedValue(
+          ok({ ...cross('confirmed', 'real'), models: [model('gemini', 'adjudication')] }),
+        ),
+    });
+
+    const res = await createDeliberationBackend(primary, secondary, {
+      crossReview: true,
+    }).reviewCode({ diff: DIFF });
+
+    expect(res.ok && res.data.models).toEqual([
+      model('codex'),
+      model('gemini'),
+      model('codex', 'adjudication'),
+      model('gemini', 'adjudication'),
+    ]);
+  });
+
+  it("adjudicates each provider's divergent findings with the OTHER provider", async () => {
     const secReview = vi.fn().mockResolvedValue(ok(cross('confirmed', 'yes real'))); // gemini judges codex's finding
     const priReview = vi.fn().mockResolvedValue(ok(cross('disputed', 'false positive'))); // codex judges gemini's finding
-    const { primary, secondary } = mixedPair({ crossReview: priReview }, { crossReview: secReview });
+    const { primary, secondary } = mixedPair(
+      { crossReview: priReview },
+      { crossReview: secReview },
+    );
 
-    const res = await createDeliberationBackend(primary, secondary, { crossReview: true }).reviewCode({ diff: DIFF });
+    const res = await createDeliberationBackend(primary, secondary, {
+      crossReview: true,
+    }).reviewCode({ diff: DIFF });
 
     expect(res.ok).toBe(true);
     if (!res.ok) return;
@@ -425,22 +792,70 @@ describe('createDeliberationBackend — deliberate-deep (cross-review round)', (
     expect(div[0].adjudication).toEqual({ by: 'gemini', verdict: 'confirmed', reason: 'yes real' });
     // gemini's divergent finding, adjudicated by codex.
     expect(div[1].provider).toBe('gemini');
-    expect(div[1].adjudication).toEqual({ by: 'codex', verdict: 'disputed', reason: 'false positive' });
+    expect(div[1].adjudication).toEqual({
+      by: 'codex',
+      verdict: 'disputed',
+      reason: 'false positive',
+    });
     // Each judge saw the diff and only the OTHER provider's one finding.
-    expect(secReview).toHaveBeenCalledWith(expect.objectContaining({ content: DIFF, findings: [expect.objectContaining({ file: 'a.ts', line: 5 })] }));
-    expect(priReview).toHaveBeenCalledWith(expect.objectContaining({ content: DIFF, findings: [expect.objectContaining({ file: 'b.ts', line: 2 })] }));
+    expect(secReview).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: DIFF,
+        findings: [expect.objectContaining({ file: 'a.ts', line: 5 })],
+      }),
+    );
+    expect(priReview).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: DIFF,
+        findings: [expect.objectContaining({ file: 'b.ts', line: 2 })],
+      }),
+    );
   });
 
   it('ISS-014: forwards the caller model to the PRIMARY judge only', async () => {
     const secReview = vi.fn().mockResolvedValue(ok(cross('confirmed', 'r'))); // gemini judge
     const priReview = vi.fn().mockResolvedValue(ok(cross('disputed', 'r'))); // codex judge
-    const { primary, secondary } = mixedPair({ crossReview: priReview }, { crossReview: secReview });
+    const { primary, secondary } = mixedPair(
+      { crossReview: priReview },
+      { crossReview: secReview },
+    );
 
-    await createDeliberationBackend(primary, secondary, { crossReview: true }).reviewCode({ diff: DIFF, model: 'gpt-5.4' });
+    await createDeliberationBackend(primary, secondary, { crossReview: true }).reviewCode({
+      diff: DIFF,
+      model: 'gpt-5.4',
+    });
 
     // codex is the primary → its adjudication turn gets the override; gemini resolves its own default.
     expect(priReview).toHaveBeenCalledWith(expect.objectContaining({ model: 'gpt-5.4' }));
     expect(secReview).toHaveBeenCalledWith(expect.objectContaining({ model: undefined }));
+  });
+
+  it('routes a resumed secondary owner model to that provider review and adjudication turns', async () => {
+    const primaryJudge = vi.fn().mockResolvedValue(ok(cross('disputed', 'r')));
+    const secondaryJudge = vi.fn().mockResolvedValue(ok(cross('confirmed', 'r')));
+    const { primary, secondary } = mixedPair(
+      { crossReview: primaryJudge },
+      { crossReview: secondaryJudge },
+    );
+    const lookup = vi.fn().mockReturnValue({ status: 'found', value: 'gemini' });
+
+    await createDeliberationBackend(primary, secondary, {
+      crossReview: true,
+      lookup,
+    }).reviewCode({
+      diff: DIFF,
+      session_id: 'sid',
+      model: 'Gemini 3.1 Pro (High)',
+    });
+
+    expect(secondary.reviewCode).toHaveBeenCalledWith(
+      expect.objectContaining({ model: 'Gemini 3.1 Pro (High)' }),
+    );
+    expect(primary.reviewCode).toHaveBeenCalledWith(expect.objectContaining({ model: undefined }));
+    expect(secondaryJudge).toHaveBeenCalledWith(
+      expect.objectContaining({ model: 'Gemini 3.1 Pro (High)' }),
+    );
+    expect(primaryJudge).toHaveBeenCalledWith(expect.objectContaining({ model: undefined }));
   });
 
   it('ISS-012: slices the cross-review subject to the files each finding touches', async () => {
@@ -449,9 +864,14 @@ describe('createDeliberationBackend — deliberate-deep (cross-review round)', (
       'diff --git a/b.ts b/b.ts\n--- a/b.ts\n+++ b/b.ts\n@@ -1 +1 @@\n-b\n+B';
     const secReview = vi.fn().mockResolvedValue(ok(cross('confirmed', 'r'))); // judges codex's a.ts finding
     const priReview = vi.fn().mockResolvedValue(ok(cross('disputed', 'r'))); // judges gemini's b.ts finding
-    const { primary, secondary } = mixedPair({ crossReview: priReview }, { crossReview: secReview });
+    const { primary, secondary } = mixedPair(
+      { crossReview: priReview },
+      { crossReview: secReview },
+    );
 
-    await createDeliberationBackend(primary, secondary, { crossReview: true }).reviewCode({ diff: twoFile });
+    await createDeliberationBackend(primary, secondary, { crossReview: true }).reviewCode({
+      diff: twoFile,
+    });
 
     // gemini judges the a.ts finding → subject sliced to the a.ts section only.
     const secArg = secReview.mock.calls[0][0];
@@ -466,10 +886,16 @@ describe('createDeliberationBackend — deliberate-deep (cross-review round)', (
   it('ISS-012: an over-budget cross-review subject fails cleanly (cross_review_failures, no judge call)', async () => {
     const secReview = vi.fn().mockResolvedValue(ok(cross('confirmed', 'r')));
     const priReview = vi.fn().mockResolvedValue(ok(cross('disputed', 'r')));
-    const { primary, secondary } = mixedPair({ crossReview: priReview }, { crossReview: secReview });
+    const { primary, secondary } = mixedPair(
+      { crossReview: priReview },
+      { crossReview: secReview },
+    );
 
     // maxChunkTokens:1 → any subject blows the budget → both judges skipped.
-    const res = await createDeliberationBackend(primary, secondary, { crossReview: true, maxChunkTokens: 1 }).reviewCode({ diff: DIFF });
+    const res = await createDeliberationBackend(primary, secondary, {
+      crossReview: true,
+      maxChunkTokens: 1,
+    }).reviewCode({ diff: DIFF });
 
     expect(res.ok).toBe(true);
     if (!res.ok) return;
@@ -483,7 +909,10 @@ describe('createDeliberationBackend — deliberate-deep (cross-review round)', (
   it('does not cross-review by default (plain deliberate leaves divergent un-adjudicated)', async () => {
     const secReview = vi.fn();
     const priReview = vi.fn();
-    const { primary, secondary } = mixedPair({ crossReview: priReview }, { crossReview: secReview });
+    const { primary, secondary } = mixedPair(
+      { crossReview: priReview },
+      { crossReview: secReview },
+    );
 
     const res = await createDeliberationBackend(primary, secondary).reviewCode({ diff: DIFF });
 
@@ -500,7 +929,9 @@ describe('createDeliberationBackend — deliberate-deep (cross-review round)', (
     const priReview = vi.fn().mockResolvedValue(ok(cross('confirmed', 'real')));
     const { primary, secondary } = mixedPair({ crossReview: priReview }, {});
 
-    const res = await createDeliberationBackend(primary, secondary, { crossReview: true }).reviewCode({ diff: DIFF });
+    const res = await createDeliberationBackend(primary, secondary, {
+      crossReview: true,
+    }).reviewCode({ diff: DIFF });
 
     expect(res.ok).toBe(true);
     if (!res.ok) return;
@@ -512,9 +943,14 @@ describe('createDeliberationBackend — deliberate-deep (cross-review round)', (
   it('surfaces a failed crossReview call as cross_review_failures, not silently (ISS-012)', async () => {
     const secReview = vi.fn().mockResolvedValue(err(`${ErrorCode.RATE_LIMITED}: out of usage`));
     const priReview = vi.fn().mockResolvedValue(ok(cross('confirmed', 'real')));
-    const { primary, secondary } = mixedPair({ crossReview: priReview }, { crossReview: secReview });
+    const { primary, secondary } = mixedPair(
+      { crossReview: priReview },
+      { crossReview: secReview },
+    );
 
-    const res = await createDeliberationBackend(primary, secondary, { crossReview: true }).reviewCode({ diff: DIFF });
+    const res = await createDeliberationBackend(primary, secondary, {
+      crossReview: true,
+    }).reviewCode({ diff: DIFF });
 
     expect(res.ok).toBe(true);
     if (!res.ok) return;
@@ -527,14 +963,74 @@ describe('createDeliberationBackend — deliberate-deep (cross-review round)', (
     ]);
   });
 
+  it('preserves the completed main review when a judge promise rejects', async () => {
+    const primary = backend('codex', {
+      reviewCode: vi.fn().mockResolvedValue(
+        ok({
+          ...codeResult('request_changes', [f('a.ts', 5, 'bugs', 'major')], 'codex-main'),
+          models: [model('codex')],
+        }),
+      ),
+      crossReview: vi.fn().mockResolvedValue(
+        ok({
+          ...cross('confirmed', 'real'),
+          models: [model('codex', 'adjudication')],
+        }),
+      ),
+    });
+    const secondary = backend('gemini', {
+      reviewCode: vi.fn().mockResolvedValue(
+        ok({
+          ...codeResult('request_changes', [f('b.ts', 2, 'perf', 'minor')], 'gemini-main'),
+          models: [model('gemini')],
+        }),
+      ),
+      crossReview: vi.fn().mockRejectedValue(PRIVATE_REJECTION),
+    });
+
+    const result = await createDeliberationBackend(primary, secondary, {
+      crossReview: true,
+    }).reviewCode({ diff: DIFF });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.verdict).toBe('request_changes');
+    expect(result.data.session_id).toBe('codex-main');
+    expect(result.data.findings).toHaveLength(2);
+    expect(result.data.models).toEqual([
+      model('codex'),
+      model('gemini'),
+      model('codex', 'adjudication'),
+    ]);
+    expect(result.data.deliberation?.cross_review_failures).toEqual([
+      { by: 'gemini', reason: REJECTED_PROVIDER_ERROR },
+    ]);
+    expect(result.data.deliberation?.cross_review_failures?.[0].reason).not.toContain(
+      '/Users/alice',
+    );
+    expect(result.data.deliberation?.cross_review_failures?.[0].reason).not.toContain(
+      'super-secret',
+    );
+  });
+
   it('skips cross-review entirely when there are no divergent findings', async () => {
     const secReview = vi.fn();
     const priReview = vi.fn();
     const shared = [f('a.ts', 1, 'security', 'major')];
-    const primary = backend('codex', { reviewCode: vi.fn().mockResolvedValue(ok(codeResult('approve', shared))), crossReview: priReview });
-    const secondary = backend('gemini', { reviewCode: vi.fn().mockResolvedValue(ok(codeResult('approve', [f('a.ts', 1, 'security', 'major')]))), crossReview: secReview });
+    const primary = backend('codex', {
+      reviewCode: vi.fn().mockResolvedValue(ok(codeResult('approve', shared))),
+      crossReview: priReview,
+    });
+    const secondary = backend('gemini', {
+      reviewCode: vi
+        .fn()
+        .mockResolvedValue(ok(codeResult('approve', [f('a.ts', 1, 'security', 'major')]))),
+      crossReview: secReview,
+    });
 
-    const res = await createDeliberationBackend(primary, secondary, { crossReview: true }).reviewCode({ diff: DIFF });
+    const res = await createDeliberationBackend(primary, secondary, {
+      crossReview: true,
+    }).reviewCode({ diff: DIFF });
 
     expect(res.ok).toBe(true);
     if (!res.ok) return;
@@ -544,14 +1040,32 @@ describe('createDeliberationBackend — deliberate-deep (cross-review round)', (
   });
 
   it('cross-reviews plan divergent findings against the plan text', async () => {
-    const planA = { verdict: 'revise', summary: 's', findings: [f('p.ts', 1, 'feasibility', 'major')], session_id: 'a' };
-    const planB = { verdict: 'revise', summary: 's', findings: [f('q.ts', 9, 'security', 'major')], session_id: 'b' };
+    const planA = {
+      verdict: 'revise',
+      summary: 's',
+      findings: [f('p.ts', 1, 'feasibility', 'major')],
+      session_id: 'a',
+    };
+    const planB = {
+      verdict: 'revise',
+      summary: 's',
+      findings: [f('q.ts', 9, 'security', 'major')],
+      session_id: 'b',
+    };
     const secReview = vi.fn().mockResolvedValue(ok(cross('confirmed', 'agreed'))); // gemini judges codex's finding
     const priReview = vi.fn().mockResolvedValue(ok(cross('unsure', 'cannot tell'))); // codex judges gemini's finding
-    const primary = backend('codex', { reviewPlan: vi.fn().mockResolvedValue(ok(planA)), crossReview: priReview });
-    const secondary = backend('gemini', { reviewPlan: vi.fn().mockResolvedValue(ok(planB)), crossReview: secReview });
+    const primary = backend('codex', {
+      reviewPlan: vi.fn().mockResolvedValue(ok(planA)),
+      crossReview: priReview,
+    });
+    const secondary = backend('gemini', {
+      reviewPlan: vi.fn().mockResolvedValue(ok(planB)),
+      crossReview: secReview,
+    });
 
-    const res = await createDeliberationBackend(primary, secondary, { crossReview: true }).reviewPlan({ plan: 'do a thing' });
+    const res = await createDeliberationBackend(primary, secondary, {
+      crossReview: true,
+    }).reviewPlan({ plan: 'do a thing' });
 
     expect(res.ok).toBe(true);
     if (!res.ok) return;
@@ -564,14 +1078,33 @@ describe('createDeliberationBackend — deliberate-deep (cross-review round)', (
 
   it('ISS-014: a FRESH plan review also forwards the model to the primary judge only', async () => {
     // Regression: the fresh deliberatePlan path must thread input.model too.
-    const planA = { verdict: 'revise', summary: 's', findings: [f('p.ts', 1, 'feasibility', 'major')], session_id: 'a' };
-    const planB = { verdict: 'revise', summary: 's', findings: [f('q.ts', 9, 'security', 'major')], session_id: 'b' };
+    const planA = {
+      verdict: 'revise',
+      summary: 's',
+      findings: [f('p.ts', 1, 'feasibility', 'major')],
+      session_id: 'a',
+    };
+    const planB = {
+      verdict: 'revise',
+      summary: 's',
+      findings: [f('q.ts', 9, 'security', 'major')],
+      session_id: 'b',
+    };
     const secReview = vi.fn().mockResolvedValue(ok(cross('confirmed', 'r'))); // gemini judge
     const priReview = vi.fn().mockResolvedValue(ok(cross('unsure', 'r'))); // codex judge
-    const primary = backend('codex', { reviewPlan: vi.fn().mockResolvedValue(ok(planA)), crossReview: priReview });
-    const secondary = backend('gemini', { reviewPlan: vi.fn().mockResolvedValue(ok(planB)), crossReview: secReview });
+    const primary = backend('codex', {
+      reviewPlan: vi.fn().mockResolvedValue(ok(planA)),
+      crossReview: priReview,
+    });
+    const secondary = backend('gemini', {
+      reviewPlan: vi.fn().mockResolvedValue(ok(planB)),
+      crossReview: secReview,
+    });
 
-    await createDeliberationBackend(primary, secondary, { crossReview: true }).reviewPlan({ plan: 'do a thing', model: 'gpt-5.4' });
+    await createDeliberationBackend(primary, secondary, { crossReview: true }).reviewPlan({
+      plan: 'do a thing',
+      model: 'gpt-5.4',
+    });
 
     expect(priReview).toHaveBeenCalledWith(expect.objectContaining({ model: 'gpt-5.4' })); // primary judge gets it
     expect(secReview).toHaveBeenCalledWith(expect.objectContaining({ model: undefined })); // secondary resolves own

--- a/src/backends/deliberation.ts
+++ b/src/backends/deliberation.ts
@@ -1,12 +1,10 @@
-import { ok, err } from '../utils/errors.js';
+import { ErrorCode, ok, err } from '../utils/errors.js';
 import type { Result } from '../utils/errors.js';
 import type { ReviewProvider } from '../config/types.js';
-import {
-  CodeFindingSeveritySchema,
-  PlanFindingSeveritySchema,
-} from '../review/types.js';
-import type { PlanReviewResult, CodeReviewResult } from '../review/types.js';
-import { withFailover } from './failover.js';
+import { CodeFindingSeveritySchema, PlanFindingSeveritySchema } from '../review/types.js';
+import type { PlanReviewResult, CodeReviewResult, ModelIdentity } from '../review/types.js';
+import { deduplicateModelIdentities, sessionModelConflictMessage } from './orchestrator.js';
+import { lookupSessionOwner, withFailover } from './failover.js';
 import type { SessionProviderLookup } from './failover.js';
 import { sliceDiffToFiles } from '../utils/diff-files.js';
 import { estimateTokens } from '../utils/chunking.js';
@@ -16,6 +14,17 @@ import type {
   CodeReviewInput,
   PrecommitReviewInput,
 } from './backend.js';
+import { canOverrideModelOnResume } from './backend.js';
+
+const REJECTED_PROVIDER_ERROR = `${ErrorCode.UNKNOWN_ERROR}: provider call failed unexpectedly`;
+
+async function resultFromProviderCall<T>(call: () => Promise<Result<T>>): Promise<Result<T>> {
+  try {
+    return await call();
+  } catch {
+    return err<T>(REJECTED_PROVIDER_ERROR);
+  }
+}
 
 // Deliberation: run BOTH providers on the same review, then surface where they
 // agree (both flagged a finding → high confidence) vs. diverge (only one flagged
@@ -201,20 +210,32 @@ function combineCode(
   // Worst-of-both, computed from the two INDEPENDENT reviews and BY DESIGN not
   // re-derived after cross-review (ISS-015): a deliberate-deep adjudication is
   // advisory input for the caller's synthesis, not folded back into the verdict.
-  const verdict = CODE_VERDICT_RANK[ra.verdict] >= CODE_VERDICT_RANK[rb.verdict] ? ra.verdict : rb.verdict;
+  const verdict =
+    CODE_VERDICT_RANK[ra.verdict] >= CODE_VERDICT_RANK[rb.verdict] ? ra.verdict : rb.verdict;
   return {
     verdict,
     summary: joinSummaries(ra.summary, rb.summary),
     findings: [...agreed, ...divergent.map((d) => d.finding)],
     session_id: sessionId ?? ra.session_id,
     provider: p,
+    ...(ra.models || rb.models
+      ? { models: deduplicateModelIdentities([...(ra.models ?? []), ...(rb.models ?? [])]) }
+      : {}),
     // Surface the primary's chunk count at top level (the presented result).
     ...(ra.chunks_reviewed !== undefined ? { chunks_reviewed: ra.chunks_reviewed } : {}),
     deliberation: {
       providers: [p, s],
       verdicts: [
-        { provider: p, verdict: ra.verdict, ...(ra.chunks_reviewed !== undefined ? { chunks_reviewed: ra.chunks_reviewed } : {}) },
-        { provider: s, verdict: rb.verdict, ...(rb.chunks_reviewed !== undefined ? { chunks_reviewed: rb.chunks_reviewed } : {}) },
+        {
+          provider: p,
+          verdict: ra.verdict,
+          ...(ra.chunks_reviewed !== undefined ? { chunks_reviewed: ra.chunks_reviewed } : {}),
+        },
+        {
+          provider: s,
+          verdict: rb.verdict,
+          ...(rb.chunks_reviewed !== undefined ? { chunks_reviewed: rb.chunks_reviewed } : {}),
+        },
       ],
       agreement: agreementLabel(ra.verdict, rb.verdict, divergent.length),
       agreed,
@@ -236,13 +257,17 @@ function combinePlan(
     planRank,
   );
   // Worst-of-both, pre-cross-review by design (ISS-015) — see combineCode.
-  const verdict = PLAN_VERDICT_RANK[ra.verdict] >= PLAN_VERDICT_RANK[rb.verdict] ? ra.verdict : rb.verdict;
+  const verdict =
+    PLAN_VERDICT_RANK[ra.verdict] >= PLAN_VERDICT_RANK[rb.verdict] ? ra.verdict : rb.verdict;
   return {
     verdict,
     summary: joinSummaries(ra.summary, rb.summary),
     findings: [...agreed, ...divergent.map((d) => d.finding)],
     session_id: sessionId ?? ra.session_id,
     provider: p,
+    ...(ra.models || rb.models
+      ? { models: deduplicateModelIdentities([...(ra.models ?? []), ...(rb.models ?? [])]) }
+      : {}),
     deliberation: {
       providers: [p, s],
       // Plan reviews are not chunked, so no chunks_reviewed on verdicts.
@@ -311,10 +336,22 @@ function errOf<T>(r: Result<T>): string {
 
 // --- Cross-review round (deliberate-deep) ---
 
-type Adjudication = { by: ReviewProvider; verdict: 'confirmed' | 'disputed' | 'unsure'; reason: string };
+type Adjudication = {
+  by: ReviewProvider;
+  verdict: 'confirmed' | 'disputed' | 'unsure';
+  reason: string;
+};
 type CrossFinding = AnyFinding & { description: string };
 type CrossReviewFailure = { by: ReviewProvider; reason: string };
-type AdjudicateResult = { adjudications: (Adjudication | undefined)[]; failure?: CrossReviewFailure };
+type AdjudicateResult = {
+  adjudications: (Adjudication | undefined)[];
+  models: ModelIdentity[];
+  failure?: CrossReviewFailure;
+};
+type DeliberationModelOverrides = {
+  primary?: string;
+  secondary?: string;
+};
 
 // Ask `judge` to adjudicate `findings` (from the other provider) against the
 // change. Returns adjudications aligned to `findings` (undefined where none),
@@ -329,40 +366,52 @@ async function runAdjudicate(
   maxChunkTokens?: number,
 ): Promise<AdjudicateResult> {
   const out: (Adjudication | undefined)[] = new Array(findings.length).fill(undefined);
-  if (findings.length === 0 || !judge.crossReview) return { adjudications: out };
+  const crossReview = judge.crossReview;
+  if (findings.length === 0 || !crossReview) return { adjudications: out, models: [] };
   // ISS-012: slice the subject to only the files these findings touch so a large
   // diff doesn't blow the single adjudication turn. Plans / no-file findings fall
   // back to the full subject. If it's STILL over budget, fail this adjudication
   // cleanly (bounded cost) — surfaced via cross_review_failures, no multi-turn.
-  const wanted = new Set(findings.map((f) => f.file).filter((f): f is string => typeof f === 'string'));
+  const wanted = new Set(
+    findings.map((f) => f.file).filter((f): f is string => typeof f === 'string'),
+  );
   const subject = sliceDiffToFiles(content, wanted);
   if (maxChunkTokens !== undefined && estimateTokens(subject) > maxChunkTokens) {
     return {
       adjudications: out,
+      models: [],
       failure: {
         by: judge.provider,
         reason: `cross-review subject exceeds max_chunk_tokens (${estimateTokens(subject)} > ${maxChunkTokens}) even after slicing to referenced files`,
       },
     };
   }
-  const res = await judge.crossReview({
-    content: subject,
-    findings: findings.map((f) => ({
-      severity: f.severity,
-      category: f.category,
-      file: f.file,
-      line: f.line,
-      description: f.description,
-    })),
-    model,
-  });
-  if (!res.ok) return { adjudications: out, failure: { by: judge.provider, reason: res.error } };
+  const res = await resultFromProviderCall(() =>
+    crossReview({
+      content: subject,
+      findings: findings.map((f) => ({
+        severity: f.severity,
+        category: f.category,
+        file: f.file,
+        line: f.line,
+        description: f.description,
+      })),
+      model,
+    }),
+  );
+  if (!res.ok) {
+    return {
+      adjudications: out,
+      models: [],
+      failure: { by: judge.provider, reason: res.error },
+    };
+  }
   for (const a of res.data.adjudications) {
     if (a.index >= 0 && a.index < findings.length) {
       out[a.index] = { by: judge.provider, verdict: a.verdict, reason: a.reason };
     }
   }
-  return { adjudications: out };
+  return { adjudications: out, models: res.data.models ?? [] };
 }
 
 // Each provider's divergent findings are adjudicated by the OTHER provider (in
@@ -373,16 +422,30 @@ async function adjudicateDivergent(
   content: string,
   primary: ReviewBackend,
   secondary: ReviewBackend,
-  primaryModel?: string,
+  modelOverrides: DeliberationModelOverrides,
   maxChunkTokens?: number,
-): Promise<{ adjudications: (Adjudication | undefined)[]; failures: CrossReviewFailure[] }> {
+): Promise<{
+  adjudications: (Adjudication | undefined)[];
+  failures: CrossReviewFailure[];
+  models: ModelIdentity[];
+}> {
   const byPrimary = divergent.filter((d) => d.provider === primary.provider);
   const bySecondary = divergent.filter((d) => d.provider === secondary.provider);
   const [secAdj, priAdj] = await Promise.all([
-    // The primary's model override applies to the PRIMARY judge only; the
-    // secondary judge resolves its own default (same convention as reviews).
-    runAdjudicate(secondary, content, byPrimary.map((d) => d.finding), undefined, maxChunkTokens),
-    runAdjudicate(primary, content, bySecondary.map((d) => d.finding), primaryModel, maxChunkTokens),
+    runAdjudicate(
+      secondary,
+      content,
+      byPrimary.map((d) => d.finding),
+      modelOverrides.secondary,
+      maxChunkTokens,
+    ),
+    runAdjudicate(
+      primary,
+      content,
+      bySecondary.map((d) => d.finding),
+      modelOverrides.primary,
+      maxChunkTokens,
+    ),
   ]);
   const out: (Adjudication | undefined)[] = new Array(divergent.length).fill(undefined);
   let si = 0;
@@ -394,7 +457,10 @@ async function adjudicateDivergent(
   const failures: CrossReviewFailure[] = [];
   if (secAdj.failure) failures.push(secAdj.failure);
   if (priAdj.failure) failures.push(priAdj.failure);
-  return { adjudications: out, failures };
+  // Review identities are primary→secondary, so adjudication identities follow
+  // the same deterministic provider order even though the two calls run in parallel.
+  const models = deduplicateModelIdentities([...priAdj.models, ...secAdj.models]);
+  return { adjudications: out, failures, models };
 }
 
 // deliberate-deep tail, shared by the fresh and resume paths: if cross-review is
@@ -407,17 +473,27 @@ async function maybeAdjudicateCode(
   primary: ReviewBackend,
   secondary: ReviewBackend,
   crossReview: boolean,
-  primaryModel?: string,
+  modelOverrides: DeliberationModelOverrides,
   maxChunkTokens?: number,
 ): Promise<CodeReviewResult> {
   const dl = combined.deliberation;
   if (!crossReview || !dl || dl.divergent.length === 0) return combined;
-  const { adjudications, failures } = await adjudicateDivergent(dl.divergent, subject, primary, secondary, primaryModel, maxChunkTokens);
+  const { adjudications, failures, models } = await adjudicateDivergent(
+    dl.divergent,
+    subject,
+    primary,
+    secondary,
+    modelOverrides,
+    maxChunkTokens,
+  );
   return {
     ...combined,
+    models: deduplicateModelIdentities([...(combined.models ?? []), ...models]),
     deliberation: {
       ...dl,
-      divergent: dl.divergent.map((d, i) => (adjudications[i] ? { ...d, adjudication: adjudications[i] } : d)),
+      divergent: dl.divergent.map((d, i) =>
+        adjudications[i] ? { ...d, adjudication: adjudications[i] } : d,
+      ),
       ...(failures.length > 0 ? { cross_review_failures: failures } : {}),
     },
   };
@@ -429,17 +505,27 @@ async function maybeAdjudicatePlan(
   primary: ReviewBackend,
   secondary: ReviewBackend,
   crossReview: boolean,
-  primaryModel?: string,
+  modelOverrides: DeliberationModelOverrides,
   maxChunkTokens?: number,
 ): Promise<PlanReviewResult> {
   const dl = combined.deliberation;
   if (!crossReview || !dl || dl.divergent.length === 0) return combined;
-  const { adjudications, failures } = await adjudicateDivergent(dl.divergent, subject, primary, secondary, primaryModel, maxChunkTokens);
+  const { adjudications, failures, models } = await adjudicateDivergent(
+    dl.divergent,
+    subject,
+    primary,
+    secondary,
+    modelOverrides,
+    maxChunkTokens,
+  );
   return {
     ...combined,
+    models: deduplicateModelIdentities([...(combined.models ?? []), ...models]),
     deliberation: {
       ...dl,
-      divergent: dl.divergent.map((d, i) => (adjudications[i] ? { ...d, adjudication: adjudications[i] } : d)),
+      divergent: dl.divergent.map((d, i) =>
+        adjudications[i] ? { ...d, adjudication: adjudications[i] } : d,
+      ),
       ...(failures.length > 0 ? { cross_review_failures: failures } : {}),
     },
   };
@@ -452,10 +538,12 @@ function ownerLeafFor(
   primary: ReviewBackend,
   secondary: ReviewBackend,
   lookup?: SessionProviderLookup,
-): { ownerLeaf: ReviewBackend; otherLeaf: ReviewBackend } {
-  const owner = lookup?.(sessionId) ?? null;
+): Result<{ ownerLeaf: ReviewBackend; otherLeaf: ReviewBackend }> {
+  const ownerResult = lookupSessionOwner(sessionId, lookup);
+  if (!ownerResult.ok) return ownerResult;
+  const owner = ownerResult.data;
   const ownerLeaf = owner && secondary.providers.includes(owner) ? secondary : primary;
-  return { ownerLeaf, otherLeaf: ownerLeaf === primary ? secondary : primary };
+  return ok({ ownerLeaf, otherLeaf: ownerLeaf === primary ? secondary : primary });
 }
 
 export async function deliberatePlan(
@@ -468,32 +556,80 @@ export async function deliberatePlan(
 ): Promise<Result<PlanReviewResult>> {
   if (input.session_id) {
     // Deliberate-on-resume (ISS-010): the OWNER resumes its session; the other
-    // leaf reviews fresh. Each leaf gets input.model only if it is the primary.
-    const { ownerLeaf, otherLeaf } = ownerLeafFor(input.session_id, primary, secondary, lookup);
+    // leaf reviews fresh. A model override belongs to the resumed owner; the
+    // fresh other provider resolves its own default.
+    const owner = ownerLeafFor(input.session_id, primary, secondary, lookup);
+    if (!owner.ok) return err<PlanReviewResult>(owner.error);
+    const { ownerLeaf, otherLeaf } = owner.data;
+    if (input.model && !canOverrideModelOnResume(ownerLeaf, ownerLeaf.provider)) {
+      return err<PlanReviewResult>(sessionModelConflictMessage());
+    }
+    const modelOverrides: DeliberationModelOverrides =
+      ownerLeaf === primary ? { primary: input.model } : { secondary: input.model };
     const [ownerRes, otherRes] = await Promise.all([
-      ownerLeaf.reviewPlan({ ...input, model: ownerLeaf === primary ? input.model : undefined }),
-      otherLeaf.reviewPlan({ ...input, session_id: undefined, model: otherLeaf === primary ? input.model : undefined }),
+      resultFromProviderCall(() => ownerLeaf.reviewPlan(input)),
+      resultFromProviderCall(() =>
+        otherLeaf.reviewPlan({
+          ...input,
+          session_id: undefined,
+          model: undefined,
+        }),
+      ),
     ]);
     // Map owner/other back to primary/secondary Results (used for both the combine
     // and the primary-led bothFailed message).
     const primaryRes = ownerLeaf === primary ? ownerRes : otherRes;
     const secondaryRes = ownerLeaf === primary ? otherRes : ownerRes;
     if (ownerRes.ok && otherRes.ok && primaryRes.ok && secondaryRes.ok) {
-      const combined = combinePlan(primary.provider, primaryRes.data, secondary.provider, secondaryRes.data, ownerRes.data.session_id);
-      return ok(await maybeAdjudicatePlan(combined, input.plan, primary, secondary, crossReview, input.model, maxChunkTokens));
+      const combined = combinePlan(
+        primary.provider,
+        primaryRes.data,
+        secondary.provider,
+        secondaryRes.data,
+        ownerRes.data.session_id,
+      );
+      return ok(
+        await maybeAdjudicatePlan(
+          combined,
+          input.plan,
+          primary,
+          secondary,
+          crossReview,
+          modelOverrides,
+          maxChunkTokens,
+        ),
+      );
     }
-    if (ownerRes.ok) return ok(degradePlan(ownerLeaf.provider, ownerRes.data, otherLeaf.provider, errOf(otherRes)));
-    if (otherRes.ok) return ok(degradePlan(otherLeaf.provider, otherRes.data, ownerLeaf.provider, errOf(ownerRes)));
-    return err<PlanReviewResult>(bothFailed(errOf(primaryRes), secondary.provider, errOf(secondaryRes)));
+    if (ownerRes.ok)
+      return ok(
+        degradePlan(ownerLeaf.provider, ownerRes.data, otherLeaf.provider, errOf(otherRes)),
+      );
+    if (otherRes.ok)
+      return ok(
+        degradePlan(otherLeaf.provider, otherRes.data, ownerLeaf.provider, errOf(ownerRes)),
+      );
+    return err<PlanReviewResult>(
+      bothFailed(errOf(primaryRes), secondary.provider, errOf(secondaryRes)),
+    );
   }
 
   const [ra, rb] = await Promise.all([
-    primary.reviewPlan(input),
-    secondary.reviewPlan({ ...input, model: undefined }),
+    resultFromProviderCall(() => primary.reviewPlan(input)),
+    resultFromProviderCall(() => secondary.reviewPlan({ ...input, model: undefined })),
   ]);
   if (ra.ok && rb.ok) {
     const combined = combinePlan(primary.provider, ra.data, secondary.provider, rb.data);
-    return ok(await maybeAdjudicatePlan(combined, input.plan, primary, secondary, crossReview, input.model, maxChunkTokens));
+    return ok(
+      await maybeAdjudicatePlan(
+        combined,
+        input.plan,
+        primary,
+        secondary,
+        crossReview,
+        { primary: input.model },
+        maxChunkTokens,
+      ),
+    );
   }
   if (ra.ok) return ok(degradePlan(primary.provider, ra.data, secondary.provider, errOf(rb)));
   if (rb.ok) return ok(degradePlan(secondary.provider, rb.data, primary.provider, errOf(ra)));
@@ -509,29 +645,76 @@ export async function deliberateCode(
   maxChunkTokens?: number,
 ): Promise<Result<CodeReviewResult>> {
   if (input.session_id) {
-    const { ownerLeaf, otherLeaf } = ownerLeafFor(input.session_id, primary, secondary, lookup);
+    const owner = ownerLeafFor(input.session_id, primary, secondary, lookup);
+    if (!owner.ok) return err<CodeReviewResult>(owner.error);
+    const { ownerLeaf, otherLeaf } = owner.data;
+    if (input.model && !canOverrideModelOnResume(ownerLeaf, ownerLeaf.provider)) {
+      return err<CodeReviewResult>(sessionModelConflictMessage());
+    }
+    const modelOverrides: DeliberationModelOverrides =
+      ownerLeaf === primary ? { primary: input.model } : { secondary: input.model };
     const [ownerRes, otherRes] = await Promise.all([
-      ownerLeaf.reviewCode({ ...input, model: ownerLeaf === primary ? input.model : undefined }),
-      otherLeaf.reviewCode({ ...input, session_id: undefined, model: otherLeaf === primary ? input.model : undefined }),
+      resultFromProviderCall(() => ownerLeaf.reviewCode(input)),
+      resultFromProviderCall(() =>
+        otherLeaf.reviewCode({
+          ...input,
+          session_id: undefined,
+          model: undefined,
+        }),
+      ),
     ]);
     const primaryRes = ownerLeaf === primary ? ownerRes : otherRes;
     const secondaryRes = ownerLeaf === primary ? otherRes : ownerRes;
     if (ownerRes.ok && otherRes.ok && primaryRes.ok && secondaryRes.ok) {
-      const combined = combineCode(primary.provider, primaryRes.data, secondary.provider, secondaryRes.data, ownerRes.data.session_id);
-      return ok(await maybeAdjudicateCode(combined, input.diff, primary, secondary, crossReview, input.model, maxChunkTokens));
+      const combined = combineCode(
+        primary.provider,
+        primaryRes.data,
+        secondary.provider,
+        secondaryRes.data,
+        ownerRes.data.session_id,
+      );
+      return ok(
+        await maybeAdjudicateCode(
+          combined,
+          input.diff,
+          primary,
+          secondary,
+          crossReview,
+          modelOverrides,
+          maxChunkTokens,
+        ),
+      );
     }
-    if (ownerRes.ok) return ok(degradeCode(ownerLeaf.provider, ownerRes.data, otherLeaf.provider, errOf(otherRes)));
-    if (otherRes.ok) return ok(degradeCode(otherLeaf.provider, otherRes.data, ownerLeaf.provider, errOf(ownerRes)));
-    return err<CodeReviewResult>(bothFailed(errOf(primaryRes), secondary.provider, errOf(secondaryRes)));
+    if (ownerRes.ok)
+      return ok(
+        degradeCode(ownerLeaf.provider, ownerRes.data, otherLeaf.provider, errOf(otherRes)),
+      );
+    if (otherRes.ok)
+      return ok(
+        degradeCode(otherLeaf.provider, otherRes.data, ownerLeaf.provider, errOf(ownerRes)),
+      );
+    return err<CodeReviewResult>(
+      bothFailed(errOf(primaryRes), secondary.provider, errOf(secondaryRes)),
+    );
   }
 
   const [ra, rb] = await Promise.all([
-    primary.reviewCode(input),
-    secondary.reviewCode({ ...input, model: undefined }),
+    resultFromProviderCall(() => primary.reviewCode(input)),
+    resultFromProviderCall(() => secondary.reviewCode({ ...input, model: undefined })),
   ]);
   if (ra.ok && rb.ok) {
     const combined = combineCode(primary.provider, ra.data, secondary.provider, rb.data);
-    return ok(await maybeAdjudicateCode(combined, input.diff, primary, secondary, crossReview, input.model, maxChunkTokens));
+    return ok(
+      await maybeAdjudicateCode(
+        combined,
+        input.diff,
+        primary,
+        secondary,
+        crossReview,
+        { primary: input.model },
+        maxChunkTokens,
+      ),
+    );
   }
   if (ra.ok) return ok(degradeCode(primary.provider, ra.data, secondary.provider, errOf(rb)));
   if (rb.ok) return ok(degradeCode(secondary.provider, rb.data, primary.provider, errOf(ra)));
@@ -550,16 +733,23 @@ export function createDeliberationBackend(
   // Budget for the cross-review subject (ISS-012). Undefined = unbounded.
   const maxChunkTokens = opts.maxChunkTokens;
   return {
-    // Presents as the primary for tagging + the session_id/model gate; but a
-    // resumed session routes to its OWNING leaf via lookup (ISS-011). The
-    // allowsModelOverrideOnResume gate stays the primary's conservative one — a
-    // secondary-owned resume combined with a model override may still be rejected;
-    // acceptable, out of scope for T-027.
+    // Presents as the primary for tagging, while owner-aware capability lookup
+    // and resume routing both target the leaf that owns the session (ISS-011).
     provider: primary.provider,
     providers: [...primary.providers, ...secondary.providers],
     allowsModelOverrideOnResume: primary.allowsModelOverrideOnResume,
-    reviewPlan: (input: PlanReviewInput) => deliberatePlan(primary, secondary, input, crossReview, lookup, maxChunkTokens),
-    reviewCode: (input: CodeReviewInput) => deliberateCode(primary, secondary, input, crossReview, lookup, maxChunkTokens),
+    allowsModelOverrideOnResumeFor: (provider) => {
+      const owner = primary.providers.includes(provider)
+        ? primary
+        : secondary.providers.includes(provider)
+          ? secondary
+          : null;
+      return owner ? canOverrideModelOnResume(owner, provider) : false;
+    },
+    reviewPlan: (input: PlanReviewInput) =>
+      deliberatePlan(primary, secondary, input, crossReview, lookup, maxChunkTokens),
+    reviewCode: (input: CodeReviewInput) =>
+      deliberateCode(primary, secondary, input, crossReview, lookup, maxChunkTokens),
     // Precommit stays failover — it runs constantly and is latency-sensitive. It
     // still routes resumes to the owning leaf via the same lookup.
     reviewPrecommit: (input: PrecommitReviewInput) =>

--- a/src/backends/failover.test.ts
+++ b/src/backends/failover.test.ts
@@ -17,7 +17,12 @@ function backend(provider: ReviewProvider, methods: Methods = {}): ReviewBackend
   };
 }
 
-const CODE_OK = { verdict: 'approve' as const, summary: 's', findings: [], session_id: 'sec-session' };
+const CODE_OK = {
+  verdict: 'approve' as const,
+  summary: 's',
+  findings: [],
+  session_id: 'sec-session',
+};
 const DIFF = 'diff --git a/f b/f\n@@ -1 +1 @@\n-a\n+b';
 
 beforeEach(() => {
@@ -61,9 +66,14 @@ describe('createFailoverBackend', () => {
   it('fails over to the secondary when the primary binary is unavailable (killed/quarantined)', async () => {
     const secReview = vi.fn().mockResolvedValue(ok(CODE_OK));
     const primary = backend('codex', {
-      reviewCode: vi.fn().mockResolvedValue(err(`${ErrorCode.PROVIDER_UNAVAILABLE}: codex binary was killed`)),
+      reviewCode: vi
+        .fn()
+        .mockResolvedValue(err(`${ErrorCode.PROVIDER_UNAVAILABLE}: codex binary was killed`)),
     });
-    const res = await createFailoverBackend(primary, backend('gemini', { reviewCode: secReview })).reviewCode({
+    const res = await createFailoverBackend(
+      primary,
+      backend('gemini', { reviewCode: secReview }),
+    ).reviewCode({
       diff: DIFF,
     });
 
@@ -77,7 +87,10 @@ describe('createFailoverBackend', () => {
     const primary = backend('codex', {
       reviewCode: vi.fn().mockResolvedValue(err(`${ErrorCode.INVALID_INPUT}: bad diff`)),
     });
-    const res = await createFailoverBackend(primary, backend('gemini', { reviewCode: secReview })).reviewCode({
+    const res = await createFailoverBackend(
+      primary,
+      backend('gemini', { reviewCode: secReview }),
+    ).reviewCode({
       diff: DIFF,
     });
 
@@ -91,7 +104,10 @@ describe('createFailoverBackend', () => {
     const primary = backend('codex', {
       reviewCode: vi.fn().mockResolvedValue(ok({ ...CODE_OK, session_id: 'pri' })),
     });
-    const res = await createFailoverBackend(primary, backend('gemini', { reviewCode: secReview })).reviewCode({
+    const res = await createFailoverBackend(
+      primary,
+      backend('gemini', { reviewCode: secReview }),
+    ).reviewCode({
       diff: DIFF,
     });
 
@@ -123,7 +139,10 @@ describe('createFailoverBackend', () => {
     const primary = backend('codex', {
       reviewCode: vi.fn().mockResolvedValue(err(`${ErrorCode.RATE_LIMITED}: usage`)),
     });
-    const res = await createFailoverBackend(primary, backend('gemini', { reviewCode: secReview })).reviewCode({
+    const res = await createFailoverBackend(
+      primary,
+      backend('gemini', { reviewCode: secReview }),
+    ).reviewCode({
       diff: DIFF,
       session_id: 'codex-sess',
     });
@@ -195,7 +214,7 @@ describe('createFailoverBackend — resume ownership routing', () => {
     const secReview = vi.fn().mockResolvedValue(ok({ ...CODE_OK, session_id: 'sess-1' }));
     const primary = backend('codex', { reviewCode: priReview });
     const secondary = backend('gemini', { reviewCode: secReview });
-    const lookup = vi.fn().mockReturnValue('gemini');
+    const lookup = vi.fn().mockReturnValue({ status: 'found', value: 'gemini' });
 
     const res = await createFailoverBackend(primary, secondary, lookup).reviewCode(RESUME);
 
@@ -208,7 +227,11 @@ describe('createFailoverBackend — resume ownership routing', () => {
   it('routes a primary-owned resume to the primary', async () => {
     const priReview = vi.fn().mockResolvedValue(ok({ ...CODE_OK, session_id: 'sess-1' }));
     const secReview = vi.fn();
-    const fb = createFailoverBackend(backend('codex', { reviewCode: priReview }), backend('gemini', { reviewCode: secReview }), vi.fn().mockReturnValue('codex'));
+    const fb = createFailoverBackend(
+      backend('codex', { reviewCode: priReview }),
+      backend('gemini', { reviewCode: secReview }),
+      vi.fn().mockReturnValue({ status: 'found', value: 'codex' }),
+    );
 
     const res = await fb.reviewCode(RESUME);
 
@@ -217,22 +240,46 @@ describe('createFailoverBackend — resume ownership routing', () => {
     expect(res.ok && res.data.provider).toBe('codex');
   });
 
-  it('routes to the primary when the owner is unknown (lookup returns null)', async () => {
+  it('routes to the primary when the owner is absent or legacy', async () => {
     const priReview = vi.fn().mockResolvedValue(ok({ ...CODE_OK, session_id: 'sess-1' }));
     const secReview = vi.fn();
-    const fb = createFailoverBackend(backend('codex', { reviewCode: priReview }), backend('gemini', { reviewCode: secReview }), vi.fn().mockReturnValue(null));
+    const fb = createFailoverBackend(
+      backend('codex', { reviewCode: priReview }),
+      backend('gemini', { reviewCode: secReview }),
+      vi.fn().mockReturnValue({ status: 'absent' }),
+    );
 
     const res = await fb.reviewCode(RESUME);
 
     expect(priReview).toHaveBeenCalledOnce();
     expect(secReview).not.toHaveBeenCalled();
     expect(res.ok && res.data.provider).toBe('codex');
+  });
+
+  it('rejects a resume when ownership lookup is unavailable', async () => {
+    const priReview = vi.fn();
+    const secReview = vi.fn();
+    const fb = createFailoverBackend(
+      backend('codex', { reviewCode: priReview }),
+      backend('gemini', { reviewCode: secReview }),
+      vi.fn().mockReturnValue({ status: 'unavailable' }),
+    );
+
+    const res = await fb.reviewCode(RESUME);
+
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toMatch(/^SESSION_ROUTING_UNAVAILABLE:/);
+    expect(priReview).not.toHaveBeenCalled();
+    expect(secReview).not.toHaveBeenCalled();
   });
 
   it('routes to the primary when no lookup is supplied (back-compat)', async () => {
     const priReview = vi.fn().mockResolvedValue(ok({ ...CODE_OK, session_id: 'sess-1' }));
     const secReview = vi.fn();
-    const fb = createFailoverBackend(backend('codex', { reviewCode: priReview }), backend('gemini', { reviewCode: secReview }));
+    const fb = createFailoverBackend(
+      backend('codex', { reviewCode: priReview }),
+      backend('gemini', { reviewCode: secReview }),
+    );
 
     const res = await fb.reviewCode(RESUME);
 

--- a/src/backends/failover.ts
+++ b/src/backends/failover.ts
@@ -7,6 +7,20 @@ import type {
   CodeReviewInput,
   PrecommitReviewInput,
 } from './backend.js';
+import { canOverrideModelOnResume } from './backend.js';
+
+function ownerOverrideCapability(
+  primary: ReviewBackend,
+  secondary: ReviewBackend,
+  provider: ReviewProvider,
+): boolean {
+  const owner = primary.providers.includes(provider)
+    ? primary
+    : secondary.providers.includes(provider)
+      ? secondary
+      : null;
+  return owner ? canOverrideModelOnResume(owner, provider) : false;
+}
 
 // Provider failover: wrap a primary + secondary backend so a review that fails
 // because the primary is out of usage / unavailable is transparently retried
@@ -43,13 +57,42 @@ function tag<R extends { provider?: ReviewProvider }>(
 
 type FailoverInput = { session_id?: string; model?: string };
 
-// Resolve a session id to the provider that owns it (from the sessions table).
-// Sync — better-sqlite3 is synchronous. Returns null when unknown/unresolvable.
-export type SessionProviderLookup = (sessionId: string) => ReviewProvider | null;
+export type SessionProviderLookupResult =
+  | { status: 'found'; value: ReviewProvider | null }
+  | { status: 'absent' }
+  | { status: 'unavailable' };
+
+// Ownership failures are not equivalent to an unknown legacy session: silently
+// routing through the configured primary could resume a provider-incompatible
+// conversation. Only an explicit absent/legacy result may use that fallback.
+export type SessionProviderLookup = (sessionId: string) => SessionProviderLookupResult;
+
+export function lookupSessionOwner(
+  sessionId: string,
+  lookup?: SessionProviderLookup,
+): Result<ReviewProvider | null> {
+  if (!lookup) return ok(null);
+  try {
+    const result = lookup(sessionId);
+    if (result.status === 'unavailable') {
+      return err(
+        `${ErrorCode.SESSION_ROUTING_UNAVAILABLE}: session ownership could not be established safely`,
+      );
+    }
+    return ok(result.status === 'found' ? result.value : null);
+  } catch {
+    return err(
+      `${ErrorCode.SESSION_ROUTING_UNAVAILABLE}: session ownership could not be established safely`,
+    );
+  }
+}
 
 // Exported for reuse by the deliberation composite, whose precommit path (and
 // resumed-session path) is plain failover, not deliberation.
-export async function withFailover<I extends FailoverInput, R extends { provider?: ReviewProvider }>(
+export async function withFailover<
+  I extends FailoverInput,
+  R extends { provider?: ReviewProvider },
+>(
   primary: ReviewBackend,
   secondary: ReviewBackend,
   input: I,
@@ -62,7 +105,9 @@ export async function withFailover<I extends FailoverInput, R extends { provider
   // backend ever serves >1 provider. Unknown owner (no lookup / not found) →
   // primary, the historical default.
   if (input.session_id) {
-    const owner = lookup?.(input.session_id) ?? null;
+    const ownerResult = lookupSessionOwner(input.session_id, lookup);
+    if (!ownerResult.ok) return err<R>(ownerResult.error);
+    const owner = ownerResult.data;
     const target = owner && secondary.providers.includes(owner) ? secondary : primary;
     return tag(target.provider, await run(target, input));
   }
@@ -81,9 +126,7 @@ export async function withFailover<I extends FailoverInput, R extends { provider
 
   // Both failed: lead with the primary's error (its code/prefix), note the
   // fallback outcome so the failure is diagnosable.
-  return err<R>(
-    `${first.error} (fallback to ${secondary.provider} also failed: ${second.error})`,
-  );
+  return err<R>(`${first.error} (fallback to ${secondary.provider} also failed: ${second.error})`);
 }
 
 export function createFailoverBackend(
@@ -92,12 +135,13 @@ export function createFailoverBackend(
   lookup?: SessionProviderLookup,
 ): ReviewBackend {
   return {
-    // The composite presents as the primary for tagging new sessions + the
-    // session_id/model gate. Resumes route to the OWNING leaf via `lookup`, not
-    // unconditionally to the primary.
+    // The composite presents as the primary for tagging new sessions. Resumes
+    // and their model capability checks target the OWNING leaf via `lookup`.
     provider: primary.provider,
     providers: [...primary.providers, ...secondary.providers],
     allowsModelOverrideOnResume: primary.allowsModelOverrideOnResume,
+    allowsModelOverrideOnResumeFor: (provider) =>
+      ownerOverrideCapability(primary, secondary, provider),
     reviewPlan: (input: PlanReviewInput) =>
       withFailover(primary, secondary, input, (b, i) => b.reviewPlan(i), lookup),
     reviewCode: (input: CodeReviewInput) =>

--- a/src/backends/gemini.test.ts
+++ b/src/backends/gemini.test.ts
@@ -15,14 +15,20 @@ class FakeChild extends EventEmitter {
   stdin: EventEmitter & { write: (s: string) => void; end: ReturnType<typeof vi.fn> };
   constructor(signal?: AbortSignal) {
     super();
-    const stdin = new EventEmitter() as EventEmitter & { write: (s: string) => void; end: ReturnType<typeof vi.fn> };
+    const stdin = new EventEmitter() as EventEmitter & {
+      write: (s: string) => void;
+      end: ReturnType<typeof vi.fn>;
+    };
     stdin.write = (s: string) => {
       this.stdinChunks.push(s);
     };
     stdin.end = vi.fn();
     this.stdin = stdin;
     signal?.addEventListener('abort', () => {
-      this.emit('error', Object.assign(new Error('The operation was aborted'), { name: 'AbortError' }));
+      this.emit(
+        'error',
+        Object.assign(new Error('The operation was aborted'), { name: 'AbortError' }),
+      );
     });
   }
 }
@@ -89,6 +95,7 @@ import {
   resolveLatestGeminiModel,
   parseAgyModels,
   warnIfUnknownModel,
+  clearGeminiModelCatalogCache,
 } from './gemini.js';
 import { DEFAULT_CONFIG } from '../config/types.js';
 
@@ -111,6 +118,7 @@ beforeEach(() => {
   fakeFiles = {};
   scriptedResponses = [];
   spawnCount = 0;
+  clearGeminiModelCatalogCache();
   // The flow narrates the resolved model on stderr for unpinned reviews; these
   // tests don't assert on it, so keep their output clean.
   vi.spyOn(console, 'error').mockImplementation(() => {});
@@ -154,7 +162,12 @@ describe('classifyAgyError', () => {
   });
 });
 
-const OPTS = { prompt: 'review this', model: 'Gemini 3.5 Flash (Medium)', cwd: '/repo', timeoutMs: 5000 };
+const OPTS = {
+  prompt: 'review this',
+  model: 'Gemini 3.5 Flash (Medium)',
+  cwd: '/repo',
+  timeoutMs: 5000,
+};
 
 describe('runAgyPrint', () => {
   it('spawns agy in print+sandbox mode with the model, pipes the prompt to stdin, returns stdout', async () => {
@@ -233,7 +246,9 @@ describe('runAgyPrint', () => {
     const p = runAgyPrint(OPTS);
     // One oversized chunk (>10MB) trips the cap: the run resolves to an error and
     // the child is aborted rather than buffering the stream unbounded.
-    expect(() => lastChild.stdout.emit('data', Buffer.from('x'.repeat(10 * 1024 * 1024 + 1)))).not.toThrow();
+    expect(() =>
+      lastChild.stdout.emit('data', Buffer.from('x'.repeat(10 * 1024 * 1024 + 1))),
+    ).not.toThrow();
     const res = await p;
     expect(res.ok).toBe(false);
     if (!res.ok) {
@@ -318,7 +333,9 @@ describe('runAgyModels', () => {
 
   it('returns null (degrades to fallback) when output exceeds the size cap (B2)', async () => {
     const p = runAgyModels();
-    expect(() => lastChild.stdout.emit('data', Buffer.from('x'.repeat(10 * 1024 * 1024 + 1)))).not.toThrow();
+    expect(() =>
+      lastChild.stdout.emit('data', Buffer.from('x'.repeat(10 * 1024 * 1024 + 1))),
+    ).not.toThrow();
     expect(await p).toBeNull(); // over-cap output → null, caller falls back to the default model
   });
 
@@ -334,6 +351,29 @@ describe('runAgyModels', () => {
 });
 
 describe('resolveLatestGeminiModel', () => {
+  it('single-flights and caches the model catalog for repeated resolutions', async () => {
+    script({ stdout: REAL_AGY_MODELS, code: 0 });
+    const [a, b] = await Promise.all([resolveLatestGeminiModel(), resolveLatestGeminiModel()]);
+    const c = await resolveLatestGeminiModel();
+    expect(a).toBe('Gemini 3.5 Flash (Medium)');
+    expect(b).toBe(a);
+    expect(c).toBe(a);
+    expect(spawnCount).toBe(1);
+  });
+
+  it('refreshes the process catalog after the five-minute TTL', async () => {
+    const clock = vi.spyOn(Date, 'now').mockReturnValue(1_000);
+    script(
+      { stdout: 'Gemini 4.0 Flash (Medium)', code: 0 },
+      { stdout: 'Gemini 4.1 Flash (Medium)', code: 0 },
+    );
+
+    expect(await resolveLatestGeminiModel()).toBe('Gemini 4.0 Flash (Medium)');
+    clock.mockReturnValue(301_001);
+    expect(await resolveLatestGeminiModel()).toBe('Gemini 4.1 Flash (Medium)');
+    expect(spawnCount).toBe(2);
+  });
+
   it('resolves to the newest Flash reported by agy', async () => {
     script({ stdout: 'Gemini 4.0 Flash (Medium)\nGemini 3.5 Flash (Medium)', code: 0 });
     expect(await resolveLatestGeminiModel()).toBe('Gemini 4.0 Flash (Medium)');
@@ -342,6 +382,14 @@ describe('resolveLatestGeminiModel', () => {
   it('falls back to the known-good model when the query fails', async () => {
     script({ stderr: 'boom', code: 1 });
     expect(await resolveLatestGeminiModel()).toBe('Gemini 3.5 Flash (Medium)');
+  });
+
+  it('caches an unavailable catalog for five minutes instead of repeatedly spawning agy', async () => {
+    script({ stderr: 'boom', code: 1 });
+
+    expect(await resolveLatestGeminiModel()).toBe('Gemini 3.5 Flash (Medium)');
+    expect(await resolveLatestGeminiModel()).toBe('Gemini 3.5 Flash (Medium)');
+    expect(spawnCount).toBe(1);
   });
 
   it('falls back to the known-good model when no Flash line is parseable', async () => {
@@ -411,6 +459,16 @@ describe('readConversationId', () => {
     fakeFiles[CACHE] = '{ not valid json';
     expect(readConversationId('/repo')).toBeUndefined();
   });
+
+  it.each([
+    ['empty', ''],
+    ['surrounding whitespace', ' conv-abc '],
+    ['control characters', 'conv\u007fabc'],
+    ['more than 256 characters', 'x'.repeat(257)],
+  ])('returns undefined when the cached conversation id has %s', (_case, conversationId) => {
+    fakeFiles[CACHE] = JSON.stringify({ '/repo': conversationId });
+    expect(readConversationId('/repo')).toBeUndefined();
+  });
 });
 
 describe('runSerialized', () => {
@@ -432,7 +490,9 @@ describe('runSerialized', () => {
   });
 
   it('keeps the chain alive after a section rejects (no deadlock)', async () => {
-    await expect(runSerialized(async () => Promise.reject(new Error('boom')))).rejects.toThrow('boom');
+    await expect(runSerialized(async () => Promise.reject(new Error('boom')))).rejects.toThrow(
+      'boom',
+    );
     await expect(runSerialized(async () => 'ok')).resolves.toBe('ok');
   });
 });
@@ -506,11 +566,53 @@ describe('createGeminiBackend', () => {
     // No cache entry on purpose — the resume path must not depend on capture.
     script({ stdout: JSON.stringify(CODE_OK) });
 
-    const res = await createGeminiBackend(PINNED_CONFIG).reviewCode({ diff: SMALL_DIFF, session_id: 'conv-prev' });
+    const res = await createGeminiBackend(PINNED_CONFIG).reviewCode({
+      diff: SMALL_DIFF,
+      session_id: 'conv-prev',
+    });
 
     expect(res.ok).toBe(true);
     if (res.ok) expect(res.data.session_id).toBe('conv-prev');
     expect(lastArgs[lastArgs.indexOf('--conversation') + 1]).toBe('conv-prev');
+  });
+
+  it.each([
+    ['empty', ''],
+    ['surrounding whitespace', ' conv-prev '],
+    ['control characters', 'conv\nforged'],
+    ['more than 256 characters', 'x'.repeat(257)],
+  ])('rejects a resumed session id with %s before calling agy', async (_case, sessionId) => {
+    const result = await createGeminiBackend(PINNED_CONFIG).reviewPlan({
+      plan: 'x',
+      session_id: sessionId,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain(ErrorCode.INVALID_INPUT);
+      expect(result.error).toContain('invalid session ID');
+      expect(result).not.toHaveProperty('session_id');
+    }
+    expect(spawnCount).toBe(0);
+  });
+
+  it.each([
+    ['empty', ''],
+    ['surrounding whitespace', ' conv-new '],
+    ['control characters', 'conv\u009fforged'],
+    ['more than 256 characters', 'x'.repeat(257)],
+  ])('rejects a fresh cached conversation id with %s', async (_case, conversationId) => {
+    fakeFiles[CACHE] = JSON.stringify({ [CWD]: conversationId });
+    script({ stdout: JSON.stringify(PLAN_OK) });
+
+    const result = await createGeminiBackend(PINNED_CONFIG).reviewPlan({ plan: 'x' });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain(ErrorCode.STORAGE_ERROR);
+      expect(result.error).toContain('no conversation id was captured');
+      expect(result).not.toHaveProperty('session_id');
+    }
   });
 
   it('retries once on malformed JSON, then succeeds (two spawns)', async () => {
@@ -533,7 +635,9 @@ describe('createGeminiBackend', () => {
     fakeFiles[CACHE] = JSON.stringify({ [CWD]: 'conv-x' });
     script({ stdout: 'not json', code: 0 }); // attempt 1 malformed; attempt 2 left to time out
 
-    const p = createGeminiBackend({ ...PINNED_CONFIG, timeout_seconds: 10 }).reviewPlan({ plan: 'x' });
+    const p = createGeminiBackend({ ...PINNED_CONFIG, timeout_seconds: 10 }).reviewPlan({
+      plan: 'x',
+    });
     await vi.advanceTimersByTimeAsync(10_000 + 50); // blow past the total budget → attempt 2 aborts
     const res = await p;
 
@@ -550,7 +654,10 @@ describe('createGeminiBackend', () => {
   // timeouts, never real classified errors.
   it('still surfaces a genuine process error on the retry, not a masked parse error (m2)', async () => {
     fakeFiles[CACHE] = JSON.stringify({ [CWD]: 'conv-x' });
-    script({ stdout: 'not json', code: 0 }, { stderr: 'Error: you are not authenticated', code: 1 });
+    script(
+      { stdout: 'not json', code: 0 },
+      { stderr: 'Error: you are not authenticated', code: 1 },
+    );
 
     const res = await createGeminiBackend(PINNED_CONFIG).reviewPlan({ plan: 'x' });
 
@@ -569,7 +676,9 @@ describe('createGeminiBackend', () => {
     vi.useFakeTimers();
     fakeFiles[CACHE] = JSON.stringify({ [CWD]: 'conv-x' });
 
-    const p = createGeminiBackend({ ...PINNED_CONFIG, timeout_seconds: 10 }).reviewPlan({ plan: 'x' });
+    const p = createGeminiBackend({ ...PINNED_CONFIG, timeout_seconds: 10 }).reviewPlan({
+      plan: 'x',
+    });
     // Let attempt 1 spawn, consume 6s, then return malformed (exit 0).
     await vi.advanceTimersByTimeAsync(6_000);
     lastChild.stdout.emit('data', Buffer.from('not json'));
@@ -635,7 +744,10 @@ describe('createGeminiBackend', () => {
       { stdout: JSON.stringify(CODE_OK) },
     );
 
-    const res = await createGeminiBackend(DEFAULT_CONFIG).reviewCode({ diff: SMALL_DIFF, model: 'latest' });
+    const res = await createGeminiBackend(DEFAULT_CONFIG).reviewCode({
+      diff: SMALL_DIFF,
+      model: 'latest',
+    });
 
     expect(res.ok).toBe(true);
     expect(spawnCount).toBe(2);
@@ -680,7 +792,9 @@ describe('createGeminiBackend', () => {
     // Generously script success for every chunk (extra entries are ignored).
     script(...Array.from({ length: 10 }, () => ({ stdout: JSON.stringify(CODE_OK) })));
 
-    const res = await createGeminiBackend({ ...PINNED_CONFIG, max_chunk_tokens: 2500 }).reviewCode({ diff: BIG_DIFF });
+    const res = await createGeminiBackend({ ...PINNED_CONFIG, max_chunk_tokens: 2500 }).reviewCode({
+      diff: BIG_DIFF,
+    });
 
     expect(res.ok).toBe(true);
     if (res.ok) {
@@ -698,7 +812,10 @@ describe('createGeminiBackend', () => {
     // First spawn validates against `agy models`; second is the review.
     script({ stdout: REAL_AGY_MODELS, code: 0 }, { stdout: JSON.stringify(CODE_OK) });
 
-    const res = await createGeminiBackend({ ...DEFAULT_CONFIG, model: 'FakeModel-9000' }).reviewCode({
+    const res = await createGeminiBackend({
+      ...DEFAULT_CONFIG,
+      model: 'FakeModel-9000',
+    }).reviewCode({
       diff: SMALL_DIFF,
     });
 
@@ -714,7 +831,10 @@ describe('createGeminiBackend', () => {
     fakeFiles[CACHE] = JSON.stringify({ [CWD]: 'conv-low' });
     script({ stdout: REAL_AGY_MODELS, code: 0 }, { stdout: JSON.stringify(CODE_OK) });
 
-    const res = await createGeminiBackend({ ...DEFAULT_CONFIG, model: 'Gemini 3.5 Flash (Low)' }).reviewCode({
+    const res = await createGeminiBackend({
+      ...DEFAULT_CONFIG,
+      model: 'Gemini 3.5 Flash (Low)',
+    }).reviewCode({
       diff: SMALL_DIFF,
     });
 
@@ -728,7 +848,10 @@ describe('createGeminiBackend', () => {
     fakeFiles[CACHE] = JSON.stringify({ [CWD]: 'conv-rec' });
     script({ stdout: JSON.stringify(CODE_OK) });
 
-    const res = await createGeminiBackend({ ...DEFAULT_CONFIG, model: 'Gemini 3.1 Pro (High)' }).reviewCode({
+    const res = await createGeminiBackend({
+      ...DEFAULT_CONFIG,
+      model: 'Gemini 3.1 Pro (High)',
+    }).reviewCode({
       diff: SMALL_DIFF,
     });
 
@@ -741,7 +864,9 @@ describe('createGeminiBackend', () => {
     // Chunk 1 succeeds (captures conv-partial); chunk 2 fails at the agy boundary.
     script({ stdout: JSON.stringify(CODE_OK) }, { stderr: 'you are not authenticated', code: 1 });
 
-    const res = await createGeminiBackend({ ...PINNED_CONFIG, max_chunk_tokens: 2500 }).reviewCode({ diff: BIG_DIFF });
+    const res = await createGeminiBackend({ ...PINNED_CONFIG, max_chunk_tokens: 2500 }).reviewCode({
+      diff: BIG_DIFF,
+    });
 
     expect(res.ok).toBe(false);
     if (!res.ok) {
@@ -756,8 +881,18 @@ describe('createGeminiBackend', () => {
     // capture B's id. Serialization makes each run+capture atomic — this fails
     // deterministically (both become 'race-id-B') if the serialization is removed.
     script(
-      { stdout: JSON.stringify(PLAN_OK), onEmit: () => { fakeFiles[CACHE] = JSON.stringify({ [CWD]: 'race-id-A' }); } },
-      { stdout: JSON.stringify(PLAN_OK), onEmit: () => { fakeFiles[CACHE] = JSON.stringify({ [CWD]: 'race-id-B' }); } },
+      {
+        stdout: JSON.stringify(PLAN_OK),
+        onEmit: () => {
+          fakeFiles[CACHE] = JSON.stringify({ [CWD]: 'race-id-A' });
+        },
+      },
+      {
+        stdout: JSON.stringify(PLAN_OK),
+        onEmit: () => {
+          fakeFiles[CACHE] = JSON.stringify({ [CWD]: 'race-id-B' });
+        },
+      },
     );
     const backend = createGeminiBackend(PINNED_CONFIG);
 

--- a/src/backends/gemini.ts
+++ b/src/backends/gemini.ts
@@ -7,6 +7,8 @@ import type { Result } from '../utils/errors.js';
 import type { ReviewBridgeConfig } from '../config/types.js';
 import { RECOMMENDED_MODELS } from '../config/types.js';
 import type { CopilotInstructions } from '../config/copilot-instructions.js';
+import { escapeTerminalControls } from '../utils/terminal.js';
+import { SessionIdSchema } from '../utils/input-validation.js';
 import type { ReviewBackend } from './backend.js';
 import {
   runPlanReview,
@@ -230,7 +232,8 @@ export function readConversationId(cwd: string): string | undefined {
   try {
     const map = JSON.parse(content) as Record<string, unknown>;
     const id = map[cwd];
-    return typeof id === 'string' ? id : undefined;
+    const parsed = SessionIdSchema.safeParse(id);
+    return parsed.success ? parsed.data : undefined;
   } catch {
     return undefined;
   }
@@ -271,6 +274,9 @@ const GEMINI_DEFAULT_MODEL = 'Gemini 3.5 Flash (Medium)';
 // `agy models` is a quick metadata call; bound it well under a review timeout so
 // a hung query degrades to the fallback fast.
 const MODEL_QUERY_TIMEOUT_MS = 15_000;
+const MODEL_CATALOG_TTL_MS = 5 * 60 * 1000;
+let modelCatalogCache: { output: string | null; expiresAt: number } | undefined;
+let modelCatalogInFlight: Promise<string | null> | undefined;
 
 // `latest` for gemini means the newest Flash, at the same effort tier we default
 // to where available. Flash is the fast review line; Pro is a heavier, separate
@@ -361,10 +367,36 @@ export function runAgyModels(timeoutMs: number = MODEL_QUERY_TIMEOUT_MS): Promis
   });
 }
 
+async function getAgyModelCatalog(timeoutMs?: number): Promise<string | null> {
+  const now = Date.now();
+  if (modelCatalogCache && modelCatalogCache.expiresAt > now) {
+    return modelCatalogCache.output;
+  }
+  if (modelCatalogInFlight) return modelCatalogInFlight;
+
+  modelCatalogInFlight = runAgyModels(timeoutMs).then((output) => {
+    // Cache unavailable catalogs too. Otherwise a missing or unhealthy agy
+    // binary would spawn another bounded metadata process for every review,
+    // defeating the process-wide five-minute catalog cache.
+    modelCatalogCache = { output, expiresAt: Date.now() + MODEL_CATALOG_TTL_MS };
+    return output;
+  });
+  try {
+    return await modelCatalogInFlight;
+  } finally {
+    modelCatalogInFlight = undefined;
+  }
+}
+
+export function clearGeminiModelCatalogCache(): void {
+  modelCatalogCache = undefined;
+  modelCatalogInFlight = undefined;
+}
+
 // Resolve gemini's `latest`: the newest Flash from `agy models`, degrading to the
 // known-good fallback if the query fails or yields no parseable Flash line.
 export async function resolveLatestGeminiModel(timeoutMs?: number): Promise<string> {
-  const output = await runAgyModels(timeoutMs);
+  const output = await getAgyModelCatalog(timeoutMs);
   if (!output) return GEMINI_DEFAULT_MODEL;
   return pickLatestFlashModel(output) ?? GEMINI_DEFAULT_MODEL;
 }
@@ -394,12 +426,12 @@ function isRecommendedGeminiModel(model: string): boolean {
 // miss. Non-blocking: we still forward the user's model as-is (L-006). Stays silent
 // when the model list is unavailable (can't validate → no false alarm).
 export async function warnIfUnknownModel(requested: string): Promise<void> {
-  const output = await runAgyModels();
+  const output = await getAgyModelCatalog();
   if (!output) return;
   const known = parseAgyModels(output).map(normalizeModelName);
   if (!known.includes(normalizeModelName(requested))) {
     console.error(
-      `[codex-bridge] warning: model "${requested}" is not in agy's model list ` +
+      `[codex-bridge] warning: model "${escapeTerminalControls(requested)}" is not in agy's model list ` +
         `(run \`agy models\` to see options). agy may silently run a different model.`,
     );
   }
@@ -412,7 +444,20 @@ export async function warnIfUnknownModel(requested: string): Promise<void> {
 async function runAgyReview<T extends Record<string, unknown>>(
   params: TurnParams & { config: ReviewBridgeConfig; cwd: string },
 ): Promise<Result<T & { session_id: string }>> {
-  const { prompt, responseSchema, sessionId, resolvedModel, config, cwd } = params;
+  const { prompt, responseSchema, sessionId: rawSessionId, resolvedModel, config, cwd } = params;
+  let sessionId: string | undefined;
+  if (rawSessionId !== undefined) {
+    const parsedSessionId = SessionIdSchema.safeParse(rawSessionId);
+    if (!parsedSessionId.success) {
+      return err<T & { session_id: string }>(`${ErrorCode.INVALID_INPUT}: invalid session ID`);
+    }
+    sessionId = parsedSessionId.data;
+  }
+  if (!resolvedModel) {
+    return err<T & { session_id: string }>(
+      `${ErrorCode.MODEL_ERROR}: no model was resolved for the Gemini review`,
+    );
+  }
   // One shared deadline across both attempts (total budget), mirroring Codex's
   // single AbortSignal.timeout — a fresh per-attempt timeout would grant up to
   // ~2× timeout_seconds of wall-clock (m2).
@@ -426,7 +471,13 @@ async function runAgyReview<T extends Record<string, unknown>>(
       // The retry gets only the budget remaining after attempt 1 (floored at 1ms
       // so setTimeout never goes negative — an exhausted budget aborts at once).
       const timeoutMs = Math.max(deadline - Date.now(), 1);
-      const run = await runAgyPrint({ prompt, model: resolvedModel, conversationId: sessionId, cwd, timeoutMs });
+      const run = await runAgyPrint({
+        prompt,
+        model: resolvedModel,
+        conversationId: sessionId,
+        cwd,
+        timeoutMs,
+      });
       if (!run.ok) {
         // A retry that timed out AFTER a prior parse failure: the malformed
         // response — not the clock — is the actionable cause, so surface it as a
@@ -465,8 +516,15 @@ async function runAgyReview<T extends Record<string, unknown>>(
             `Check that ~/.gemini/antigravity-cli is readable.`,
         );
       }
+      const parsedSessionId = SessionIdSchema.safeParse(resolvedId);
+      if (!parsedSessionId.success) {
+        return err<T & { session_id: string }>(
+          `${ErrorCode.STORAGE_ERROR}: agy review succeeded but captured an invalid conversation id. ` +
+            `Check that ~/.gemini/antigravity-cli is readable.`,
+        );
+      }
       // Single cast justified: safeParse validated result.data matches the schema.
-      return ok({ ...(result.data as T), session_id: resolvedId });
+      return ok({ ...(result.data as T), session_id: parsedSessionId.data });
     }
     return err<T & { session_id: string }>(`${ErrorCode.RESPONSE_PARSE_ERROR}: ${lastError}`);
   });
@@ -483,7 +541,7 @@ export function createGeminiBackend(
   // quiet to avoid noise on every gemini startup.
   if (config.reasoning_effort !== 'medium') {
     console.error(
-      `[codex-bridge] note: reasoning_effort "${config.reasoning_effort}" is ignored by the Gemini backend — ` +
+      `[codex-bridge] note: reasoning_effort "${escapeTerminalControls(config.reasoning_effort)}" is ignored by the Gemini backend — ` +
         `effort is part of the agy model name (e.g. "Gemini 3.5 Flash (High)"). Pin a higher-effort model instead.`,
     );
   }
@@ -492,6 +550,7 @@ export function createGeminiBackend(
     runAgyReview<T>({ ...params, config, cwd: process.cwd() });
   const deps = {
     config,
+    provider: 'gemini' as const,
     copilotInstructions,
     // agy accepts a model on resume (nothing reasserts it), and persists each
     // conversation natively — so chunks review independently (resumesAcrossChunks

--- a/src/backends/index.test.ts
+++ b/src/backends/index.test.ts
@@ -65,6 +65,26 @@ describe('createBackend — two-provider composite', () => {
     expect(backend).toBe(compositeStub);
   });
 
+  it('injects persisted model lookup into every Codex leaf', () => {
+    const providerLookup = vi.fn();
+    const modelLookup = vi.fn();
+    const config = { ...DEFAULT_CONFIG, provider: 'gemini' as const, mode: 'deliberate' as const };
+
+    createBackend(config, undefined, providerLookup, modelLookup);
+
+    expect(createCodexBackend).toHaveBeenCalledWith(
+      expect.objectContaining({ provider: 'codex' }),
+      undefined,
+      { lookupSessionModel: modelLookup },
+    );
+    expect(createCompositeBackend).toHaveBeenCalledWith(
+      geminiStub,
+      codexStub,
+      config,
+      providerLookup,
+    );
+  });
+
   it('builds the secondary leaf with the other provider and a cleared model pin', () => {
     createBackend({ ...DEFAULT_CONFIG, provider: 'codex', model: 'gpt-5.4' });
     expect(createGeminiBackend).toHaveBeenCalledWith(

--- a/src/backends/index.ts
+++ b/src/backends/index.ts
@@ -5,6 +5,7 @@ import { createCodexBackend } from './codex.js';
 import { createGeminiBackend } from './gemini.js';
 import type { SessionProviderLookup } from './failover.js';
 import { createCompositeBackend, withSingleMode } from './composite.js';
+import type { ModelIdentity } from '../review/types.js';
 
 export type { ReviewBackend } from './backend.js';
 
@@ -16,10 +17,13 @@ export type { ReviewBackend } from './backend.js';
 function createLeafBackend(
   config: ReviewBridgeConfig,
   copilotInstructions?: CopilotInstructions,
+  lookupSessionModel?: (sessionId: string) => ModelIdentity | null,
 ): ReviewBackend {
   switch (config.provider) {
     case 'codex':
-      return createCodexBackend(config, copilotInstructions);
+      return lookupSessionModel
+        ? createCodexBackend(config, copilotInstructions, { lookupSessionModel })
+        : createCodexBackend(config, copilotInstructions);
     case 'gemini':
       return createGeminiBackend(config, copilotInstructions);
   }
@@ -27,7 +31,9 @@ function createLeafBackend(
   // compile if a provider is added without a case; it then falls back to codex
   // rather than throwing.
   config.provider satisfies never;
-  return createCodexBackend(config, copilotInstructions);
+  return lookupSessionModel
+    ? createCodexBackend(config, copilotInstructions, { lookupSessionModel })
+    : createCodexBackend(config, copilotInstructions);
 }
 
 // Build the review backend the config selects. `mode` picks the base composition:
@@ -43,9 +49,10 @@ export function createBackend(
   config: ReviewBridgeConfig,
   copilotInstructions?: CopilotInstructions,
   lookupSessionProvider?: SessionProviderLookup,
+  lookupSessionModel?: (sessionId: string) => ModelIdentity | null,
 ): ReviewBackend {
   const mode = config.mode ?? (config.fallback ? 'failover' : 'single');
-  const primary = createLeafBackend(config, copilotInstructions);
+  const primary = createLeafBackend(config, copilotInstructions, lookupSessionModel);
   if (mode === 'single') return withSingleMode(primary);
 
   const secondaryProvider: ReviewProvider = config.provider === 'codex' ? 'gemini' : 'codex';
@@ -55,6 +62,7 @@ export function createBackend(
   const secondary = createLeafBackend(
     { ...config, provider: secondaryProvider, model: undefined },
     copilotInstructions,
+    lookupSessionModel,
   );
   return createCompositeBackend(primary, secondary, config, lookupSessionProvider);
 }

--- a/src/backends/orchestrator.test.ts
+++ b/src/backends/orchestrator.test.ts
@@ -1,12 +1,14 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { toJSONSchema } from 'zod';
-import { ok } from '../utils/errors.js';
+import { ErrorCode, ok } from '../utils/errors.js';
 import { DEFAULT_CONFIG } from '../config/types.js';
 import {
   runPlanReview,
   runCodeReview,
+  runPrecommitReview,
   runCrossReview,
   deduplicateFindings,
+  deduplicateModelIdentities,
   mergeCodeResults,
   mergePrecommitResults,
   RESPONSE_SCHEMAS,
@@ -14,6 +16,7 @@ import {
   type TurnRunner,
   type ReviewFlowDeps,
 } from './orchestrator.js';
+import type { ModelIdentity } from '../review/types.js';
 
 // A fake TurnRunner that records every call and returns a canned valid result.
 // Lets us assert how the flow drives the backend (sessionId/model per turn)
@@ -32,7 +35,9 @@ function makeFakeTurn(canned: Record<string, unknown>): { turn: TurnRunner; call
   const calls: TurnParams[] = [];
   const turn: TurnRunner = <T extends Record<string, unknown>>(params: TurnParams) => {
     calls.push({ ...params });
-    return Promise.resolve(ok({ ...canned, session_id: 'fake-session' } as T & { session_id: string }));
+    return Promise.resolve(
+      ok({ ...canned, session_id: 'fake-session' } as T & { session_id: string }),
+    );
   };
   return { turn, calls };
 }
@@ -41,6 +46,32 @@ const CANNED_PLAN = { verdict: 'approve', summary: 'ok', findings: [] };
 const CANNED_CODE = { verdict: 'approve', summary: 'ok', findings: [] };
 
 const SMALL_DIFF = 'diff --git a/f.ts b/f.ts\n--- a/f.ts\n+++ b/f.ts\n@@ -1 +1 @@\n-a\n+b\n';
+
+describe('deduplicateModelIdentities', () => {
+  it('removes exact duplicates while preserving first-seen order and every identity dimension', () => {
+    const base: ModelIdentity = {
+      provider: 'codex',
+      role: 'review',
+      requested: null,
+      resolved: 'gpt-5.6-sol',
+      observed: 'gpt-5.6-sol',
+      evidence: 'runtime_session_record',
+    };
+    const distinct: ModelIdentity[] = [
+      { ...base, provider: 'gemini' },
+      { ...base, role: 'adjudication' },
+      { ...base, requested: 'latest' },
+      { ...base, resolved: 'gpt-5.5' },
+      { ...base, observed: null },
+      { ...base, evidence: 'bridge_selection' },
+    ];
+
+    expect(deduplicateModelIdentities([base, base, ...distinct, base])).toEqual([
+      base,
+      ...distinct,
+    ]);
+  });
+});
 
 // Build a multi-file diff large enough to force the chunk loop to split.
 function bigDiff(files: number, lines: number): string {
@@ -61,18 +92,23 @@ function deps(
 ): ReviewFlowDeps {
   return {
     config: { ...DEFAULT_CONFIG, ...overrides },
+    provider: 'codex',
     allowsModelOverrideOnResume,
     // Faithful stand-in for a backend resolver: an explicit pin passes through,
     // 'latest'/unset collapses to a fixed default. Backend-specific 'latest'
     // discovery (agy models / SDK pin) is tested in the backend suites.
-    resolveModel: async (requested) => (requested && requested !== 'latest' ? requested : 'default-model'),
+    resolveModel: async (requested) =>
+      requested && requested !== 'latest' ? requested : 'default-model',
     resumesAcrossChunks,
   };
 }
 
 // Like makeFakeTurn but returns a distinct session id per call (session-0,
 // session-1, ...) so tests can assert which session each chunk runs against.
-function makeCountingTurn(canned: Record<string, unknown>): { turn: TurnRunner; calls: TurnParams[] } {
+function makeCountingTurn(canned: Record<string, unknown>): {
+  turn: TurnRunner;
+  calls: TurnParams[];
+} {
   const calls: TurnParams[] = [];
   let n = 0;
   const turn: TurnRunner = <T extends Record<string, unknown>>(params: TurnParams) => {
@@ -86,7 +122,11 @@ function makeCountingTurn(canned: Record<string, unknown>): { turn: TurnRunner; 
 describe('orchestrator — allowsModelOverrideOnResume capability', () => {
   it('capability=false: session_id + model is rejected as a conflict; turn not called', async () => {
     const { turn, calls } = makeFakeTurn(CANNED_PLAN);
-    const res = await runPlanReview({ plan: 'do a thing', session_id: 's1', model: 'm' }, deps(false), turn);
+    const res = await runPlanReview(
+      { plan: 'do a thing', session_id: 's1', model: 'm' },
+      deps(false),
+      turn,
+    );
     expect(res.ok).toBe(false);
     if (!res.ok) expect(res.error).toContain('Cannot change model on a resumed session');
     expect(calls).toHaveLength(0);
@@ -94,7 +134,11 @@ describe('orchestrator — allowsModelOverrideOnResume capability', () => {
 
   it('capability=true: session_id + model is allowed and the model is forwarded to the turn', async () => {
     const { turn, calls } = makeFakeTurn(CANNED_PLAN);
-    const res = await runPlanReview({ plan: 'do a thing', session_id: 's1', model: 'm' }, deps(true), turn);
+    const res = await runPlanReview(
+      { plan: 'do a thing', session_id: 's1', model: 'm' },
+      deps(true),
+      turn,
+    );
     expect(res.ok).toBe(true);
     expect(calls).toHaveLength(1);
     expect(calls[0].sessionId).toBe('s1');
@@ -103,7 +147,11 @@ describe('orchestrator — allowsModelOverrideOnResume capability', () => {
 
   it('capability=true single-chunk code review: forwards both session_id and model', async () => {
     const { turn, calls } = makeFakeTurn(CANNED_CODE);
-    const res = await runCodeReview({ diff: SMALL_DIFF, session_id: 's1', model: 'm' }, deps(true), turn);
+    const res = await runCodeReview(
+      { diff: SMALL_DIFF, session_id: 's1', model: 'm' },
+      deps(true),
+      turn,
+    );
     expect(res.ok).toBe(true);
     expect(calls).toHaveLength(1);
     expect(calls[0].sessionId).toBe('s1');
@@ -113,7 +161,11 @@ describe('orchestrator — allowsModelOverrideOnResume capability', () => {
   it('capability=true multi-chunk: model is forwarded on every chunk, including resumed ones', async () => {
     const { turn, calls } = makeFakeTurn(CANNED_CODE);
     // Tiny budget forces the diff to split into several chunks.
-    const res = await runCodeReview({ diff: bigDiff(3, 30), model: 'm' }, deps(true, { max_chunk_tokens: 2500 }), turn);
+    const res = await runCodeReview(
+      { diff: bigDiff(3, 30), model: 'm' },
+      deps(true, { max_chunk_tokens: 2500 }),
+      turn,
+    );
     expect(res.ok).toBe(true);
     expect(calls.length).toBeGreaterThanOrEqual(2);
     // Every turn (chunk 1 fresh + chunks 2..N resumed) carries the model.
@@ -122,7 +174,11 @@ describe('orchestrator — allowsModelOverrideOnResume capability', () => {
 
   it('capability=false multi-chunk: model applies on chunk 1 only, omitted on resumed chunks', async () => {
     const { turn, calls } = makeFakeTurn(CANNED_CODE);
-    const res = await runCodeReview({ diff: bigDiff(3, 30), model: 'm' }, deps(false, { max_chunk_tokens: 2500 }), turn);
+    const res = await runCodeReview(
+      { diff: bigDiff(3, 30), model: 'm' },
+      deps(false, { max_chunk_tokens: 2500 }),
+      turn,
+    );
     expect(res.ok).toBe(true);
     expect(calls.length).toBeGreaterThanOrEqual(2);
     expect(calls[0].model).toBe('m');
@@ -135,40 +191,190 @@ describe('orchestrator — model resolution wiring', () => {
     allowsModelOverrideOnResume: boolean,
     resolveModel: (requested: string | undefined) => Promise<string>,
   ): ReviewFlowDeps {
-    return { config: { ...DEFAULT_CONFIG }, allowsModelOverrideOnResume, resolveModel, resumesAcrossChunks: true };
+    return {
+      config: { ...DEFAULT_CONFIG },
+      provider: allowsModelOverrideOnResume ? 'gemini' : 'codex',
+      allowsModelOverrideOnResume,
+      resolveModel,
+      resumesAcrossChunks: true,
+    };
   }
 
   it('uses the resolved id for both model and resolvedModel on a fresh session', async () => {
     const { turn, calls } = makeFakeTurn(CANNED_PLAN);
-    await runPlanReview({ plan: 'x' }, resolverDeps(false, async () => 'RESOLVED-X'), turn);
+    await runPlanReview(
+      { plan: 'x' },
+      resolverDeps(false, async () => 'RESOLVED-X'),
+      turn,
+    );
     expect(calls[0].model).toBe('RESOLVED-X');
     expect(calls[0].resolvedModel).toBe('RESOLVED-X');
   });
 
-  it('omits the per-turn model on a Codex-style resume but still reports resolvedModel', async () => {
+  it('normalizes surrounding whitespace in resolver output before use and reporting', async () => {
     const { turn, calls } = makeFakeTurn(CANNED_PLAN);
-    await runPlanReview({ plan: 'x', session_id: 's1' }, resolverDeps(false, async () => 'RESOLVED-X'), turn);
+    const res = await runPlanReview(
+      { plan: 'x' },
+      resolverDeps(false, async () => '  RESOLVED-X  '),
+      turn,
+    );
+
+    expect(res.ok).toBe(true);
+    expect(calls[0].model).toBe('RESOLVED-X');
+    expect(calls[0].resolvedModel).toBe('RESOLVED-X');
+    expect(res.ok && res.data.models?.[0]).toMatchObject({ resolved: 'RESOLVED-X' });
+  });
+
+  it.each([
+    ['control-bearing', 'unsafe\n--another-flag'],
+    ['empty after trimming', '   '],
+    ['over 200 characters', 'x'.repeat(201)],
+  ])('rejects %s resolver output before every provider-facing turn', async (_name, invalid) => {
+    const { turn, calls } = makeFakeTurn(CANNED_PLAN);
+    const resolveModel = async (): Promise<string> => invalid;
+    const finding = {
+      severity: 'major' as const,
+      category: 'bugs',
+      file: 'a.ts',
+      line: 1,
+      description: 'bug',
+    };
+
+    const results = await Promise.all([
+      runPlanReview({ plan: 'x' }, resolverDeps(false, resolveModel), turn),
+      runCodeReview({ diff: SMALL_DIFF }, resolverDeps(true, resolveModel), turn),
+      runPrecommitReview({ diff: SMALL_DIFF }, resolverDeps(false, resolveModel), turn),
+      runCrossReview(
+        { content: SMALL_DIFF, findings: [finding] },
+        resolverDeps(true, resolveModel),
+        turn,
+      ),
+    ]);
+
+    expect(calls).toHaveLength(0);
+    for (const result of results) {
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toBe(
+          `${ErrorCode.MODEL_ERROR}: model resolver returned an invalid model label`,
+        );
+        expect(result.error).not.toContain(invalid);
+      }
+    }
+  });
+
+  it('rejects invalid resolver output once before a multi-chunk review starts', async () => {
+    const { turn, calls } = makeCountingTurn(CANNED_CODE);
+    const resolveModel = vi.fn().mockResolvedValue('unsafe\u0000model');
+    const d = resolverDeps(true, resolveModel);
+    d.config = { ...d.config, max_chunk_tokens: 2500 };
+
+    const res = await runCodeReview({ diff: bigDiff(3, 30) }, d, turn);
+
+    expect(res.ok).toBe(false);
+    expect(resolveModel).toHaveBeenCalledTimes(1);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('omits the per-turn model and does not substitute the current default on a Codex-style resume', async () => {
+    const { turn, calls } = makeFakeTurn(CANNED_PLAN);
+    const resolveModel = vi.fn().mockResolvedValue('CURRENT-DEFAULT');
+    const d = resolverDeps(false, resolveModel);
+    d.lookupSessionModel = () => ({
+      provider: 'codex',
+      role: 'review',
+      requested: 'gpt-5.5',
+      resolved: 'gpt-5.5',
+      observed: 'gpt-5.5',
+      evidence: 'runtime_session_record',
+    });
+    const res = await runPlanReview({ plan: 'x', session_id: 's1' }, d, turn);
     expect(calls[0].sessionId).toBe('s1');
     expect(calls[0].model).toBeUndefined();
-    expect(calls[0].resolvedModel).toBe('RESOLVED-X');
+    expect(calls[0].resolvedModel).toBe('gpt-5.5');
+    expect(resolveModel).not.toHaveBeenCalled();
+    expect(res.ok && res.data.models?.[0]).toMatchObject({
+      requested: null,
+      resolved: 'gpt-5.5',
+      observed: 'gpt-5.5',
+    });
+  });
+
+  it('prefers fresh runtime observation while retaining the persisted resolved model on resume', async () => {
+    const { turn } = makeFakeTurn(CANNED_PLAN);
+    const d = resolverDeps(false, vi.fn().mockResolvedValue('CURRENT-DEFAULT'));
+    d.lookupSessionModel = () => ({
+      provider: 'codex',
+      role: 'review',
+      requested: 'gpt-5.5',
+      resolved: 'gpt-5.5',
+      observed: 'gpt-5.5',
+      evidence: 'runtime_session_record',
+    });
+    d.observeSessionModel = vi.fn().mockResolvedValue('gpt-5.6-sol');
+
+    const result = await runPlanReview({ plan: 'x', session_id: 's1' }, d, turn);
+
+    expect(result.ok && result.data.models?.[0]).toEqual({
+      provider: 'codex',
+      role: 'review',
+      requested: null,
+      resolved: 'gpt-5.5',
+      observed: 'gpt-5.6-sol',
+      evidence: 'runtime_session_record',
+    });
+    expect(d.observeSessionModel).toHaveBeenCalledOnce();
+    expect(consoleSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports unavailable evidence for a Codex resume with no retained or observed identity', async () => {
+    const { turn, calls } = makeFakeTurn(CANNED_PLAN);
+    const d = resolverDeps(false, vi.fn().mockResolvedValue('CURRENT-DEFAULT'));
+
+    const result = await runPlanReview({ plan: 'x', session_id: 'legacy-session' }, d, turn);
+
+    expect(calls[0].model).toBeUndefined();
+    expect(calls[0].resolvedModel).toBeUndefined();
+    expect(result.ok && result.data.models).toEqual([
+      {
+        provider: 'codex',
+        role: 'review',
+        requested: null,
+        resolved: null,
+        observed: null,
+        evidence: 'unavailable',
+      },
+    ]);
   });
 
   it('forwards the resolved model on resume when the backend allows it (Gemini-style)', async () => {
     const { turn, calls } = makeFakeTurn(CANNED_PLAN);
-    await runPlanReview({ plan: 'x', session_id: 's1' }, resolverDeps(true, async () => 'RESOLVED-X'), turn);
+    await runPlanReview(
+      { plan: 'x', session_id: 's1' },
+      resolverDeps(true, async () => 'RESOLVED-X'),
+      turn,
+    );
     expect(calls[0].model).toBe('RESOLVED-X');
     expect(calls[0].resolvedModel).toBe('RESOLVED-X');
   });
 
   it('narrates the resolved model on stderr for an unpinned (latest/unset) request', async () => {
     const { turn } = makeFakeTurn(CANNED_PLAN);
-    await runPlanReview({ plan: 'x' }, resolverDeps(false, async () => 'RESOLVED-X'), turn);
+    await runPlanReview(
+      { plan: 'x' },
+      resolverDeps(false, async () => 'RESOLVED-X'),
+      turn,
+    );
     expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('RESOLVED-X'));
   });
 
   it('stays quiet when an explicit model is pinned', async () => {
     const { turn } = makeFakeTurn(CANNED_PLAN);
-    await runPlanReview({ plan: 'x', model: 'pinned-1' }, resolverDeps(true, async (r) => r ?? 'x'), turn);
+    await runPlanReview(
+      { plan: 'x', model: 'pinned-1' },
+      resolverDeps(true, async (r) => r ?? 'x'),
+      turn,
+    );
     expect(consoleSpy).not.toHaveBeenCalled();
   });
 
@@ -189,22 +395,32 @@ describe('orchestrator — model resolution wiring', () => {
     let resolveCount = 0;
     const d: ReviewFlowDeps = {
       config: { ...DEFAULT_CONFIG, max_chunk_tokens: 2500 },
+      provider: 'gemini',
       allowsModelOverrideOnResume: true,
-      resolveModel: async () => { resolveCount++; return 'RESOLVED-X'; },
+      resolveModel: async () => {
+        resolveCount++;
+        return 'RESOLVED-X';
+      },
       resumesAcrossChunks: false,
     };
     const res = await runCodeReview({ diff: bigDiff(3, 30) }, d, turn);
     expect(res.ok).toBe(true);
     expect(calls.length).toBeGreaterThanOrEqual(2);
     expect(resolveCount).toBe(1); // resolved once per review, not per chunk
-    expect(calls.every((c) => c.resolvedModel === 'RESOLVED-X' && c.model === 'RESOLVED-X')).toBe(true);
+    expect(calls.every((c) => c.resolvedModel === 'RESOLVED-X' && c.model === 'RESOLVED-X')).toBe(
+      true,
+    );
   });
 });
 
 describe('orchestrator — resumesAcrossChunks capability (chunked reviews)', () => {
   it('resumesAcrossChunks=true (Codex): chunks 2..N resume the prior chunk session', async () => {
     const { turn, calls } = makeCountingTurn(CANNED_CODE);
-    const res = await runCodeReview({ diff: bigDiff(3, 30) }, deps(false, { max_chunk_tokens: 2500 }, true), turn);
+    const res = await runCodeReview(
+      { diff: bigDiff(3, 30) },
+      deps(false, { max_chunk_tokens: 2500 }, true),
+      turn,
+    );
     expect(res.ok).toBe(true);
     expect(calls.length).toBeGreaterThanOrEqual(2);
     expect(calls[0].sessionId).toBeUndefined(); // chunk 1 starts fresh
@@ -215,7 +431,11 @@ describe('orchestrator — resumesAcrossChunks capability (chunked reviews)', ()
 
   it('resumesAcrossChunks=false (Gemini): chunks 2..N run independently; review id is chunk 1', async () => {
     const { turn, calls } = makeCountingTurn(CANNED_CODE);
-    const res = await runCodeReview({ diff: bigDiff(3, 30) }, deps(true, { max_chunk_tokens: 2500 }, false), turn);
+    const res = await runCodeReview(
+      { diff: bigDiff(3, 30) },
+      deps(true, { max_chunk_tokens: 2500 }, false),
+      turn,
+    );
     expect(res.ok).toBe(true);
     expect(calls.length).toBeGreaterThanOrEqual(2);
     expect(calls[0].sessionId).toBeUndefined(); // chunk 1 fresh (no cross-phase session)
@@ -240,14 +460,34 @@ describe('orchestrator — resumesAcrossChunks capability (chunked reviews)', ()
 
 describe('orchestrator — runCrossReview (deliberate-deep)', () => {
   const CANNED_CROSS = { adjudications: [{ index: 0, verdict: 'confirmed', reason: 'real' }] };
-  const finding = { severity: 'major', category: 'bugs', file: 'a.ts', line: 5, description: 'off-by-one' };
+  const finding = {
+    severity: 'major',
+    category: 'bugs',
+    file: 'a.ts',
+    line: 5,
+    description: 'off-by-one',
+  };
 
   it('runs a single turn and returns adjudications with the session_id stripped', async () => {
     const { turn, calls } = makeFakeTurn(CANNED_CROSS);
-    const res = await runCrossReview({ content: SMALL_DIFF, findings: [finding] }, deps(false), turn);
+    const res = await runCrossReview(
+      { content: SMALL_DIFF, findings: [finding] },
+      deps(false),
+      turn,
+    );
     expect(res.ok).toBe(true);
     if (!res.ok) return;
-    expect(res.data).toEqual(CANNED_CROSS);
+    expect(res.data).toMatchObject(CANNED_CROSS);
+    expect(res.data.models).toEqual([
+      {
+        provider: 'codex',
+        role: 'adjudication',
+        requested: null,
+        resolved: 'default-model',
+        observed: null,
+        evidence: 'bridge_selection',
+      },
+    ]);
     expect(res.data).not.toHaveProperty('session_id'); // cross-review is stateless — no thread leaks out
     expect(calls).toHaveLength(1);
     expect(calls[0].prompt).toContain('off-by-one'); // the finding reached the prompt
@@ -256,7 +496,11 @@ describe('orchestrator — runCrossReview (deliberate-deep)', () => {
 
   it('forwards an explicit model pin to the turn', async () => {
     const { turn, calls } = makeFakeTurn(CANNED_CROSS);
-    await runCrossReview({ content: 'x', findings: [finding], model: 'gpt-5.5' }, deps(false), turn);
+    await runCrossReview(
+      { content: 'x', findings: [finding], model: 'gpt-5.5' },
+      deps(false),
+      turn,
+    );
     expect(calls[0].model).toBe('gpt-5.5');
   });
 
@@ -264,6 +508,77 @@ describe('orchestrator — runCrossReview (deliberate-deep)', () => {
     const { turn } = makeFakeTurn(CANNED_CROSS);
     await runCrossReview({ content: 'x', findings: [finding] }, deps(false), turn);
     expect(consoleSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('orchestrator — evidence-aware model identity', () => {
+  it('reports selected and runtime-observed identity for a fresh Codex review', async () => {
+    const { turn } = makeFakeTurn(CANNED_PLAN);
+    const d = deps(false);
+    d.observeSessionModel = vi.fn().mockResolvedValue('gpt-5.6-sol');
+    const res = await runPlanReview({ plan: 'x' }, d, turn);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.models).toEqual([
+      {
+        provider: 'codex',
+        role: 'review',
+        requested: null,
+        resolved: 'default-model',
+        observed: 'gpt-5.6-sol',
+        evidence: 'runtime_session_record',
+      },
+    ]);
+  });
+
+  it('reports Gemini bridge selection without claiming runtime observation', async () => {
+    const { turn } = makeFakeTurn(CANNED_PLAN);
+    const d = deps(true);
+    d.provider = 'gemini';
+    const res = await runPlanReview({ plan: 'x', model: 'Gemini 3.5 Flash (High)' }, d, turn);
+    expect(res.ok && res.data.models).toEqual([
+      {
+        provider: 'gemini',
+        role: 'review',
+        requested: 'Gemini 3.5 Flash (High)',
+        resolved: 'Gemini 3.5 Flash (High)',
+        observed: null,
+        evidence: 'bridge_selection',
+      },
+    ]);
+  });
+
+  it('returns both identities and warns once when observation differs from selection', async () => {
+    const { turn } = makeFakeTurn(CANNED_PLAN);
+    const d = deps(false);
+    d.observeSessionModel = vi.fn().mockResolvedValue('gpt-5.5');
+    const res = await runPlanReview({ plan: 'x', model: 'gpt-5.6-sol' }, d, turn);
+    expect(res.ok && res.data.models?.[0]).toMatchObject({
+      resolved: 'gpt-5.6-sol',
+      observed: 'gpt-5.5',
+    });
+    expect(consoleSpy).toHaveBeenCalledTimes(1);
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('model identity mismatch'));
+  });
+
+  it('observes once after the final successful chunk', async () => {
+    const { turn } = makeCountingTurn(CANNED_CODE);
+    const d = deps(false, { max_chunk_tokens: 2500 }, true);
+    d.observeSessionModel = vi.fn().mockResolvedValue('gpt-5.6-sol');
+    const res = await runCodeReview({ diff: bigDiff(3, 30) }, d, turn);
+    expect(res.ok).toBe(true);
+    expect(d.observeSessionModel).toHaveBeenCalledTimes(1);
+    expect(res.ok && res.data.models).toHaveLength(1);
+  });
+
+  it('emits empty model arrays for synthetic code and precommit results', async () => {
+    const { turn, calls } = makeFakeTurn(CANNED_CODE);
+    const d = deps(false);
+    const code = await runCodeReview({ diff: '' }, d, turn);
+    const precommit = await runPrecommitReview({ diff: '' }, d, turn);
+    expect(code.ok && code.data.models).toEqual([]);
+    expect(precommit.ok && precommit.data.models).toEqual([]);
+    expect(calls).toHaveLength(0);
   });
 });
 
@@ -288,33 +603,52 @@ describe('merge helpers', () => {
 
   describe('deduplicateFindings', () => {
     it('collapses same file:line:category to the higher-severity finding', () => {
-      const out = deduplicateFindings([cf('a.ts', 1, 'bugs', 'minor'), cf('a.ts', 1, 'bugs', 'critical')]);
+      const out = deduplicateFindings([
+        cf('a.ts', 1, 'bugs', 'minor'),
+        cf('a.ts', 1, 'bugs', 'critical'),
+      ]);
       expect(out).toHaveLength(1);
       expect(out[0].severity).toBe('critical');
     });
 
     it('keeps distinct keys separate', () => {
-      const out = deduplicateFindings([cf('a.ts', 1, 'bugs', 'major'), cf('a.ts', 2, 'bugs', 'major')]);
+      const out = deduplicateFindings([
+        cf('a.ts', 1, 'bugs', 'major'),
+        cf('a.ts', 2, 'bugs', 'major'),
+      ]);
       expect(out).toHaveLength(2);
     });
 
     it('preserves keyless findings (null file or line) without deduping them', () => {
-      const out = deduplicateFindings([cf(null, null, 'style', 'minor'), cf(null, null, 'style', 'minor')]);
+      const out = deduplicateFindings([
+        cf(null, null, 'style', 'minor'),
+        cf(null, null, 'style', 'minor'),
+      ]);
       expect(out).toHaveLength(2); // keyless can't be matched → both kept
     });
   });
 
   describe('mergeCodeResults', () => {
-    const cr = (verdict: 'approve' | 'request_changes' | 'reject', summary: string, findings: ReturnType<typeof cf>[]) => ({ verdict, summary, findings, session_id: 's' });
+    const cr = (
+      verdict: 'approve' | 'request_changes' | 'reject',
+      summary: string,
+      findings: ReturnType<typeof cf>[],
+    ) => ({ verdict, summary, findings, session_id: 's' });
 
     it('takes the worst verdict (approve < request_changes < reject)', () => {
-      const merged = mergeCodeResults([cr('approve', 'a', []), cr('reject', 'b', []), cr('request_changes', 'c', [])], 'sid');
+      const merged = mergeCodeResults(
+        [cr('approve', 'a', []), cr('reject', 'b', []), cr('request_changes', 'c', [])],
+        'sid',
+      );
       expect(merged.verdict).toBe('reject');
     });
 
     it('joins summaries, dedups findings across chunks, and records chunks_reviewed', () => {
       const merged = mergeCodeResults(
-        [cr('approve', 'first.', [cf('a.ts', 1, 'bugs', 'minor')]), cr('approve', 'second.', [cf('a.ts', 1, 'bugs', 'critical')])],
+        [
+          cr('approve', 'first.', [cf('a.ts', 1, 'bugs', 'minor')]),
+          cr('approve', 'second.', [cf('a.ts', 1, 'bugs', 'critical')]),
+        ],
         'sid',
       );
       expect(merged.summary).toBe('first. second.');
@@ -326,16 +660,28 @@ describe('merge helpers', () => {
   });
 
   describe('mergePrecommitResults', () => {
-    const pr = (ready: boolean, blockers: string[], warnings: string[]) => ({ ready_to_commit: ready, blockers, warnings, session_id: 's' });
+    const pr = (ready: boolean, blockers: string[], warnings: string[]) => ({
+      ready_to_commit: ready,
+      blockers,
+      warnings,
+      session_id: 's',
+    });
 
     it('is ready_to_commit only when EVERY chunk is ready (AND across chunks)', () => {
-      expect(mergePrecommitResults([pr(true, [], []), pr(true, [], [])], 'sid').ready_to_commit).toBe(true);
-      expect(mergePrecommitResults([pr(true, [], []), pr(false, ['x'], [])], 'sid').ready_to_commit).toBe(false);
+      expect(
+        mergePrecommitResults([pr(true, [], []), pr(true, [], [])], 'sid').ready_to_commit,
+      ).toBe(true);
+      expect(
+        mergePrecommitResults([pr(true, [], []), pr(false, ['x'], [])], 'sid').ready_to_commit,
+      ).toBe(false);
     });
 
     it('dedupes identical blockers/warnings across chunks, preserving first-seen order', () => {
       const merged = mergePrecommitResults(
-        [pr(false, ['secret in config', 'debug log'], ['slow test']), pr(false, ['secret in config'], ['slow test', 'todo left'])],
+        [
+          pr(false, ['secret in config', 'debug log'], ['slow test']),
+          pr(false, ['secret in config'], ['slow test', 'todo left']),
+        ],
         'sid',
       );
       expect(merged.blockers).toEqual(['secret in config', 'debug log']); // 'secret in config' not repeated
@@ -359,7 +705,9 @@ describe('merge helpers', () => {
       if (n.type === 'object' && n.properties && typeof n.properties === 'object') {
         const props = Object.keys(n.properties as Record<string, unknown>);
         const required = Array.isArray(n.required) ? (n.required as string[]) : [];
-        expect(new Set(required), `${path}: required must cover every property`).toEqual(new Set(props));
+        expect(new Set(required), `${path}: required must cover every property`).toEqual(
+          new Set(props),
+        );
         for (const [k, v] of Object.entries(n.properties as Record<string, unknown>)) {
           assertRequiredCoversProps(v, `${path}.${k}`);
         }
@@ -367,14 +715,19 @@ describe('merge helpers', () => {
       if (n.items) assertRequiredCoversProps(n.items, `${path}[]`);
       for (const key of ['anyOf', 'allOf', 'oneOf'] as const) {
         if (Array.isArray(n[key])) {
-          (n[key] as unknown[]).forEach((child, idx) => assertRequiredCoversProps(child, `${path}.${key}[${idx}]`));
+          (n[key] as unknown[]).forEach((child, idx) =>
+            assertRequiredCoversProps(child, `${path}.${key}[${idx}]`),
+          );
         }
       }
     };
 
     for (const [name, schema] of Object.entries(RESPONSE_SCHEMAS)) {
       it(`${name} response schema: every property is required at every level`, () => {
-        assertRequiredCoversProps(toJSONSchema(schema), name);
+        const json = toJSONSchema(schema) as { properties?: Record<string, unknown> };
+        expect(json.properties).not.toHaveProperty('models');
+        expect(json.properties).not.toHaveProperty('provenance');
+        assertRequiredCoversProps(json, name);
       });
     }
   });

--- a/src/backends/orchestrator.ts
+++ b/src/backends/orchestrator.ts
@@ -6,7 +6,7 @@ import {
   PlanReviewResultSchema,
   CodeReviewResultSchema,
   PrecommitResultSchema,
-  CrossReviewResultSchema,
+  CrossReviewResponseSchema,
   CodeFindingSeveritySchema,
 } from '../review/types.js';
 import type {
@@ -14,6 +14,7 @@ import type {
   CodeReviewResult,
   PrecommitResult,
   CrossReviewResult,
+  ModelIdentity,
   CodeFinding,
   CodeFindingSeverity,
 } from '../review/types.js';
@@ -28,12 +29,15 @@ import { chunkDiff, estimateTokens } from '../utils/chunking.js';
 import { filterByFiles, formatForPrompt } from '../config/copilot-instructions.js';
 import type { CopilotInstructions } from '../config/copilot-instructions.js';
 import { extractFilesFromDiff } from '../utils/diff-files.js';
+import { ModelSelectorSchema } from '../utils/input-validation.js';
+import type { ReviewProvider } from '../config/types.js';
 import type {
   PlanReviewInput,
   CodeReviewInput,
   PrecommitReviewInput,
   CrossReviewInput,
 } from './backend.js';
+import { escapeTerminalControls } from '../utils/terminal.js';
 
 // Provider-agnostic review orchestration shared by every backend. Carries no
 // SDK/provider assumptions: the per-turn model call, error classification, and
@@ -148,6 +152,8 @@ const PlanReviewResponseSchema = PlanReviewResultSchema.omit({
   provider: true,
   review_mode: true,
   deliberation: true,
+  models: true,
+  provenance: true,
 });
 const CodeReviewResponseSchema = CodeReviewResultSchema.omit({
   session_id: true,
@@ -155,12 +161,16 @@ const CodeReviewResponseSchema = CodeReviewResultSchema.omit({
   provider: true,
   review_mode: true,
   deliberation: true,
+  models: true,
+  provenance: true,
 });
 const PrecommitResponseSchema = PrecommitResultSchema.omit({
   session_id: true,
   chunks_reviewed: true,
   provider: true,
   review_mode: true,
+  models: true,
+  provenance: true,
 });
 
 // The exact model-facing schemas handed to the provider SDKs (via toJSONSchema in
@@ -172,6 +182,7 @@ export const RESPONSE_SCHEMAS = {
   plan: PlanReviewResponseSchema,
   code: CodeReviewResponseSchema,
   precommit: PrecommitResponseSchema,
+  cross: CrossReviewResponseSchema,
 } as const;
 
 export function sessionModelConflictMessage(): string {
@@ -191,10 +202,10 @@ export interface TurnParams {
   sessionId?: string;
   // Applied only when starting a fresh session; omitted on resume.
   model?: string;
-  // The model the active session actually runs on. Always set; used for
-  // error-context so messages report the correct model even when `model` is
-  // intentionally undefined on resumed chunks of a chunked review.
-  resolvedModel: string;
+  // The concrete identity retained/selected for the active session, when the
+  // bridge knows it. It stays undefined for an unrecorded legacy Codex resume
+  // instead of substituting today's default. Used for error context otherwise.
+  resolvedModel?: string;
 }
 
 export type TurnRunner = <T extends Record<string, unknown>>(
@@ -203,6 +214,7 @@ export type TurnRunner = <T extends Record<string, unknown>>(
 
 export interface ReviewFlowDeps {
   config: ReviewBridgeConfig;
+  provider: ReviewProvider;
   copilotInstructions?: CopilotInstructions;
   // When false (e.g. Codex, whose SDK reasserts --model on resume) the flow
   // rejects session_id + model and omits the model on resumed chunks. When true
@@ -212,12 +224,137 @@ export interface ReviewFlowDeps {
   // per-call override or config.model (undefined if neither set). Each backend
   // maps 'latest' (and unset) to its own newest supported model — Codex bounded
   // by the SDK pin, Gemini via `agy models` — and returns an explicit pin
-  // unchanged (L-006). Always yields a usable id (safe fallback, never throws).
+  // unchanged (L-006). Orchestration treats this as an untrusted boundary and
+  // validates the returned label before it reaches an SDK or subprocess.
   resolveModel: (requested: string | undefined) => Promise<string>;
+  // A resumed Codex turn must retain the conversation's known identity instead
+  // of substituting today's configured default. Storage/registry lookups are
+  // injected so this provider-neutral module never imports persistence.
+  lookupSessionModel?: (sessionId: string) => ModelIdentity | null;
+  // Codex can expose stronger control-plane evidence in its local rollout.
+  // Gemini intentionally leaves this undefined because agy has no equivalent.
+  observeSessionModel?: (sessionId: string) => Promise<string | undefined>;
   // Whether chunks 2..N of one review resume chunk 1's session. Codex resumes
   // (one thread per review); Gemini reviews each chunk independently to avoid
   // O(N²) context growth, so its review session id is chunk 1's.
   resumesAcrossChunks: boolean;
+}
+
+interface PreparedModel {
+  requested: string | null;
+  resolved: string | null;
+  turnResolved?: string;
+  known: ModelIdentity | null;
+}
+
+function safeModel(value: string | null | undefined): string | null {
+  if (value === null || value === undefined) return null;
+  const parsed = ModelSelectorSchema.safeParse(value);
+  return parsed.success ? parsed.data : null;
+}
+
+function lookupKnownModel(deps: ReviewFlowDeps, sessionId: string): ModelIdentity | null {
+  try {
+    return deps.lookupSessionModel?.(sessionId) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function prepareModel(
+  input: { session_id?: string; model?: string },
+  deps: ReviewFlowDeps,
+  quiet = false,
+): Promise<Result<PreparedModel>> {
+  // A Codex resume must retain the bridge's prior identity rather than replacing
+  // it with today's configured default. Fresh runtime observation may disagree;
+  // that mismatch is reported after the successful turn.
+  if (input.session_id && !deps.allowsModelOverrideOnResume) {
+    const known = lookupKnownModel(deps, input.session_id);
+    const resolved = safeModel(known?.resolved);
+    const observed = safeModel(known?.observed);
+    return ok({
+      requested: null,
+      resolved,
+      turnResolved: resolved ?? observed ?? undefined,
+      known,
+    });
+  }
+
+  const requestedRaw = input.model ?? deps.config.model;
+  const resolvedResult = await resolveModelValidated(deps.resolveModel, requestedRaw, quiet);
+  if (!resolvedResult.ok) return resolvedResult;
+  return ok({
+    requested: safeModel(requestedRaw),
+    resolved: resolvedResult.data,
+    turnResolved: resolvedResult.data,
+    known: null,
+  });
+}
+
+function normalizedModel(value: string): string {
+  return value.trim().toLowerCase().replace(/\s+/g, ' ');
+}
+
+export function deduplicateModelIdentities(models: readonly ModelIdentity[]): ModelIdentity[] {
+  const seen = new Set<string>();
+  const out: ModelIdentity[] = [];
+  for (const model of models) {
+    const key = JSON.stringify([
+      model.provider,
+      model.role,
+      model.requested,
+      model.resolved,
+      model.observed,
+      model.evidence,
+    ]);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(model);
+  }
+  return out;
+}
+
+async function enrichModelIdentity<R extends { session_id: string; models?: ModelIdentity[] }>(
+  result: Result<R>,
+  deps: ReviewFlowDeps,
+  prepared: PreparedModel,
+  role: ModelIdentity['role'],
+): Promise<Result<R>> {
+  if (!result.ok) return result;
+
+  let observed = safeModel(prepared.known?.observed);
+  if (deps.observeSessionModel) {
+    try {
+      observed = safeModel(await deps.observeSessionModel(result.data.session_id)) ?? observed;
+    } catch {
+      // Observation is optional evidence. The provider result remains valid.
+    }
+  }
+
+  const resolved = prepared.resolved ?? safeModel(prepared.known?.resolved);
+  const evidence: ModelIdentity['evidence'] = observed
+    ? 'runtime_session_record'
+    : resolved
+      ? 'bridge_selection'
+      : 'unavailable';
+  const identity: ModelIdentity = {
+    provider: deps.provider,
+    role,
+    requested: prepared.requested,
+    resolved,
+    observed,
+    evidence,
+  };
+
+  if (resolved && observed && normalizedModel(resolved) !== normalizedModel(observed)) {
+    console.error(
+      `[codex-bridge] warning: model identity mismatch for ${deps.provider}: ` +
+        `bridge selected "${escapeTerminalControls(resolved)}" but runtime recorded "${escapeTerminalControls(observed)}"`,
+    );
+  }
+
+  return ok({ ...result.data, models: [identity] });
 }
 
 export async function runPlanReview(
@@ -225,7 +362,7 @@ export async function runPlanReview(
   deps: ReviewFlowDeps,
   turn: TurnRunner,
 ): Promise<Result<PlanReviewResult>> {
-  const { config, copilotInstructions, allowsModelOverrideOnResume, resolveModel } = deps;
+  const { config, copilotInstructions, allowsModelOverrideOnResume } = deps;
   if (!allowsModelOverrideOnResume && input.session_id && input.model) {
     return err<PlanReviewResult>(sessionModelConflictMessage());
   }
@@ -235,29 +372,50 @@ export async function runPlanReview(
     focus: config.review_standards.plan_review.focus,
     depth: config.review_standards.plan_review.depth,
   });
-  const resolved = await resolveModelLogged(resolveModel, input.model ?? config.model);
-  return turn<Omit<PlanReviewResult, 'session_id'>>({
+  const preparedResult = await prepareModel(input, deps);
+  if (!preparedResult.ok) return preparedResult;
+  const prepared = preparedResult.data;
+  const result = await turn<Omit<PlanReviewResult, 'session_id'>>({
     prompt,
     responseSchema: PlanReviewResponseSchema,
     sessionId: input.session_id,
-    model: perTurnModel(resolved, input.session_id, allowsModelOverrideOnResume),
-    resolvedModel: resolved,
+    model: perTurnModel(prepared.turnResolved, input.session_id, allowsModelOverrideOnResume),
+    resolvedModel: prepared.turnResolved,
   });
+  return enrichModelIdentity(result, deps, prepared, 'review');
 }
 
 // Resolve the model and, when the caller didn't pin one, narrate what
 // 'latest'/unset resolved to. The result schema is fixed, so stderr is the
 // surfacing point for "which model actually ran" (T-019). An explicit pin is
 // self-evident and stays quiet.
-async function resolveModelLogged(
+async function resolveModelValidated(
   resolveModel: (requested: string | undefined) => Promise<string>,
   requested: string | undefined,
-): Promise<string> {
-  const resolved = await resolveModel(requested);
-  if (requested === undefined || requested === 'latest') {
-    console.error(`[codex-bridge] resolved model: ${resolved} (requested: ${requested ?? 'default'})`);
+  quiet: boolean,
+): Promise<Result<string>> {
+  let resolvedRaw: string;
+  try {
+    resolvedRaw = await resolveModel(requested);
+  } catch {
+    return err(`${ErrorCode.MODEL_ERROR}: model resolver failed`);
   }
-  return resolved;
+
+  // Treat the resolver as an untrusted provider boundary too. Its result is used
+  // as an SDK/subprocess argument, so normalize and validate it before the first
+  // turn instead of merely nulling the response metadata after the raw value ran.
+  const resolved = ModelSelectorSchema.safeParse(resolvedRaw);
+  if (!resolved.success) {
+    return err(`${ErrorCode.MODEL_ERROR}: model resolver returned an invalid model label`);
+  }
+
+  if (!quiet && (requested === undefined || requested === 'latest')) {
+    console.error(
+      `[codex-bridge] resolved model: ${escapeTerminalControls(resolved.data)} ` +
+        `(requested: ${escapeTerminalControls(requested ?? 'default')})`,
+    );
+  }
+  return ok(resolved.data);
 }
 
 // The model to apply on a given turn. Backends that reassert model on resume
@@ -265,7 +423,7 @@ async function resolveModelLogged(
 // model it was created with. Backends that allow a mid-session model change
 // (Gemini) always send the resolved model.
 function perTurnModel(
-  resolved: string,
+  resolved: string | undefined,
   sessionId: string | undefined,
   allowsModelOverrideOnResume: boolean,
 ): string | undefined {
@@ -292,22 +450,22 @@ export async function runCodeReview(
   deps: ReviewFlowDeps,
   turn: TurnRunner,
 ): Promise<Result<CodeReviewResult>> {
-  const { config, copilotInstructions, allowsModelOverrideOnResume, resolveModel, resumesAcrossChunks } =
-    deps;
+  const { config, copilotInstructions, allowsModelOverrideOnResume, resumesAcrossChunks } = deps;
   if (!allowsModelOverrideOnResume && input.session_id && input.model) {
     return err<CodeReviewResult>(sessionModelConflictMessage());
   }
   if (input.diff.length > 20 && !looksLikeDiff(input.diff)) {
     return err<CodeReviewResult>(
       `${ErrorCode.INVALID_INPUT}: Input doesn't look like a git diff. ` +
-      `Expected unified diff format (with 'diff --git', '---/+++', or '@@' markers). ` +
-      `If reviewing a plan or description, use review_plan instead.`,
+        `Expected unified diff format (with 'diff --git', '---/+++', or '@@' markers). ` +
+        `If reviewing a plan or description, use review_plan instead.`,
     );
   }
   // Match prompt builder logic: empty array falls through to config criteria
-  const criteria = input.criteria && input.criteria.length > 0
-    ? input.criteria
-    : config.review_standards.code_review.criteria;
+  const criteria =
+    input.criteria && input.criteria.length > 0
+      ? input.criteria
+      : config.review_standards.code_review.criteria;
   const files = extractFilesFromDiff(input.diff);
   const instrText = formatForPrompt(filterByFiles(copilotInstructions, files));
   const variableOverhead = computeVariableOverhead([
@@ -319,7 +477,10 @@ export async function runCodeReview(
   // Floor of 500 prevents zero/negative budget when overhead exceeds max_chunk_tokens.
   // In practice this means very small max_chunk_tokens values may produce chunks
   // larger than configured — this is preferable to disabling chunking entirely.
-  const diffBudget = Math.max(config.max_chunk_tokens - PROMPT_OVERHEAD_TOKENS - variableOverhead, 500);
+  const diffBudget = Math.max(
+    config.max_chunk_tokens - PROMPT_OVERHEAD_TOKENS - variableOverhead,
+    500,
+  );
   const chunks = chunkDiff(input.diff, diffBudget);
 
   // Empty diff — synthetic approve (no model resolution needed)
@@ -329,10 +490,13 @@ export async function runCodeReview(
       summary: 'No changes to review.',
       findings: [],
       session_id: input.session_id ?? randomUUID(),
+      models: [],
     });
   }
 
-  const resolved = await resolveModelLogged(resolveModel, input.model ?? config.model);
+  const preparedResult = await prepareModel(input, deps);
+  if (!preparedResult.ok) return preparedResult;
+  const prepared = preparedResult.data;
 
   // Single chunk — standard path (no chunks_reviewed)
   if (chunks.length === 1) {
@@ -342,13 +506,14 @@ export async function runCodeReview(
       criteria: config.review_standards.code_review.criteria,
       require_tests: config.review_standards.code_review.require_tests,
     });
-    return turn<Omit<CodeReviewResult, 'session_id' | 'chunks_reviewed'>>({
+    const result = await turn<Omit<CodeReviewResult, 'session_id' | 'chunks_reviewed'>>({
       prompt,
       responseSchema: CodeReviewResponseSchema,
       sessionId: input.session_id,
-      model: perTurnModel(resolved, input.session_id, allowsModelOverrideOnResume),
-      resolvedModel: resolved,
+      model: perTurnModel(prepared.turnResolved, input.session_id, allowsModelOverrideOnResume),
+      resolvedModel: prepared.turnResolved,
     });
+    return enrichModelIdentity(result, deps, prepared, 'review');
   }
 
   // Multi-chunk — sequential review with per-chunk timeout
@@ -373,8 +538,8 @@ export async function runCodeReview(
       prompt,
       responseSchema: CodeReviewResponseSchema,
       sessionId: chunkSession,
-      model: perTurnModel(resolved, chunkSession, allowsModelOverrideOnResume),
-      resolvedModel: resolved,
+      model: perTurnModel(prepared.turnResolved, chunkSession, allowsModelOverrideOnResume),
+      resolvedModel: prepared.turnResolved,
     });
 
     if (!result.ok) {
@@ -395,7 +560,12 @@ export async function runCodeReview(
   }
 
   const finalSessionId = resumesAcrossChunks ? threaded : reviewSessionId;
-  return ok(mergeCodeResults(chunkResults, finalSessionId!));
+  return enrichModelIdentity(
+    ok(mergeCodeResults(chunkResults, finalSessionId!)),
+    deps,
+    prepared,
+    'review',
+  );
 }
 
 export async function runPrecommitReview(
@@ -403,16 +573,15 @@ export async function runPrecommitReview(
   deps: ReviewFlowDeps,
   turn: TurnRunner,
 ): Promise<Result<PrecommitResult>> {
-  const { config, copilotInstructions, allowsModelOverrideOnResume, resolveModel, resumesAcrossChunks } =
-    deps;
+  const { config, copilotInstructions, allowsModelOverrideOnResume, resumesAcrossChunks } = deps;
   if (!allowsModelOverrideOnResume && input.session_id && input.model) {
     return err<PrecommitResult>(sessionModelConflictMessage());
   }
   if (input.diff.length > 20 && !looksLikeDiff(input.diff)) {
     return err<PrecommitResult>(
       `${ErrorCode.INVALID_INPUT}: Input doesn't look like a git diff. ` +
-      `Expected unified diff format (with 'diff --git', '---/+++', or '@@' markers). ` +
-      `If reviewing a plan or description, use review_plan instead.`,
+        `Expected unified diff format (with 'diff --git', '---/+++', or '@@' markers). ` +
+        `If reviewing a plan or description, use review_plan instead.`,
     );
   }
   const checklist = input.checklist ?? [];
@@ -426,7 +595,10 @@ export async function runPrecommitReview(
   // Floor of 500 prevents zero/negative budget when overhead exceeds max_chunk_tokens.
   // In practice this means very small max_chunk_tokens values may produce chunks
   // larger than configured — this is preferable to disabling chunking entirely.
-  const diffBudget = Math.max(config.max_chunk_tokens - PROMPT_OVERHEAD_TOKENS - variableOverhead, 500);
+  const diffBudget = Math.max(
+    config.max_chunk_tokens - PROMPT_OVERHEAD_TOKENS - variableOverhead,
+    500,
+  );
   const chunks = chunkDiff(input.diff, diffBudget);
 
   // Empty diff — synthetic pass (no model resolution needed)
@@ -436,10 +608,13 @@ export async function runPrecommitReview(
       blockers: [],
       warnings: [],
       session_id: input.session_id ?? randomUUID(),
+      models: [],
     });
   }
 
-  const resolved = await resolveModelLogged(resolveModel, input.model ?? config.model);
+  const preparedResult = await prepareModel(input, deps);
+  if (!preparedResult.ok) return preparedResult;
+  const prepared = preparedResult.data;
 
   // Single chunk — standard path (no chunks_reviewed)
   if (chunks.length === 1) {
@@ -448,13 +623,14 @@ export async function runPrecommitReview(
       copilot_instructions: precommitInstrText,
       block_on: config.review_standards.precommit.block_on,
     });
-    return turn<Omit<PrecommitResult, 'session_id' | 'chunks_reviewed'>>({
+    const result = await turn<Omit<PrecommitResult, 'session_id' | 'chunks_reviewed'>>({
       prompt,
       responseSchema: PrecommitResponseSchema,
       sessionId: input.session_id,
-      model: perTurnModel(resolved, input.session_id, allowsModelOverrideOnResume),
-      resolvedModel: resolved,
+      model: perTurnModel(prepared.turnResolved, input.session_id, allowsModelOverrideOnResume),
+      resolvedModel: prepared.turnResolved,
     });
+    return enrichModelIdentity(result, deps, prepared, 'review');
   }
 
   // Multi-chunk — sequential review
@@ -469,14 +645,17 @@ export async function runPrecommitReview(
 
   for (let i = 0; i < chunks.length; i++) {
     const chunkHeader = `Chunk ${i + 1} of ${chunks.length}: checking the following files only.`;
-    const prompt = buildPrecommitPrompt({ ...input, diff: chunks[i], chunkHeader }, precommitConfig);
+    const prompt = buildPrecommitPrompt(
+      { ...input, diff: chunks[i], chunkHeader },
+      precommitConfig,
+    );
     const chunkSession = chunkSessionFor(i, resumesAcrossChunks, threaded, input.session_id);
     const result = await turn<Omit<PrecommitResult, 'session_id' | 'chunks_reviewed'>>({
       prompt,
       responseSchema: PrecommitResponseSchema,
       sessionId: chunkSession,
-      model: perTurnModel(resolved, chunkSession, allowsModelOverrideOnResume),
-      resolvedModel: resolved,
+      model: perTurnModel(prepared.turnResolved, chunkSession, allowsModelOverrideOnResume),
+      resolvedModel: prepared.turnResolved,
     });
 
     if (!result.ok) {
@@ -495,7 +674,12 @@ export async function runPrecommitReview(
   }
 
   const finalSessionId = resumesAcrossChunks ? threaded : reviewSessionId;
-  return ok(mergePrecommitResults(chunkResults, finalSessionId!));
+  return enrichModelIdentity(
+    ok(mergePrecommitResults(chunkResults, finalSessionId!)),
+    deps,
+    prepared,
+    'review',
+  );
 }
 
 // Cross-review (deliberate-deep): adjudicate another reviewer's findings in a
@@ -508,14 +692,17 @@ export async function runCrossReview(
 ): Promise<Result<CrossReviewResult>> {
   // Resolve quietly: cross-review only runs after this provider's primary review
   // already narrated the same resolution, so logging again just duplicates stderr.
-  const resolved = await deps.resolveModel(input.model ?? deps.config.model);
-  const result = await turn<CrossReviewResult>({
+  const preparedResult = await prepareModel({ model: input.model }, deps, true);
+  if (!preparedResult.ok) return preparedResult;
+  const prepared = preparedResult.data;
+  const result = await turn<{ adjudications: CrossReviewResult['adjudications'] }>({
     prompt: buildCrossReviewPrompt(input),
-    responseSchema: CrossReviewResultSchema,
-    model: perTurnModel(resolved, undefined, deps.allowsModelOverrideOnResume),
-    resolvedModel: resolved,
+    responseSchema: CrossReviewResponseSchema,
+    model: perTurnModel(prepared.turnResolved, undefined, deps.allowsModelOverrideOnResume),
+    resolvedModel: prepared.turnResolved,
   });
-  if (!result.ok) return result;
-  const { session_id: _sessionId, ...data } = result.data;
+  const enriched = await enrichModelIdentity(result, deps, prepared, 'adjudication');
+  if (!enriched.ok) return enriched;
+  const { session_id: _sessionId, ...data } = enriched.data;
   return ok(data);
 }

--- a/src/cli/commands.test.ts
+++ b/src/cli/commands.test.ts
@@ -16,7 +16,10 @@ vi.mock('../backends/index.js', () => ({
 vi.mock('../config/loader.js', () => ({
   loadConfig: vi.fn().mockReturnValue({
     ok: true,
-    data: { config: { review_standards: { precommit: { auto_diff: true } } }, source: { kind: 'default' } },
+    data: {
+      config: { review_standards: { precommit: { auto_diff: true } } },
+      source: { kind: 'default' },
+    },
   }),
   formatConfigSource: vi.fn(() => 'default'),
 }));
@@ -37,6 +40,7 @@ vi.mock('./stdin.js', () => ({
 
 // Mock resolve-diff
 vi.mock('../utils/resolve-diff.js', () => ({
+  NO_STAGED_CHANGES: 'NO_STAGED_CHANGES:',
   resolvePrecommitDiff: vi.fn(),
 }));
 
@@ -58,9 +62,21 @@ function createDeps(): CliDeps & { stdoutBuf: string; stderrBuf: string; exitCod
     stdoutBuf: '',
     stderrBuf: '',
     exitCode: null as number | null,
-    stdout: { write: (s: string) => { deps.stdoutBuf += s; return true; } },
-    stderr: { write: (s: string) => { deps.stderrBuf += s; return true; } },
-    exit: (code: number) => { deps.exitCode = code; },
+    stdout: {
+      write: (s: string) => {
+        deps.stdoutBuf += s;
+        return true;
+      },
+    },
+    stderr: {
+      write: (s: string) => {
+        deps.stderrBuf += s;
+        return true;
+      },
+    },
+    exit: (code: number) => {
+      deps.exitCode = code;
+    },
     env: {},
     isTTY: false,
   };
@@ -114,7 +130,20 @@ describe('review-plan command', () => {
     mockCreateClient.mockReturnValue(mockClient);
 
     const deps = createDeps();
-    await runCli(['node', 'bridge', 'review-plan', '--plan', 'f.md', '--focus', 'security,performance', '--depth', 'thorough'], deps);
+    await runCli(
+      [
+        'node',
+        'bridge',
+        'review-plan',
+        '--plan',
+        'f.md',
+        '--focus',
+        'security,performance',
+        '--depth',
+        'thorough',
+      ],
+      deps,
+    );
 
     expect(mockClient.reviewPlan).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -122,6 +151,52 @@ describe('review-plan command', () => {
         depth: 'thorough',
       }),
     );
+  });
+
+  it('trims a valid model selector before invoking the backend', async () => {
+    mockReadInput.mockResolvedValue({ ok: true, data: 'plan' });
+    const mockClient = {
+      provider: 'codex' as const,
+      providers: ['codex'] as const,
+      allowsModelOverrideOnResume: false,
+      reviewPlan: vi.fn().mockResolvedValue({
+        ok: true,
+        data: { verdict: 'approve', summary: 'ok', findings: [], session_id: 's1' },
+      }),
+      reviewCode: vi.fn(),
+      reviewPrecommit: vi.fn(),
+    };
+    mockCreateClient.mockReturnValue(mockClient);
+
+    await runCli(
+      ['node', 'bridge', 'review-plan', '--plan', 'f.md', '--model', '  gpt-5.6-sol  '],
+      createDeps(),
+    );
+
+    expect(mockClient.reviewPlan).toHaveBeenCalledWith(
+      expect.objectContaining({ model: 'gpt-5.6-sol' }),
+    );
+  });
+
+  it('rejects control-bearing models and whitespace-mutated session ids before initialization', async () => {
+    const controls = createDeps();
+    await runCli(
+      ['node', 'bridge', 'review-plan', '--plan', 'f.md', '--model', 'gpt\nforged'],
+      controls,
+    );
+    expect(controls.exitCode).toBe(1);
+    expect(controls.stderrBuf).toContain('INVALID_INPUT');
+    expect(mockCreateClient).not.toHaveBeenCalled();
+
+    vi.clearAllMocks();
+    const whitespace = createDeps();
+    await runCli(
+      ['node', 'bridge', 'review-plan', '--plan', 'f.md', '--session', ' surrounded '],
+      whitespace,
+    );
+    expect(whitespace.exitCode).toBe(1);
+    expect(whitespace.stderrBuf).toContain('INVALID_INPUT');
+    expect(mockCreateClient).not.toHaveBeenCalled();
   });
 
   it('outputs JSON when --json flag is set', async () => {
@@ -140,7 +215,10 @@ describe('review-plan command', () => {
     const deps = createDeps();
     await runCli(['node', 'bridge', 'review-plan', '--plan', 'f.md', '--json'], deps);
 
-    expect(JSON.parse(deps.stdoutBuf)).toEqual(data);
+    expect(JSON.parse(deps.stdoutBuf)).toEqual({
+      ...data,
+      provenance: { persistence: 'not_recorded', warning: null },
+    });
   });
 
   it('exits 1 when input read fails', async () => {
@@ -186,6 +264,33 @@ describe('review-code command', () => {
       expect.objectContaining({ diff: 'diff --git ...' }),
     );
     expect(deps.exitCode).toBe(0);
+  });
+
+  it('returns an unrecorded synthetic result for an empty diff without routing a session', async () => {
+    mockReadInput.mockResolvedValue({ ok: true, data: '' });
+    const reviewCode = vi.fn();
+    mockCreateClient.mockReturnValue({
+      provider: 'codex',
+      providers: ['codex'],
+      allowsModelOverrideOnResume: false,
+      reviewPlan: vi.fn(),
+      reviewCode,
+      reviewPrecommit: vi.fn(),
+    });
+    const deps = createDeps();
+
+    await runCli(
+      ['node', 'bridge', 'review-code', '--diff', 'empty.patch', '--session', 'unknown', '--json'],
+      deps,
+    );
+
+    expect(JSON.parse(deps.stdoutBuf)).toMatchObject({
+      verdict: 'approve',
+      session_id: 'unknown',
+      models: [],
+      provenance: { persistence: 'not_recorded', warning: null },
+    });
+    expect(reviewCode).not.toHaveBeenCalled();
   });
 });
 
@@ -239,7 +344,10 @@ describe('review-precommit command', () => {
     const { loadConfig } = await import('../config/loader.js');
     vi.mocked(loadConfig).mockReturnValueOnce({
       ok: true,
-      data: { config: { review_standards: { precommit: { auto_diff: false } } }, source: { kind: 'default' } },
+      data: {
+        config: { review_standards: { precommit: { auto_diff: false } } },
+        source: { kind: 'default' },
+      },
     } as never);
     mockResolveDiff.mockResolvedValue({ ok: true, data: 'staged diff' });
     mockCreateClient.mockReturnValue(precommitClient());
@@ -313,6 +421,34 @@ describe('review-precommit command', () => {
     expect(deps.exitCode).toBe(1);
     expect(deps.stderrBuf).toContain('GIT_ERROR');
   });
+
+  it('returns an unrecorded no-staged result without routing or invoking a provider', async () => {
+    mockResolveDiff.mockResolvedValue({
+      ok: false,
+      error: 'NO_STAGED_CHANGES: No staged changes found.',
+    });
+    const reviewPrecommit = vi.fn();
+    mockCreateClient.mockReturnValue({
+      provider: 'codex',
+      providers: ['codex'],
+      allowsModelOverrideOnResume: false,
+      reviewPlan: vi.fn(),
+      reviewCode: vi.fn(),
+      reviewPrecommit,
+    });
+    const deps = createDeps();
+
+    await runCli(['node', 'bridge', 'review-precommit', '--session', 'unknown', '--json'], deps);
+
+    expect(JSON.parse(deps.stdoutBuf)).toMatchObject({
+      ready_to_commit: false,
+      session_id: 'unknown',
+      models: [],
+      provenance: { persistence: 'not_recorded', warning: null },
+    });
+    expect(reviewPrecommit).not.toHaveBeenCalled();
+    expect(deps.exitCode).toBe(2);
+  });
 });
 
 describe('config errors', () => {
@@ -330,6 +466,23 @@ describe('config errors', () => {
     expect(deps.exitCode).toBe(1);
     expect(deps.stderrBuf).toContain('CONFIG_ERROR');
     expect(deps.stderrBuf).toContain('RB_CONFIG_PATH');
+  });
+
+  it('escapes controls in errors rendered before the generic handler runs', async () => {
+    const escape = String.fromCharCode(0x1b);
+    const c1 = String.fromCharCode(0x85);
+    const { loadConfig } = await import('../config/loader.js');
+    vi.mocked(loadConfig).mockReturnValueOnce({
+      ok: false,
+      error: `CONFIG_ERROR: bad\nline${escape}escape${c1}c1`,
+    });
+
+    const deps = createDeps();
+    await runCli(['node', 'bridge', 'review-plan', '--plan', '/tmp/p.md'], deps);
+
+    expect(deps.stderrBuf).toBe('Error: CONFIG_ERROR: bad\\nline\\x1Bescape\\x85c1\n');
+    expect(deps.stderrBuf).not.toContain(escape);
+    expect(deps.stderrBuf).not.toContain(c1);
   });
 });
 
@@ -373,7 +526,11 @@ describe('cross-provider resume guard (ISS-017)', () => {
     if (savedEnv === undefined) delete process.env.REVIEW_BRIDGE_DB;
     else process.env.REVIEW_BRIDGE_DB = savedEnv;
     for (const suffix of ['', '-wal', '-shm']) {
-      try { rmSync(dbPath + suffix); } catch { /* ignore */ }
+      try {
+        rmSync(dbPath + suffix);
+      } catch {
+        /* ignore */
+      }
     }
   });
 
@@ -388,7 +545,10 @@ describe('cross-provider resume guard (ISS-017)', () => {
     });
 
     const deps = createDeps();
-    await runCli(['node', 'bridge', 'review-code', '--diff', '/tmp/d.diff', '--session', 'g-sess'], deps);
+    await runCli(
+      ['node', 'bridge', 'review-code', '--diff', '/tmp/d.diff', '--session', 'g-sess'],
+      deps,
+    );
 
     expect(deps.exitCode).toBe(1);
     expect(deps.stderrBuf).toContain('PROVIDER_MISMATCH');
@@ -409,7 +569,10 @@ describe('cross-provider resume guard (ISS-017)', () => {
     });
 
     const deps = createDeps();
-    await runCli(['node', 'bridge', 'review-code', '--diff', '/tmp/d.diff', '--session', 'g-sess'], deps);
+    await runCli(
+      ['node', 'bridge', 'review-code', '--diff', '/tmp/d.diff', '--session', 'g-sess'],
+      deps,
+    );
 
     expect(reviewCode).toHaveBeenCalled();
     expect(deps.exitCode).not.toBe(1);

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -1,4 +1,5 @@
 import { readFile } from 'node:fs/promises';
+import { randomUUID } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { Command, Option } from 'commander';
@@ -7,12 +8,12 @@ import { loadConfig, formatConfigSource } from '../config/loader.js';
 import { createBackend } from '../backends/index.js';
 import type { ReviewBackend } from '../backends/backend.js';
 import type { ReviewBridgeConfig } from '../config/types.js';
-import { openReviewDb, makeSessionProviderLookup } from '../storage/db.js';
+import { makeSessionModelLookup, makeSessionProviderLookup, openReviewDb } from '../storage/db.js';
 import { checkSessionProvider } from '../storage/session-tracker.js';
 import { loadCopilotInstructions } from '../config/copilot-instructions.js';
 import type { CopilotInstructions } from '../config/copilot-instructions.js';
 import { readInput, resetStdinGuard } from './stdin.js';
-import { resolvePrecommitDiff } from '../utils/resolve-diff.js';
+import { NO_STAGED_CHANGES, resolvePrecommitDiff } from '../utils/resolve-diff.js';
 import { createHandler } from './handlers.js';
 import type { HandlerIO } from './handlers.js';
 import {
@@ -22,6 +23,10 @@ import {
   detectColor,
 } from './formatter.js';
 import type { PlanReviewResult, CodeReviewResult, PrecommitResult } from '../review/types.js';
+import { escapeTerminalControls } from '../utils/terminal.js';
+import { ModelSelectorSchema, SessionIdSchema } from '../utils/input-validation.js';
+import { err, ErrorCode, ok } from '../utils/errors.js';
+import type { Result } from '../utils/errors.js';
 
 export interface CliDeps {
   stdout: HandlerIO['stdout'];
@@ -58,40 +63,89 @@ interface CliClient {
   config: ReviewBridgeConfig;
 }
 
+interface ValidatedSelectors {
+  session: string | undefined;
+  model: string | undefined;
+}
+
+function validateSelectors(
+  session: string | undefined,
+  model: string | undefined,
+): Result<ValidatedSelectors> {
+  if (session !== undefined) {
+    const parsed = SessionIdSchema.safeParse(session);
+    if (!parsed.success) {
+      return err(
+        `${ErrorCode.INVALID_INPUT}: session must be 1–256 control-free characters without surrounding whitespace`,
+      );
+    }
+  }
+  if (model !== undefined) {
+    const parsed = ModelSelectorSchema.safeParse(model);
+    if (!parsed.success) {
+      return err(
+        `${ErrorCode.INVALID_INPUT}: model must be 1–200 control-free characters after trimming`,
+      );
+    }
+    return ok({ session, model: parsed.data });
+  }
+  return ok({ session, model: undefined });
+}
+
 function initClient(configDir: string | undefined, deps: CliDeps): CliClient | null {
   const configResult = loadConfig(configDir);
   if (!configResult.ok) {
-    deps.stderr.write(`Error: ${configResult.error}\n`);
+    deps.stderr.write(`Error: ${escapeTerminalControls(configResult.error)}\n`);
     deps.exit(1);
     return null;
   }
   const { config, source } = configResult.data;
-  deps.stderr.write(`[codex-bridge] config source: ${formatConfigSource(source)}\n`);
+  deps.stderr.write(
+    `[codex-bridge] config source: ${escapeTerminalControls(formatConfigSource(source))}\n`,
+  );
 
   let copilotInstr: CopilotInstructions | undefined;
   if (config.copilot_instructions) {
     // When walk-up discovered a project config, anchor copilot-instructions
     // at that project root rather than process.cwd(). For env/user/default,
     // copilot stays tied to the caller-passed dir or process.cwd().
-    const instrCwd =
-      source.kind === 'project' ? dirname(source.path) : configDir;
+    const instrCwd = source.kind === 'project' ? dirname(source.path) : configDir;
     const instrResult = loadCopilotInstructions(instrCwd);
     if (instrResult.ok) {
       copilotInstr = instrResult.data;
     } else {
-      deps.stderr.write(`Copilot instructions load failed, skipping: ${instrResult.error}\n`);
+      deps.stderr.write(
+        `Copilot instructions load failed, skipping: ${escapeTerminalControls(instrResult.error)}\n`,
+      );
     }
   }
 
   // Read-only so the CLI never creates or writes the review db (no recording).
-  // Undefined when no shared db is reachable → resume routing + guard fail open.
+  // Undefined when no shared db is reachable (no reviews.db, or the CLI runs
+  // outside the server's cwd — ISS-018). With no db there is nothing to
+  // consult, so resume routing and the cross-provider guard fail OPEN: no
+  // lookup is passed and the backend routes to its primary as before. A db we
+  // have but cannot read still fails closed inside the lookup itself.
   const db = openReviewDb({ readonly: true });
   try {
-    const client = createBackend(config, copilotInstr, makeSessionProviderLookup(db));
+    const storedModels = makeSessionModelLookup(db);
+    const client = createBackend(
+      config,
+      copilotInstr,
+      db ? makeSessionProviderLookup(db) : undefined,
+      (sessionId) => {
+        const found = storedModels(sessionId);
+        return found.status === 'found' && found.value.status === 'recorded'
+          ? found.value.model
+          : null;
+      },
+    );
     return { client, db, config };
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
-    deps.stderr.write(`Error: Failed to initialize the review backend: ${msg}\n`);
+    deps.stderr.write(
+      `Error: Failed to initialize the review backend: ${escapeTerminalControls(msg)}\n`,
+    );
     deps.exit(1);
     return null;
   }
@@ -107,7 +161,7 @@ function guardSession(
 ): boolean {
   const guard = checkSessionProvider(init.db, sessionId, init.client.providers);
   if (!guard.ok) {
-    io.stderr.write(`Error: ${guard.error}\n`);
+    io.stderr.write(`Error: ${escapeTerminalControls(guard.error)}\n`);
     deps.exit(1);
     return false;
   }
@@ -141,7 +195,11 @@ export async function runCli(argv?: string[], deps: CliDeps = DEFAULT_DEPS): Pro
   program.exitOverride();
   program.configureOutput({
     writeOut: (str) => deps.stdout.write(str),
-    writeErr: (str) => deps.stderr.write(str),
+    writeErr: (str) => {
+      const finalNewline = str.endsWith('\n');
+      const body = finalNewline ? str.slice(0, -1) : str;
+      return deps.stderr.write(`${escapeTerminalControls(body)}${finalNewline ? '\n' : ''}`);
+    },
   });
 
   program
@@ -160,15 +218,21 @@ export async function runCli(argv?: string[], deps: CliDeps = DEFAULT_DEPS): Pro
       resetStdinGuard();
       const json = opts.json ?? false;
       const io = buildIO(deps, json);
+      const selectors = validateSelectors(opts.session, opts.model);
+      if (!selectors.ok) {
+        io.stderr.write(`Error: ${escapeTerminalControls(selectors.error)}\n`);
+        deps.exit(1);
+        return;
+      }
 
       const init = initClient(opts.config, deps);
       if (!init) return;
       const { client } = init;
-      if (!guardSession(init, opts.session, io, deps)) return;
+      if (!guardSession(init, selectors.data.session, io, deps)) return;
 
       const inputResult = await readInput(opts.plan);
       if (!inputResult.ok) {
-        io.stderr.write(`Error: ${inputResult.error}\n`);
+        io.stderr.write(`Error: ${escapeTerminalControls(inputResult.error)}\n`);
         deps.exit(1);
         return;
       }
@@ -177,12 +241,15 @@ export async function runCli(argv?: string[], deps: CliDeps = DEFAULT_DEPS): Pro
         execute: () =>
           client.reviewPlan({
             plan: inputResult.data,
-            focus: opts.focus ? opts.focus.split(',').map((s: string) => s.trim()).filter(Boolean) : undefined,
+            focus: opts.focus
+              ? opts.focus
+                  .split(',')
+                  .map((s: string) => s.trim())
+                  .filter(Boolean)
+              : undefined,
             depth: opts.depth,
-            session_id: opts.session,
-            // Normalize empty string to undefined so the client picks config
-            // default (matches MCP's z.string().min(1) behavior).
-            model: opts.model?.trim() || undefined,
+            session_id: selectors.data.session,
+            model: selectors.data.model,
             deliberate: opts.deliberate,
           }),
         format: formatPlanResult,
@@ -207,28 +274,50 @@ export async function runCli(argv?: string[], deps: CliDeps = DEFAULT_DEPS): Pro
       resetStdinGuard();
       const json = opts.json ?? false;
       const io = buildIO(deps, json);
-
-      const init = initClient(opts.config, deps);
-      if (!init) return;
-      const { client } = init;
-      if (!guardSession(init, opts.session, io, deps)) return;
-
-      const inputResult = await readInput(opts.diff);
-      if (!inputResult.ok) {
-        io.stderr.write(`Error: ${inputResult.error}\n`);
+      const selectors = validateSelectors(opts.session, opts.model);
+      if (!selectors.ok) {
+        io.stderr.write(`Error: ${escapeTerminalControls(selectors.error)}\n`);
         deps.exit(1);
         return;
       }
 
+      const init = initClient(opts.config, deps);
+      if (!init) return;
+      const { client } = init;
+
+      const inputResult = await readInput(opts.diff);
+      if (!inputResult.ok) {
+        io.stderr.write(`Error: ${escapeTerminalControls(inputResult.error)}\n`);
+        deps.exit(1);
+        return;
+      }
+      const synthetic = inputResult.data.trim().length === 0;
+      if (!synthetic && !guardSession(init, selectors.data.session, io, deps)) return;
+
       const handler = createHandler<CodeReviewResult>({
         execute: () =>
-          client.reviewCode({
-            diff: inputResult.data,
-            criteria: opts.focus ? opts.focus.split(',').map((s: string) => s.trim()).filter(Boolean) : undefined,
-            session_id: opts.session,
-            model: opts.model?.trim() || undefined,
-            deliberate: opts.deliberate,
-          }),
+          synthetic
+            ? Promise.resolve(
+                ok<CodeReviewResult>({
+                  verdict: 'approve',
+                  summary: 'No changes to review.',
+                  findings: [],
+                  session_id: selectors.data.session ?? randomUUID(),
+                  models: [],
+                }),
+              )
+            : client.reviewCode({
+                diff: inputResult.data,
+                criteria: opts.focus
+                  ? opts.focus
+                      .split(',')
+                      .map((s: string) => s.trim())
+                      .filter(Boolean)
+                  : undefined,
+                session_id: selectors.data.session,
+                model: selectors.data.model,
+                deliberate: opts.deliberate,
+              }),
         format: formatCodeResult,
         exitCode: () => 0,
       });
@@ -250,18 +339,23 @@ export async function runCli(argv?: string[], deps: CliDeps = DEFAULT_DEPS): Pro
       resetStdinGuard();
       const json = opts.json ?? false;
       const io = buildIO(deps, json);
+      const selectors = validateSelectors(opts.session, opts.model);
+      if (!selectors.ok) {
+        io.stderr.write(`Error: ${escapeTerminalControls(selectors.error)}\n`);
+        deps.exit(1);
+        return;
+      }
 
       const init = initClient(opts.config, deps);
       if (!init) return;
       const { client, config } = init;
-      if (!guardSession(init, opts.session, io, deps)) return;
 
       // Read explicit diff if provided via file/stdin
       let explicitDiff: string | undefined;
       if (opts.diff) {
         const inputResult = await readInput(opts.diff);
         if (!inputResult.ok) {
-          io.stderr.write(`Error: ${inputResult.error}\n`);
+          io.stderr.write(`Error: ${escapeTerminalControls(inputResult.error)}\n`);
           deps.exit(1);
           return;
         }
@@ -275,21 +369,42 @@ export async function runCli(argv?: string[], deps: CliDeps = DEFAULT_DEPS): Pro
         ? false
         : (opts.autoDiff ?? config.review_standards.precommit.auto_diff);
 
+      const diffResult = await resolvePrecommitDiff({
+        diff: explicitDiff,
+        auto_diff: autoDiff,
+      });
+      if (!diffResult.ok) {
+        if (!diffResult.error.startsWith(NO_STAGED_CHANGES)) {
+          io.stderr.write(`Error: ${escapeTerminalControls(diffResult.error)}\n`);
+          deps.exit(1);
+          return;
+        }
+        const syntheticHandler = createHandler<PrecommitResult>({
+          execute: () =>
+            Promise.resolve(
+              ok<PrecommitResult>({
+                ready_to_commit: false,
+                blockers: [],
+                warnings: ['No staged changes found'],
+                session_id: selectors.data.session ?? randomUUID(),
+                models: [],
+              }),
+            ),
+          format: formatPrecommitResult,
+          exitCode: () => 2,
+        });
+        await syntheticHandler(io);
+        return;
+      }
+      if (!guardSession(init, selectors.data.session, io, deps)) return;
+
       const handler = createHandler<PrecommitResult>({
-        execute: async () => {
-          const diffResult = await resolvePrecommitDiff({
-            diff: explicitDiff,
-            auto_diff: autoDiff,
-          });
-          if (!diffResult.ok) {
-            return diffResult;
-          }
-          return client.reviewPrecommit({
+        execute: () =>
+          client.reviewPrecommit({
             diff: diffResult.data,
-            session_id: opts.session,
-            model: opts.model?.trim() || undefined,
-          });
-        },
+            session_id: selectors.data.session,
+            model: selectors.data.model,
+          }),
         format: formatPrecommitResult,
         exitCode: (result) => (result.ready_to_commit ? 0 : 2),
       });

--- a/src/cli/formatter.test.ts
+++ b/src/cli/formatter.test.ts
@@ -38,8 +38,22 @@ describe('formatPlanResult', () => {
     verdict: 'revise',
     summary: 'Needs some changes.',
     findings: [
-      { severity: 'minor', category: 'style', description: 'Use consistent naming', file: 'src/foo.ts', line: 10, suggestion: 'Rename to camelCase' },
-      { severity: 'critical', category: 'security', description: 'SQL injection risk', file: 'src/db.ts', line: 42, suggestion: null },
+      {
+        severity: 'minor',
+        category: 'style',
+        description: 'Use consistent naming',
+        file: 'src/foo.ts',
+        line: 10,
+        suggestion: 'Rename to camelCase',
+      },
+      {
+        severity: 'critical',
+        category: 'security',
+        description: 'SQL injection risk',
+        file: 'src/db.ts',
+        line: 42,
+        suggestion: null,
+      },
     ],
     session_id: 'sess-123',
   };
@@ -64,7 +78,12 @@ describe('formatPlanResult', () => {
   });
 
   it('handles empty findings', () => {
-    const empty: PlanReviewResult = { verdict: 'approve', summary: 'All good.', findings: [], session_id: 's' };
+    const empty: PlanReviewResult = {
+      verdict: 'approve',
+      summary: 'All good.',
+      findings: [],
+      session_id: 's',
+    };
     const out = formatPlanResult(empty, false);
     expect(out).toContain('No findings');
     expect(out).toContain('APPROVE');
@@ -74,12 +93,140 @@ describe('formatPlanResult', () => {
     const r: PlanReviewResult = {
       verdict: 'approve',
       summary: 'ok',
-      findings: [{ severity: 'suggestion', category: 'docs', description: 'Add readme', file: 'README.md', line: null, suggestion: null }],
+      findings: [
+        {
+          severity: 'suggestion',
+          category: 'docs',
+          description: 'Add readme',
+          file: 'README.md',
+          line: null,
+          suggestion: null,
+        },
+      ],
       session_id: 's',
     };
     const out = formatPlanResult(r, false);
     expect(out).toContain('README.md');
     expect(out).not.toContain('README.md:');
+  });
+
+  it('prints one honest model line per review and adjudication contribution', () => {
+    const withMetadata: PlanReviewResult = {
+      ...result,
+      models: [
+        {
+          provider: 'codex',
+          role: 'review',
+          requested: null,
+          resolved: 'gpt-5.6-sol',
+          observed: 'gpt-5.6-sol',
+          evidence: 'runtime_session_record',
+        },
+        {
+          provider: 'gemini',
+          role: 'adjudication',
+          requested: 'latest',
+          resolved: 'Gemini 3.5 Flash (High)',
+          observed: null,
+          evidence: 'bridge_selection',
+        },
+      ],
+      provenance: { persistence: 'memory_only', warning: 'History was not saved.' },
+    };
+
+    const modelLines = formatPlanResult(withMetadata, false)
+      .split('\n')
+      .filter((line) => line.startsWith('Model:'));
+    expect(modelLines).toEqual([
+      'Model: role=review provider=codex requested=null resolved=gpt-5.6-sol observed=gpt-5.6-sol evidence=runtime_session_record',
+      'Model: role=adjudication provider=gemini requested=latest resolved=Gemini 3.5 Flash (High) observed=null evidence=bridge_selection',
+    ]);
+  });
+
+  it('prints a persistence warning only when provenance.warning is non-null', () => {
+    const warning = formatPlanResult(
+      {
+        ...result,
+        provenance: { persistence: 'memory_only', warning: 'History was not saved.' },
+      },
+      false,
+    );
+    const durable = formatPlanResult(
+      {
+        ...result,
+        provenance: { persistence: 'durable', warning: null },
+      },
+      false,
+    );
+    const absent = formatPlanResult(result, false);
+
+    expect(warning).toContain('Persistence warning: History was not saved.');
+    expect(durable).not.toContain('Persistence warning:');
+    expect(absent).not.toContain('Persistence warning:');
+  });
+
+  it('prints unavailable requested, resolved, and observed identities as null', () => {
+    const out = formatPlanResult(
+      {
+        ...result,
+        models: [
+          {
+            provider: 'codex',
+            role: 'review',
+            requested: null,
+            resolved: null,
+            observed: null,
+            evidence: 'unavailable',
+          },
+        ],
+      },
+      false,
+    );
+    expect(out).toContain(
+      'Model: role=review provider=codex requested=null resolved=null observed=null evidence=unavailable',
+    );
+  });
+
+  it('escapes untrusted controls in every dynamic human field', () => {
+    const escape = String.fromCharCode(0x1b);
+    const c1 = String.fromCharCode(0x85);
+    const unsafe: PlanReviewResult = {
+      verdict: 'approve',
+      summary: 'summary\nforged',
+      findings: [
+        {
+          severity: 'minor',
+          category: 'style',
+          description: `description${escape}forged`,
+          file: 'src/file\rname.ts',
+          line: 1,
+          suggestion: `suggestion${c1}forged`,
+        },
+      ],
+      session_id: 'session\nforged',
+      models: [
+        {
+          provider: 'codex',
+          role: 'review',
+          requested: null,
+          resolved: `model${escape}forged`,
+          observed: null,
+          evidence: 'unavailable',
+        },
+      ],
+      provenance: { persistence: 'memory_only', warning: 'db\nforged' },
+    };
+
+    const out = formatPlanResult(unsafe, false);
+    expect(out).toContain('summary\\nforged');
+    expect(out).toContain('src/file\\rname.ts:1');
+    expect(out).toContain('description\\x1Bforged');
+    expect(out).toContain('suggestion\\x85forged');
+    expect(out).toContain('resolved=model\\x1Bforged');
+    expect(out).toContain('Persistence warning: db\\nforged');
+    expect(out).toContain('Session: session\\nforged');
+    expect(out).not.toContain(escape);
+    expect(out).not.toContain(c1);
   });
 });
 
@@ -88,7 +235,14 @@ describe('formatCodeResult', () => {
     verdict: 'request_changes',
     summary: 'Found bugs.',
     findings: [
-      { severity: 'major', category: 'bugs', description: 'Off by one', file: 'src/loop.ts', line: 5, suggestion: 'Use < instead of <=' },
+      {
+        severity: 'major',
+        category: 'bugs',
+        description: 'Off by one',
+        file: 'src/loop.ts',
+        line: 5,
+        suggestion: 'Use < instead of <=',
+      },
     ],
     session_id: 'sess-456',
   };
@@ -105,17 +259,53 @@ describe('formatCodeResult', () => {
     const r: CodeReviewResult = {
       verdict: 'approve',
       summary: 'ok',
-      findings: [{ severity: 'nitpick', category: 'style', description: 'Trailing space', file: null, line: null, suggestion: null }],
+      findings: [
+        {
+          severity: 'nitpick',
+          category: 'style',
+          description: 'Trailing space',
+          file: null,
+          line: null,
+          suggestion: null,
+        },
+      ],
       session_id: 's',
     };
     const out = formatCodeResult(r, false);
     expect(out).toContain('[NITPICK]');
   });
+
+  it('prints model metadata for code reviews', () => {
+    const out = formatCodeResult(
+      {
+        ...result,
+        models: [
+          {
+            provider: 'gemini',
+            role: 'review',
+            requested: null,
+            resolved: 'Gemini 3.5 Flash (High)',
+            observed: null,
+            evidence: 'bridge_selection',
+          },
+        ],
+      },
+      false,
+    );
+    expect(out).toContain(
+      'Model: role=review provider=gemini requested=null resolved=Gemini 3.5 Flash (High) observed=null evidence=bridge_selection',
+    );
+  });
 });
 
 describe('formatPrecommitResult', () => {
   it('shows OK TO COMMIT when ready', () => {
-    const result: PrecommitResult = { ready_to_commit: true, blockers: [], warnings: [], session_id: 's1' };
+    const result: PrecommitResult = {
+      ready_to_commit: true,
+      blockers: [],
+      warnings: [],
+      session_id: 's1',
+    };
     const out = formatPrecommitResult(result, false);
     expect(out).toContain('OK TO COMMIT');
     expect(out).not.toContain('COMMIT BLOCKED');
@@ -157,5 +347,30 @@ describe('formatPrecommitResult', () => {
     const out = formatPrecommitResult(result, false);
     expect(out).toContain('Blockers:');
     expect(out).not.toContain('Warnings:');
+  });
+
+  it('prints model metadata and escapes blocker/warning controls', () => {
+    const escape = String.fromCharCode(0x1b);
+    const result: PrecommitResult = {
+      ready_to_commit: false,
+      blockers: ['blocker\nforged'],
+      warnings: [`warning${escape}forged`],
+      session_id: 's5',
+      models: [
+        {
+          provider: 'codex',
+          role: 'review',
+          requested: null,
+          resolved: 'gpt-5.6-sol',
+          observed: 'gpt-5.6-sol',
+          evidence: 'runtime_session_record',
+        },
+      ],
+    };
+    const out = formatPrecommitResult(result, false);
+    expect(out).toContain('blocker\\nforged');
+    expect(out).toContain('warning\\x1Bforged');
+    expect(out).toContain('Model: role=review provider=codex');
+    expect(out).not.toContain(escape);
   });
 });

--- a/src/cli/formatter.ts
+++ b/src/cli/formatter.ts
@@ -1,5 +1,14 @@
 import pc from 'picocolors';
-import type { PlanReviewResult, CodeReviewResult, PrecommitResult, PlanFinding, CodeFinding } from '../review/types.js';
+import type {
+  PlanReviewResult,
+  CodeReviewResult,
+  PrecommitResult,
+  PlanFinding,
+  CodeFinding,
+  ModelIdentity,
+  ReviewProvenance,
+} from '../review/types.js';
+import { escapeTerminalControls } from '../utils/terminal.js';
 
 export function detectColor(env: Record<string, string | undefined>, isTTY: boolean): boolean {
   if (env.FORCE_COLOR !== undefined) {
@@ -55,10 +64,14 @@ function verdictBadge(verdict: string, color: boolean): string {
 
 function locationStr(file: string | null, line: number | null): string {
   if (!file) return '';
-  return line ? ` ${file}:${line}` : ` ${file}`;
+  const safeFile = escapeTerminalControls(file);
+  return line ? ` ${safeFile}:${line}` : ` ${safeFile}`;
 }
 
-function formatFindings(findings: ReadonlyArray<PlanFinding | CodeFinding>, color: boolean): string {
+function formatFindings(
+  findings: ReadonlyArray<PlanFinding | CodeFinding>,
+  color: boolean,
+): string {
   if (findings.length === 0) return '  No findings.\n';
 
   const sorted = [...findings].sort(
@@ -69,24 +82,50 @@ function formatFindings(findings: ReadonlyArray<PlanFinding | CodeFinding>, colo
   for (const f of sorted) {
     const badge = severityBadge(f.severity, color);
     const loc = locationStr(f.file, f.line);
-    lines.push(`  ${badge}${loc} — ${f.description}`);
+    lines.push(`  ${badge}${loc} — ${escapeTerminalControls(f.description)}`);
     if (f.suggestion) {
       const prefix = color ? pc.dim('    ↳ ') : '    -> ';
-      lines.push(`${prefix}${f.suggestion}`);
+      lines.push(`${prefix}${escapeTerminalControls(f.suggestion)}`);
     }
   }
   return lines.join('\n') + '\n';
+}
+
+interface ReviewMetadata {
+  models?: ModelIdentity[];
+  provenance?: ReviewProvenance;
+}
+
+function modelValue(value: string | null): string {
+  return value === null ? 'null' : escapeTerminalControls(value);
+}
+
+function appendReviewMetadata(lines: string[], result: ReviewMetadata): void {
+  for (const model of result.models ?? []) {
+    lines.push(
+      `Model: role=${escapeTerminalControls(model.role)} ` +
+        `provider=${escapeTerminalControls(model.provider)} ` +
+        `requested=${modelValue(model.requested)} ` +
+        `resolved=${modelValue(model.resolved)} ` +
+        `observed=${modelValue(model.observed)} ` +
+        `evidence=${escapeTerminalControls(model.evidence)}`,
+    );
+  }
+  if (result.provenance?.warning !== null && result.provenance?.warning !== undefined) {
+    lines.push(`Persistence warning: ${escapeTerminalControls(result.provenance.warning)}`);
+  }
 }
 
 export function formatPlanResult(result: PlanReviewResult, color: boolean): string {
   const lines: string[] = [];
   lines.push(`Verdict: ${verdictBadge(result.verdict, color)}`);
   lines.push('');
-  lines.push(result.summary);
+  lines.push(escapeTerminalControls(result.summary));
   lines.push('');
   lines.push(`Findings (${result.findings.length}):`);
   lines.push(formatFindings(result.findings, color));
-  lines.push(`Session: ${result.session_id}`);
+  appendReviewMetadata(lines, result);
+  lines.push(`Session: ${escapeTerminalControls(result.session_id)}`);
   return lines.join('\n');
 }
 
@@ -94,11 +133,12 @@ export function formatCodeResult(result: CodeReviewResult, color: boolean): stri
   const lines: string[] = [];
   lines.push(`Verdict: ${verdictBadge(result.verdict, color)}`);
   lines.push('');
-  lines.push(result.summary);
+  lines.push(escapeTerminalControls(result.summary));
   lines.push('');
   lines.push(`Findings (${result.findings.length}):`);
   lines.push(formatFindings(result.findings, color));
-  lines.push(`Session: ${result.session_id}`);
+  appendReviewMetadata(lines, result);
+  lines.push(`Session: ${escapeTerminalControls(result.session_id)}`);
   return lines.join('\n');
 }
 
@@ -118,7 +158,7 @@ export function formatPrecommitResult(result: PrecommitResult, color: boolean): 
     lines.push('Blockers:');
     for (const b of result.blockers) {
       const bullet = color ? pc.red('  - ') : '  - ';
-      lines.push(`${bullet}${b}`);
+      lines.push(`${bullet}${escapeTerminalControls(b)}`);
     }
   }
 
@@ -127,11 +167,12 @@ export function formatPrecommitResult(result: PrecommitResult, color: boolean): 
     lines.push('Warnings:');
     for (const w of result.warnings) {
       const bullet = color ? pc.yellow('  - ') : '  - ';
-      lines.push(`${bullet}${w}`);
+      lines.push(`${bullet}${escapeTerminalControls(w)}`);
     }
   }
 
   lines.push('');
-  lines.push(`Session: ${result.session_id}`);
+  appendReviewMetadata(lines, result);
+  lines.push(`Session: ${escapeTerminalControls(result.session_id)}`);
   return lines.join('\n');
 }

--- a/src/cli/handlers.test.ts
+++ b/src/cli/handlers.test.ts
@@ -3,14 +3,28 @@ import { createHandler } from './handlers.js';
 import type { HandlerIO } from './handlers.js';
 import type { Result } from '../utils/errors.js';
 
-function createMockIO(overrides?: Partial<HandlerIO>): HandlerIO & { stdoutBuf: string; stderrBuf: string; exitCode: number | null } {
+function createMockIO(
+  overrides?: Partial<HandlerIO>,
+): HandlerIO & { stdoutBuf: string; stderrBuf: string; exitCode: number | null } {
   const io = {
     stdoutBuf: '',
     stderrBuf: '',
     exitCode: null as number | null,
-    stdout: { write: (s: string) => { io.stdoutBuf += s; return true; } },
-    stderr: { write: (s: string) => { io.stderrBuf += s; return true; } },
-    exit: (code: number) => { io.exitCode = code; },
+    stdout: {
+      write: (s: string) => {
+        io.stdoutBuf += s;
+        return true;
+      },
+    },
+    stderr: {
+      write: (s: string) => {
+        io.stderrBuf += s;
+        return true;
+      },
+    },
+    exit: (code: number) => {
+      io.exitCode = code;
+    },
     color: false,
     json: false,
     ...overrides,
@@ -47,6 +61,93 @@ describe('createHandler', () => {
 
       expect(JSON.parse(io.stdoutBuf)).toEqual({ value: 42 });
       expect(io.exitCode).toBe(0);
+    });
+
+    it('adds not_recorded provenance to a successful CLI review when absent', async () => {
+      const data = { session_id: 'session-1', value: 42 };
+      const formatSpy = vi.fn().mockReturnValue('formatted');
+      const handler = createHandler<typeof data>({
+        execute: async () => ({ ok: true, data }),
+        format: formatSpy,
+        exitCode: () => 0,
+      });
+
+      const io = createMockIO({ json: true });
+      await handler(io);
+
+      expect(JSON.parse(io.stdoutBuf)).toEqual({
+        ...data,
+        provenance: { persistence: 'not_recorded', warning: null },
+      });
+      expect(data).not.toHaveProperty('provenance');
+    });
+
+    it('preserves existing provenance and passes JSON through exactly', async () => {
+      const data = {
+        session_id: 'session-1',
+        value: 42,
+        models: [
+          {
+            provider: 'codex',
+            role: 'review',
+            requested: null,
+            resolved: 'gpt-5.6-sol',
+            observed: 'gpt-5.6-sol',
+            evidence: 'runtime_session_record',
+          },
+        ],
+        provenance: { persistence: 'memory_only', warning: 'DB unavailable' },
+      };
+      const handler = createHandler<typeof data>({
+        execute: async () => ({ ok: true, data }),
+        format: () => 'not used',
+        exitCode: () => 0,
+      });
+
+      const io = createMockIO({ json: true });
+      await handler(io);
+
+      expect(io.stdoutBuf).toBe(`${JSON.stringify(data)}\n`);
+    });
+
+    it('keeps JSON output parse-equivalent without emitting raw DEL or C1 controls', async () => {
+      const del = String.fromCharCode(0x7f);
+      const c1 = String.fromCharCode(0x85);
+      const data = { value: `before${del}middle${c1}after` };
+      const handler = createHandler<typeof data>({
+        execute: async () => ({ ok: true, data }),
+        format: () => 'not used',
+        exitCode: () => 0,
+      });
+
+      const io = createMockIO({ json: true });
+      await handler(io);
+
+      expect(JSON.parse(io.stdoutBuf)).toEqual(data);
+      expect(io.stdoutBuf).not.toContain(del);
+      expect(io.stdoutBuf).not.toContain(c1);
+      expect(io.stdoutBuf).toContain('\\u007f');
+      expect(io.stdoutBuf).toContain('\\u0085');
+    });
+
+    it('passes enriched provenance to human formatters and exit-code logic', async () => {
+      const data = { session_id: 'session-1', blocked: false };
+      const formatSpy = vi.fn().mockReturnValue('formatted');
+      const exitCodeSpy = vi.fn().mockReturnValue(0);
+      const handler = createHandler<typeof data>({
+        execute: async () => ({ ok: true, data }),
+        format: formatSpy,
+        exitCode: exitCodeSpy,
+      });
+
+      await handler(createMockIO());
+
+      const expected = {
+        ...data,
+        provenance: { persistence: 'not_recorded', warning: null },
+      };
+      expect(formatSpy).toHaveBeenCalledWith(expected, false);
+      expect(exitCodeSpy).toHaveBeenCalledWith(expected);
     });
 
     it('uses exitCode callback to determine exit code', async () => {
@@ -93,6 +194,26 @@ describe('createHandler', () => {
       expect(io.exitCode).toBe(1);
     });
 
+    it('escapes control characters in human error output', async () => {
+      const escape = String.fromCharCode(0x1b);
+      const c1 = String.fromCharCode(0x85);
+      const handler = createHandler<string>({
+        execute: async (): Promise<Result<string>> => ({
+          ok: false,
+          error: `bad\nline${escape}escape${c1}c1`,
+        }),
+        format: () => 'not used',
+        exitCode: () => 0,
+      });
+
+      const io = createMockIO();
+      await handler(io);
+
+      expect(io.stderrBuf).toBe('Error: bad\\nline\\x1Bescape\\x85c1\n');
+      expect(io.stderrBuf).not.toContain(escape);
+      expect(io.stderrBuf).not.toContain(c1);
+    });
+
     it('writes JSON error when json mode is enabled', async () => {
       const handler = createHandler<string>({
         execute: async (): Promise<Result<string>> => ({ ok: false, error: 'timeout' }),
@@ -105,6 +226,26 @@ describe('createHandler', () => {
 
       expect(JSON.parse(io.stderrBuf)).toEqual({ error: 'timeout' });
       expect(io.exitCode).toBe(1);
+    });
+
+    it('preserves the exact error value in JSON mode while JSON-escaping controls', async () => {
+      const del = String.fromCharCode(0x7f);
+      const c1 = String.fromCharCode(0x85);
+      const error = `bad\n${String.fromCharCode(0x1b)}${del}${c1}`;
+      const handler = createHandler<string>({
+        execute: async (): Promise<Result<string>> => ({ ok: false, error }),
+        format: () => 'not used',
+        exitCode: () => 0,
+      });
+
+      const io = createMockIO({ json: true });
+      await handler(io);
+
+      expect(JSON.parse(io.stderrBuf)).toEqual({ error });
+      expect(io.stderrBuf).not.toContain(del);
+      expect(io.stderrBuf).not.toContain(c1);
+      expect(io.stderrBuf).toContain('\\u007f');
+      expect(io.stderrBuf).toContain('\\u0085');
     });
   });
 });

--- a/src/cli/handlers.ts
+++ b/src/cli/handlers.ts
@@ -1,4 +1,5 @@
 import type { Result } from '../utils/errors.js';
+import { escapeTerminalControls, stringifyTerminalSafeJson } from '../utils/terminal.js';
 
 export interface HandlerIO {
   stdout: { write(s: string): boolean };
@@ -14,7 +15,27 @@ export interface HandlerConfig<TResult> {
   exitCode: (result: TResult) => number;
 }
 
-export function createHandler<TResult>(config: HandlerConfig<TResult>): (io: HandlerIO) => Promise<void> {
+const CLI_PROVENANCE = {
+  persistence: 'not_recorded',
+  warning: null,
+} as const;
+
+function withCliProvenance<TResult>(data: TResult): TResult {
+  if (
+    typeof data !== 'object' ||
+    data === null ||
+    !('session_id' in data) ||
+    typeof data.session_id !== 'string' ||
+    ('provenance' in data && data.provenance !== undefined)
+  ) {
+    return data;
+  }
+  return { ...data, provenance: CLI_PROVENANCE };
+}
+
+export function createHandler<TResult>(
+  config: HandlerConfig<TResult>,
+): (io: HandlerIO) => Promise<void> {
   return async (io: HandlerIO) => {
     let result: Result<TResult>;
     try {
@@ -26,20 +47,21 @@ export function createHandler<TResult>(config: HandlerConfig<TResult>): (io: Han
 
     if (!result.ok) {
       if (io.json) {
-        io.stderr.write(JSON.stringify({ error: result.error }) + '\n');
+        io.stderr.write(stringifyTerminalSafeJson({ error: result.error }) + '\n');
       } else {
-        io.stderr.write(`Error: ${result.error}\n`);
+        io.stderr.write(`Error: ${escapeTerminalControls(result.error)}\n`);
       }
       io.exit(1);
       return;
     }
 
+    const output = withCliProvenance(result.data);
     if (io.json) {
-      io.stdout.write(JSON.stringify(result.data) + '\n');
+      io.stdout.write(stringifyTerminalSafeJson(output) + '\n');
     } else {
-      io.stdout.write(config.format(result.data, io.color) + '\n');
+      io.stdout.write(config.format(output, io.color) + '\n');
     }
 
-    io.exit(config.exitCode(result.data));
+    io.exit(config.exitCode(output));
   };
 }

--- a/src/config/copilot-instructions.ts
+++ b/src/config/copilot-instructions.ts
@@ -1,6 +1,7 @@
 import { readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import picomatch from 'picomatch';
+import { escapeTerminalControls } from '../utils/terminal.js';
 import { ok, err } from '../utils/errors.js';
 import type { Result } from '../utils/errors.js';
 
@@ -46,7 +47,10 @@ export function parseFrontmatter(content: string): {
   }
 
   const fmLines = lines.slice(1, closeIdx);
-  const body = lines.slice(closeIdx + 1).join('\n').trim();
+  const body = lines
+    .slice(closeIdx + 1)
+    .join('\n')
+    .trim();
 
   const frontmatter: Record<string, string> = {};
   for (const line of fmLines) {
@@ -55,8 +59,10 @@ export function parseFrontmatter(content: string): {
     const key = line.slice(0, colonIdx).trim();
     let value = line.slice(colonIdx + 1).trim();
     // Strip surrounding quotes
-    if ((value.startsWith("'") && value.endsWith("'")) ||
-        (value.startsWith('"') && value.endsWith('"'))) {
+    if (
+      (value.startsWith("'") && value.endsWith("'")) ||
+      (value.startsWith('"') && value.endsWith('"'))
+    ) {
       value = value.slice(1, -1);
     }
     if (key) frontmatter[key] = value;
@@ -97,7 +103,7 @@ export function loadCopilotInstructions(cwd?: string): Result<CopilotInstruction
   const instructionsDir = join(githubDir, 'instructions');
   let filenames: string[];
   try {
-    filenames = readdirSync(instructionsDir).filter(f => f.endsWith('.instructions.md'));
+    filenames = readdirSync(instructionsDir).filter((f) => f.endsWith('.instructions.md'));
   } catch (e: unknown) {
     if (e instanceof Error && 'code' in e && (e as NodeJS.ErrnoException).code === 'ENOENT') {
       filenames = [];
@@ -114,14 +120,14 @@ export function loadCopilotInstructions(cwd?: string): Result<CopilotInstruction
       content = readFileSync(join(instructionsDir, filename), 'utf-8');
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : String(e);
-      console.error(`Skipping ${filename}: ${msg}`);
+      console.error(`Skipping ${escapeTerminalControls(filename)}: ${escapeTerminalControls(msg)}`);
       continue;
     }
 
     const { frontmatter, body } = parseFrontmatter(content);
 
     // Skip files excluded from code review
-    const excluded = (frontmatter.excludeAgent ?? '').split(',').map(s => s.trim());
+    const excluded = (frontmatter.excludeAgent ?? '').split(',').map((s) => s.trim());
     if (excluded.includes('code-review')) continue;
 
     // Skip files without applyTo (can't be auto-applied)
@@ -147,17 +153,20 @@ export function filterByFiles(
   if (instructions.scoped.length === 0) return instructions;
   if (files.length === 0) return { repoWide: instructions.repoWide, scoped: [] };
 
-  const matched = instructions.scoped.filter(instr => {
+  const matched = instructions.scoped.filter((instr) => {
     const matchers: picomatch.Matcher[] = [];
     for (const p of instr.applyTo.split(',')) {
       try {
         matchers.push(picomatch(p.trim()));
       } catch {
-        console.error(`Invalid applyTo glob in ${instr.filename}: ${p.trim()}`);
+        console.error(
+          `Invalid applyTo glob in ${escapeTerminalControls(instr.filename)}: ` +
+            escapeTerminalControls(p.trim()),
+        );
       }
     }
     if (matchers.length === 0) return false;
-    return files.some(file => matchers.some(m => m(file)));
+    return files.some((file) => matchers.some((m) => m(file)));
   });
 
   return { repoWide: instructions.repoWide, scoped: matched };

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -11,6 +11,7 @@ import {
   PrecommitStandardsSchema,
 } from './types.js';
 import type { ReviewBridgeConfig } from './types.js';
+import { escapeTerminalControls } from '../utils/terminal.js';
 
 const CONFIG_FILENAME = '.reviewbridge.json';
 const ENV_VAR = 'RB_CONFIG_PATH';
@@ -33,7 +34,10 @@ function unknownKeys(raw: unknown, known: string[]): string[] {
 function warnUnknownConfigKeys(raw: unknown, path: string): void {
   const warn = (loc: string, keys: string[]): void => {
     if (keys.length > 0) {
-      console.error(`[codex-bridge] ignoring unrecognized config field(s) in ${loc} (${path}): ${keys.join(', ')}`);
+      console.error(
+        `[codex-bridge] ignoring unrecognized config field(s) in ${escapeTerminalControls(loc)} ` +
+          `(${escapeTerminalControls(path)}): ${escapeTerminalControls(keys.join(', '))}`,
+      );
     }
   };
   if (!isPlainObject(raw)) return;
@@ -41,9 +45,18 @@ function warnUnknownConfigKeys(raw: unknown, path: string): void {
   const rs = raw.review_standards;
   if (!isPlainObject(rs)) return;
   warn('review_standards', unknownKeys(rs, Object.keys(ReviewStandardsSchema.shape)));
-  warn('review_standards.plan_review', unknownKeys(rs.plan_review, Object.keys(PlanReviewStandardsSchema.shape)));
-  warn('review_standards.code_review', unknownKeys(rs.code_review, Object.keys(CodeReviewStandardsSchema.shape)));
-  warn('review_standards.precommit', unknownKeys(rs.precommit, Object.keys(PrecommitStandardsSchema.shape)));
+  warn(
+    'review_standards.plan_review',
+    unknownKeys(rs.plan_review, Object.keys(PlanReviewStandardsSchema.shape)),
+  );
+  warn(
+    'review_standards.code_review',
+    unknownKeys(rs.code_review, Object.keys(CodeReviewStandardsSchema.shape)),
+  );
+  warn(
+    'review_standards.precommit',
+    unknownKeys(rs.precommit, Object.keys(PrecommitStandardsSchema.shape)),
+  );
 }
 
 export type ConfigSource =
@@ -57,9 +70,7 @@ export interface LoadedConfig {
   source: ConfigSource;
 }
 
-type ProbeResult =
-  | { hit: false }
-  | { hit: true; result: Result<ReviewBridgeConfig> };
+type ProbeResult = { hit: false } | { hit: true; result: Result<ReviewBridgeConfig> };
 
 // ENOENT only → { hit: false }. Anything else (EACCES, parse, validate)
 // returns { hit: true } so the caller stops cascading and surfaces it.
@@ -92,7 +103,9 @@ function probe(path: string): ProbeResult {
   if (!validated.success) {
     return {
       hit: true,
-      result: err(`${ErrorCode.CONFIG_ERROR}: invalid config in ${path}: ${validated.error.message}`),
+      result: err(
+        `${ErrorCode.CONFIG_ERROR}: invalid config in ${path}: ${validated.error.message}`,
+      ),
     };
   }
 

--- a/src/config/types.test.ts
+++ b/src/config/types.test.ts
@@ -15,10 +15,7 @@ describe('ReviewBridgeConfigSchema', () => {
       expect(config.timeout_seconds).toBe(300);
       expect(config.max_chunk_tokens).toBe(8000);
       expect(config.project_context).toBe('');
-      expect(config.review_standards.plan_review.focus).toEqual([
-        'architecture',
-        'feasibility',
-      ]);
+      expect(config.review_standards.plan_review.focus).toEqual(['architecture', 'feasibility']);
       expect(config.review_standards.plan_review.depth).toBe('thorough');
       expect(config.review_standards.code_review.criteria).toEqual([
         'bugs',
@@ -74,6 +71,32 @@ describe('ReviewBridgeConfigSchema', () => {
       if (result.success) {
         expect(result.data.model).toBe(model);
       }
+    }
+  });
+
+  it('trims a model selector before storing it', () => {
+    const result = ReviewBridgeConfigSchema.safeParse({ model: '  experimental-model-x  ' });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.model).toBe('experimental-model-x');
+  });
+
+  it('accepts a model selector at the 200-character boundary after trimming', () => {
+    const model = 'x'.repeat(200);
+    const result = ReviewBridgeConfigSchema.safeParse({ model: `  ${model}  ` });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.model).toBe(model);
+  });
+
+  it('rejects empty, overlong, and control-character model selectors', () => {
+    for (const model of [
+      '',
+      '   ',
+      'x'.repeat(201),
+      'safe\nforged',
+      `safe${String.fromCharCode(0x7f)}forged`,
+      `safe${String.fromCharCode(0x85)}forged`,
+    ]) {
+      expect(ReviewBridgeConfigSchema.safeParse({ model }).success).toBe(false);
     }
   });
 
@@ -186,10 +209,7 @@ describe('DEFAULT_CONFIG', () => {
     expect(DEFAULT_CONFIG.timeout_seconds).toBe(300);
     expect(DEFAULT_CONFIG.max_chunk_tokens).toBe(8000);
     expect(DEFAULT_CONFIG.project_context).toBe('');
-    expect(DEFAULT_CONFIG.review_standards.precommit.block_on).toEqual([
-      'critical',
-      'major',
-    ]);
+    expect(DEFAULT_CONFIG.review_standards.precommit.block_on).toEqual(['critical', 'major']);
   });
 
   it('matches parsing an empty object', () => {

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { ModelSelectorSchema } from '../utils/input-validation.js';
 
 // Config-local severity enum — avoids cross-layer import from review/types.ts
 const BlockOnSeveritySchema = z.enum(['critical', 'major', 'minor', 'suggestion', 'nitpick']);
@@ -53,7 +54,7 @@ export const ReviewBridgeConfigSchema = z.object({
   provider: ProviderSchema.default('codex'),
   // No schema-level default — each backend resolves its own default model at
   // construction. A config value or per-call override takes precedence.
-  model: z.string().optional(),
+  model: ModelSelectorSchema.optional(),
   // Path to a `codex` binary to spawn instead of the one bundled with
   // @openai/codex-sdk. Escape hatch for when the vendored binary is missing or
   // unusable — e.g. macOS XProtect trashing it as a false positive — so the

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,20 @@
+import { escapeTerminalControls } from './utils/terminal.js';
+
 // No args = MCP server (Claude Code integration). Any arg = CLI mode.
 const isCli = process.argv.length > 2;
 
 if (isCli) {
-  import('./cli/commands.js').then(({ runCli }) => runCli()).catch((e) => {
-    console.error(e);
-    process.exit(1);
-  });
+  import('./cli/commands.js')
+    .then(({ runCli }) => runCli())
+    .catch((e) => {
+      console.error(escapeTerminalControls(e instanceof Error ? e.message : String(e)));
+      process.exit(1);
+    });
 } else {
-  import('./mcp.js').then(({ startMcpServer }) => startMcpServer()).catch((e) => {
-    console.error(e);
-    process.exit(1);
-  });
+  import('./mcp.js')
+    .then(({ startMcpServer }) => startMcpServer())
+    .catch((e) => {
+      console.error(escapeTerminalControls(e instanceof Error ? e.message : String(e)));
+      process.exit(1);
+    });
 }

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { createServer } from './server.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { escapeTerminalControls } from './utils/terminal.js';
 
 function createServerOrExit(): McpServer {
   try {
@@ -9,7 +10,9 @@ function createServerOrExit(): McpServer {
     // Print just the message (no stack) for known startup failures like
     // CONFIG_ERROR. Unexpected runtime errors after this point still bubble
     // up to index.ts where they're console.error'd with full context.
-    process.stderr.write(`[codex-bridge] ${e instanceof Error ? e.message : String(e)}\n`);
+    process.stderr.write(
+      `[codex-bridge] ${escapeTerminalControls(e instanceof Error ? e.message : String(e))}\n`,
+    );
     process.exit(1);
   }
 }

--- a/src/review/lifecycle.test.ts
+++ b/src/review/lifecycle.test.ts
@@ -649,3 +649,96 @@ describe('review lifecycle coordinator', () => {
     expect(registry.activeCount()).toBe(0);
   });
 });
+
+// Failure must reach SQLite, not only the in-memory registry. A resumed review
+// that fails on a session the database still records as `completed` would
+// otherwise report success from review_status after a restart or eviction.
+describe('failure persistence', () => {
+  async function completedSessionDb(): Promise<Database.Database> {
+    const { default: Sqlite } = await import('better-sqlite3');
+    const { initSessionsDb, getOrCreateSession, markSessionCompleted } =
+      await import('../storage/sessions.js');
+    const db = new Sqlite(':memory:');
+    initSessionsDb(db);
+    getOrCreateSession(db, 'old-owner', 'codex');
+    markSessionCompleted(db, 'old-owner');
+    return db;
+  }
+
+  async function statusOf(db: Database.Database, id: string): Promise<string | undefined> {
+    const { getSession } = await import('../storage/sessions.js');
+    const row = getSession(db, id);
+    return row.ok && row.data ? row.data.status : undefined;
+  }
+
+  it('marks a completed session failed in SQLite when its resumed review fails', async () => {
+    const db = await completedSessionDb();
+    const registry = createSessionRegistry();
+    const lifecycle = createReviewLifecycle({
+      backend: backend({
+        reviewPlan: vi.fn().mockResolvedValue(err('MODEL_ERROR: boom', 'old-owner')),
+      }),
+      registry,
+      lookupSessionProvider: () => ({ status: 'found', value: 'codex' }),
+      storage: { db, durability: 'durable', warning: null },
+      recordOutcome: vi.fn(),
+    });
+
+    const result = await lifecycle.reviewPlan({ plan: 'plan', session_id: 'old-owner' });
+
+    expect(result.ok).toBe(false);
+    expect(await statusOf(db, 'old-owner')).toBe('failed');
+  });
+
+  it('also persists the failure when the provider throws', async () => {
+    const db = await completedSessionDb();
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const lifecycle = createReviewLifecycle({
+      backend: backend({ reviewPlan: vi.fn().mockRejectedValue(new Error('crash')) }),
+      registry: createSessionRegistry(),
+      lookupSessionProvider: () => ({ status: 'found', value: 'codex' }),
+      storage: { db, durability: 'durable', warning: null },
+      recordOutcome: vi.fn(),
+    });
+
+    const result = await lifecycle.reviewPlan({ plan: 'plan', session_id: 'old-owner' });
+
+    expect(result.ok).toBe(false);
+    expect(await statusOf(db, 'old-owner')).toBe('failed');
+    consoleSpy.mockRestore();
+  });
+
+  it('records a failed FRESH review under the session id the provider returned', async () => {
+    const db = await completedSessionDb();
+    const lifecycle = createReviewLifecycle({
+      backend: backend({
+        reviewPlan: vi.fn().mockResolvedValue(err('MODEL_ERROR: boom', 'fresh-partial')),
+      }),
+      registry: createSessionRegistry(),
+      lookupSessionProvider: () => ({ status: 'absent' }),
+      storage: { db, durability: 'durable', warning: null },
+      recordOutcome: vi.fn(),
+    });
+
+    await lifecycle.reviewPlan({ plan: 'plan' });
+
+    expect(await statusOf(db, 'fresh-partial')).toBe('failed');
+  });
+
+  it('writes nothing when storage is memory-only', async () => {
+    const db = await completedSessionDb();
+    const lifecycle = createReviewLifecycle({
+      backend: backend({
+        reviewPlan: vi.fn().mockResolvedValue(err('MODEL_ERROR: boom', 'old-owner')),
+      }),
+      registry: createSessionRegistry(),
+      lookupSessionProvider: () => ({ status: 'found', value: 'codex' }),
+      storage: { db, durability: 'memory_only', warning: null },
+      recordOutcome: vi.fn(),
+    });
+
+    await lifecycle.reviewPlan({ plan: 'plan', session_id: 'old-owner' });
+
+    expect(await statusOf(db, 'old-owner')).toBe('completed');
+  });
+});

--- a/src/review/lifecycle.test.ts
+++ b/src/review/lifecycle.test.ts
@@ -1,0 +1,651 @@
+import { describe, expect, it, vi } from 'vitest';
+import type Database from 'better-sqlite3';
+import type { ReviewBackend } from '../backends/backend.js';
+import type { ModelIdentity, PlanReviewResult } from './types.js';
+import { createReviewLifecycle } from './lifecycle.js';
+import { createSessionRegistry } from '../storage/session-registry.js';
+import { createSessionRouting } from '../storage/session-routing.js';
+import { err, ErrorCode, ok } from '../utils/errors.js';
+
+const MODEL: ModelIdentity = {
+  provider: 'codex',
+  role: 'review',
+  requested: null,
+  resolved: 'gpt-5.6-sol',
+  observed: 'gpt-5.6-sol',
+  evidence: 'runtime_session_record',
+};
+
+const GEMINI_MODEL: ModelIdentity = {
+  provider: 'gemini',
+  role: 'review',
+  requested: 'Gemini 3.1 Pro (High)',
+  resolved: 'Gemini 3.1 Pro (High)',
+  observed: null,
+  evidence: 'bridge_selection',
+};
+
+const PLAN_RESULT: PlanReviewResult = {
+  verdict: 'approve',
+  summary: 'Looks good',
+  findings: [],
+  session_id: 'result-session',
+  provider: 'codex',
+  models: [MODEL],
+};
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+function backend(overrides: Partial<ReviewBackend> = {}): ReviewBackend {
+  return {
+    provider: 'codex',
+    providers: ['codex'],
+    allowsModelOverrideOnResume: false,
+    reviewPlan: vi.fn().mockResolvedValue(ok(PLAN_RESULT)),
+    reviewCode: vi.fn().mockResolvedValue(
+      ok({
+        verdict: 'approve',
+        summary: 'good',
+        findings: [],
+        session_id: 'code-session',
+        provider: 'codex',
+        models: [MODEL],
+      }),
+    ),
+    reviewPrecommit: vi.fn().mockResolvedValue(
+      ok({
+        ready_to_commit: true,
+        blockers: [],
+        warnings: [],
+        session_id: 'pre-session',
+        provider: 'codex',
+        models: [MODEL],
+      }),
+    ),
+    ...overrides,
+  };
+}
+
+describe('review lifecycle coordinator', () => {
+  it('records an immutable model snapshot and returns durable provenance', async () => {
+    const recordOutcome = vi.fn().mockResolvedValue(ok(undefined));
+    const registry = createSessionRegistry();
+    const lifecycle = createReviewLifecycle({
+      backend: backend(),
+      registry,
+      lookupSessionProvider: () => ({ status: 'absent' }),
+      storage: { db: {} as Database.Database, durability: 'durable', warning: null },
+      recordOutcome,
+    });
+
+    const result = await lifecycle.reviewPlan({ plan: 'plan' });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.provenance).toEqual({ persistence: 'durable', warning: null });
+    expect(recordOutcome).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        resultSessionId: 'result-session',
+        servingProvider: 'codex',
+        ownerModelIdentity: MODEL,
+        review: expect.objectContaining({ models: [MODEL] }),
+      }),
+    );
+    expect(registry.getStatus('result-session')).toMatchObject({
+      status: 'completed',
+      provider: 'codex',
+      model: MODEL,
+    });
+  });
+
+  it('preserves a successful review with memory-only provenance after a permanent write failure', async () => {
+    const registry = createSessionRegistry();
+    const onOutcomePersistenceFailure = vi.fn();
+    const lifecycle = createReviewLifecycle({
+      backend: backend(),
+      registry,
+      lookupSessionProvider: () => ({ status: 'absent' }),
+      storage: { db: {} as Database.Database, durability: 'durable', warning: null },
+      recordOutcome: vi.fn().mockResolvedValue(err('STORAGE_ERROR: /secret/path is readonly')),
+      onOutcomePersistenceFailure,
+    });
+
+    const result = await lifecycle.reviewPlan({ plan: 'plan' });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.provenance?.persistence).toBe('memory_only');
+    expect(result.data.provenance?.warning).toBe(
+      'Review succeeded, but its history could not be saved durably; session routing is memory-only.',
+    );
+    expect(result.data.provenance?.warning).not.toContain('/secret/path');
+    expect(registry.getStatus('result-session')?.status).toBe('completed');
+    expect(onOutcomePersistenceFailure).toHaveBeenCalledOnce();
+    expect(onOutcomePersistenceFailure).toHaveBeenCalledWith('result-session');
+  });
+
+  it('preserves a successful review when the outcome writer throws', async () => {
+    const registry = createSessionRegistry();
+    const lifecycle = createReviewLifecycle({
+      backend: backend(),
+      registry,
+      lookupSessionProvider: () => ({ status: 'absent' }),
+      storage: { db: {} as Database.Database, durability: 'durable', warning: null },
+      recordOutcome: vi.fn().mockRejectedValue(new Error('/secret/path failed')),
+    });
+
+    const result = await lifecycle.reviewPlan({ plan: 'plan' });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.provenance).toEqual({
+      persistence: 'memory_only',
+      warning:
+        'Review succeeded, but its history could not be saved durably; session routing is memory-only.',
+    });
+    expect(result.data.provenance?.warning).not.toContain('/secret/path');
+    expect(registry.getStatus('result-session')).toMatchObject({
+      status: 'completed',
+      provider: 'codex',
+    });
+  });
+
+  it('fails closed when a fresh Gemini result reuses an existing Codex registry id', async () => {
+    const registry = createSessionRegistry();
+    registry.complete(undefined, 'result-session', 'codex', MODEL);
+    const before = registry.getStatus('result-session');
+    const recordOutcome = vi.fn();
+    const client = backend({
+      provider: 'gemini',
+      providers: ['gemini'],
+      allowsModelOverrideOnResume: true,
+      reviewPlan: vi.fn().mockResolvedValue(
+        ok({
+          ...PLAN_RESULT,
+          provider: 'gemini' as const,
+          models: [GEMINI_MODEL],
+        }),
+      ),
+    });
+    const lifecycle = createReviewLifecycle({
+      backend: client,
+      registry,
+      lookupSessionProvider: () => ({ status: 'absent' }),
+      storage: { db: {} as Database.Database, durability: 'durable', warning: null },
+      recordOutcome,
+    });
+
+    const result = await lifecycle.reviewPlan({ plan: 'plan' });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/^SESSION_ROUTING_UNAVAILABLE:/);
+    expect(registry.getStatus('result-session')).toEqual(before);
+    expect(recordOutcome).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when a fresh result collides with a same-provider durable session', async () => {
+    const registry = createSessionRegistry();
+    const lookupSessionProvider = vi.fn((sessionId: string) =>
+      sessionId === 'result-session'
+        ? ({ status: 'found', value: 'codex' } as const)
+        : ({ status: 'absent' } as const),
+    );
+    const recordOutcome = vi.fn();
+    const lifecycle = createReviewLifecycle({
+      backend: backend(),
+      registry,
+      lookupSessionProvider,
+      storage: { db: {} as Database.Database, durability: 'durable', warning: null },
+      recordOutcome,
+    });
+
+    const result = await lifecycle.reviewPlan({ plan: 'plan' });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/^SESSION_ROUTING_UNAVAILABLE:/);
+    expect(registry.getStatus('result-session')).toBeNull();
+    expect(recordOutcome).not.toHaveBeenCalled();
+  });
+
+  it('uses registry absence as sufficient collision evidence for memory-only storage', async () => {
+    const recordOutcome = vi.fn().mockResolvedValue(ok(undefined));
+    const lifecycle = createReviewLifecycle({
+      backend: backend(),
+      registry: createSessionRegistry(),
+      lookupSessionProvider: () => ({ status: 'unavailable' }),
+      storage: { db: {} as Database.Database, durability: 'memory_only', warning: null },
+      recordOutcome,
+    });
+
+    const result = await lifecycle.reviewPlan({ plan: 'plan' });
+
+    expect(result.ok).toBe(true);
+    expect(recordOutcome).toHaveBeenCalledOnce();
+  });
+
+  it('seeds an absent preflight route with the attempted owner through a survivor transition', async () => {
+    const registry = createSessionRegistry();
+    const recordOutcome = vi.fn().mockResolvedValue(ok(undefined));
+    const lifecycle = createReviewLifecycle({
+      backend: backend(),
+      registry,
+      lookupSessionProvider: () => ({ status: 'absent' }),
+      storage: { db: {} as Database.Database, durability: 'durable', warning: null },
+      recordOutcome,
+    });
+
+    const result = await lifecycle.reviewPlan({ plan: 'plan', session_id: 'old-owner' });
+
+    expect(result.ok).toBe(true);
+    expect(recordOutcome).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        preflightSessionId: 'old-owner',
+        preflightProvider: 'codex',
+        resultSessionId: 'result-session',
+      }),
+    );
+    expect(registry.getStatus('old-owner')).toMatchObject({
+      status: 'failed',
+      provider: 'codex',
+    });
+  });
+
+  it('does not downgrade a transactional result-id collision to memory-only success', async () => {
+    const registry = createSessionRegistry();
+    const onOutcomePersistenceFailure = vi.fn();
+    const lifecycle = createReviewLifecycle({
+      backend: backend(),
+      registry,
+      lookupSessionProvider: (sessionId) =>
+        sessionId === 'old-owner' ? { status: 'found', value: 'codex' } : { status: 'absent' },
+      storage: { db: {} as Database.Database, durability: 'durable', warning: null },
+      recordOutcome: vi
+        .fn()
+        .mockResolvedValue(
+          err('SESSION_ROUTING_UNAVAILABLE: returned session id is already recorded'),
+        ),
+      onOutcomePersistenceFailure,
+    });
+
+    const result = await lifecycle.reviewPlan({ plan: 'plan', session_id: 'old-owner' });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/^SESSION_ROUTING_UNAVAILABLE:/);
+    expect(registry.getStatus('result-session')).toBeNull();
+    expect(registry.getStatus('old-owner')).toBeNull();
+    expect(onOutcomePersistenceFailure).not.toHaveBeenCalled();
+  });
+
+  it('accepts a later fresh result after storage recovers while an evicted survivor stays unroutable', async () => {
+    let now = 0;
+    const registry = createSessionRegistry({ ttlMs: 10, now: () => now });
+    const durableOwners = new Map<string, 'codex' | 'gemini'>();
+    const routing = createSessionRouting({
+      registry,
+      durability: 'durable',
+      providerLookup: (sessionId) => {
+        const provider = durableOwners.get(sessionId);
+        return provider ? { status: 'found', value: provider } : { status: 'absent' };
+      },
+      modelLookup: () => ({ status: 'absent' }),
+    });
+    const reviewPlan = vi
+      .fn()
+      .mockResolvedValueOnce(ok({ ...PLAN_RESULT, session_id: 'volatile-survivor' }))
+      .mockResolvedValueOnce(ok({ ...PLAN_RESULT, session_id: 'recovered-result' }));
+    const recordOutcome = vi
+      .fn()
+      .mockResolvedValueOnce(err('STORAGE_ERROR: injected write failure'))
+      .mockImplementationOnce(async (_db, outcome) => {
+        durableOwners.set(outcome.resultSessionId, outcome.servingProvider);
+        return ok(undefined);
+      });
+    const lifecycle = createReviewLifecycle({
+      backend: backend({ reviewPlan }),
+      registry,
+      lookupSessionProvider: routing.lookupProvider,
+      lookupResultSession: routing.lookupResultSession,
+      storage: { db: {} as Database.Database, durability: 'durable', warning: null },
+      recordOutcome,
+      onOutcomePersistenceFailure: routing.markOutcomePersistenceFailure,
+      onOutcomePersisted: routing.markOutcomePersisted,
+    });
+
+    const first = await lifecycle.reviewPlan({ plan: 'first' });
+    expect(first.ok && first.data.provenance?.persistence).toBe('memory_only');
+
+    now = 11;
+    expect(routing.lookupProvider('volatile-survivor')).toEqual({ status: 'unavailable' });
+
+    const second = await lifecycle.reviewPlan({ plan: 'second' });
+    expect(second.ok && second.data.provenance?.persistence).toBe('durable');
+    expect(routing.lookupProvider('recovered-result')).toEqual({
+      status: 'found',
+      value: 'codex',
+    });
+    expect(recordOutcome).toHaveBeenCalledTimes(2);
+  });
+
+  it('clears tombstones for both ids after a durable survivor transition', async () => {
+    let now = 0;
+    const registry = createSessionRegistry();
+    registry.complete(undefined, 'old-owner', 'codex', MODEL);
+    const routing = createSessionRouting({
+      registry,
+      durability: 'durable',
+      providerLookup: () => ({ status: 'absent' }),
+      modelLookup: () => ({ status: 'absent' }),
+      tombstoneTtlMs: 10,
+      now: () => now,
+    });
+    routing.markOutcomePersistenceFailure('old-owner');
+    const lifecycle = createReviewLifecycle({
+      backend: backend(),
+      registry,
+      lookupSessionProvider: routing.lookupProvider,
+      lookupResultSession: routing.lookupResultSession,
+      storage: { db: {} as Database.Database, durability: 'durable', warning: null },
+      recordOutcome: vi.fn().mockResolvedValue(ok(undefined)),
+      onOutcomePersistenceFailure: routing.markOutcomePersistenceFailure,
+      onOutcomePersisted: routing.markOutcomePersisted,
+    });
+
+    const result = await lifecycle.reviewPlan({ plan: 'transition', session_id: 'old-owner' });
+    expect(result.ok).toBe(true);
+
+    now = 11;
+    expect(routing.lookupProvider('unrelated')).toEqual({ status: 'absent' });
+  });
+
+  it('drops a provisional same-id registry owner after a transactional routing conflict', async () => {
+    const registry = createSessionRegistry();
+    registry.complete(undefined, 'shared', 'codex', MODEL);
+    const routing = createSessionRouting({
+      registry,
+      durability: 'durable',
+      providerLookup: () => ({ status: 'found', value: 'gemini' }),
+      modelLookup: () => ({ status: 'absent' }),
+    });
+    const lifecycle = createReviewLifecycle({
+      backend: backend({
+        providers: ['codex', 'gemini'],
+        reviewPlan: vi.fn().mockResolvedValue(ok({ ...PLAN_RESULT, session_id: 'shared' })),
+      }),
+      registry,
+      lookupSessionProvider: routing.lookupProvider,
+      lookupResultSession: routing.lookupResultSession,
+      storage: { db: {} as Database.Database, durability: 'durable', warning: null },
+      recordOutcome: vi
+        .fn()
+        .mockResolvedValue(
+          err('SESSION_ROUTING_UNAVAILABLE: result session owner changed during persistence'),
+        ),
+    });
+
+    const result = await lifecycle.reviewPlan({ plan: 'resume', session_id: 'shared' });
+
+    expect(result.ok).toBe(false);
+    expect(registry.getStatus('shared')).toBeNull();
+    expect(routing.lookupProvider('shared')).toEqual({ status: 'found', value: 'gemini' });
+  });
+
+  it('rejects fresh reuse of an evicted unpersisted id while allowing another fresh id', async () => {
+    let now = 0;
+    const registry = createSessionRegistry({ ttlMs: 10, now: () => now });
+    const routing = createSessionRouting({
+      registry,
+      durability: 'durable',
+      providerLookup: () => ({ status: 'absent' }),
+      modelLookup: () => ({ status: 'absent' }),
+      tombstoneTtlMs: 100,
+      now: () => now,
+    });
+    const reviewPlan = vi
+      .fn()
+      .mockResolvedValueOnce(ok({ ...PLAN_RESULT, session_id: 'reused' }))
+      .mockResolvedValueOnce(ok({ ...PLAN_RESULT, session_id: 'reused' }))
+      .mockResolvedValueOnce(ok({ ...PLAN_RESULT, session_id: 'unrelated' }));
+    const recordOutcome = vi
+      .fn()
+      .mockResolvedValueOnce(err('STORAGE_ERROR: injected write failure'))
+      .mockResolvedValueOnce(ok(undefined));
+    const lifecycle = createReviewLifecycle({
+      backend: backend({ reviewPlan }),
+      registry,
+      lookupSessionProvider: routing.lookupProvider,
+      lookupResultSession: routing.lookupResultSession,
+      storage: { db: {} as Database.Database, durability: 'durable', warning: null },
+      recordOutcome,
+      onOutcomePersistenceFailure: routing.markOutcomePersistenceFailure,
+      onOutcomePersisted: routing.markOutcomePersisted,
+    });
+
+    const first = await lifecycle.reviewPlan({ plan: 'first' });
+    expect(first.ok && first.data.provenance?.persistence).toBe('memory_only');
+    now = 11;
+
+    const reused = await lifecycle.reviewPlan({ plan: 'reuse' });
+    expect(reused.ok).toBe(false);
+    if (!reused.ok) expect(reused.error).toMatch(/^SESSION_ROUTING_UNAVAILABLE:/);
+
+    const unrelated = await lifecycle.reviewPlan({ plan: 'unrelated' });
+    expect(unrelated.ok && unrelated.data.provenance?.persistence).toBe('durable');
+    expect(recordOutcome).toHaveBeenCalledTimes(2);
+  });
+
+  it('marks configured in-memory storage honestly even when its transaction succeeds', async () => {
+    const lifecycle = createReviewLifecycle({
+      backend: backend(),
+      registry: createSessionRegistry(),
+      lookupSessionProvider: () => ({ status: 'absent' }),
+      storage: {
+        db: {} as Database.Database,
+        durability: 'memory_only',
+        warning: 'raw initialization details',
+      },
+      recordOutcome: vi.fn().mockResolvedValue(ok(undefined)),
+    });
+
+    const result = await lifecycle.reviewPlan({ plan: 'plan' });
+    expect(result.ok && result.data.provenance).toEqual({
+      persistence: 'memory_only',
+      warning: 'Durable review history is unavailable; session state is being kept in memory only.',
+    });
+  });
+
+  it('resolves synthetic empty results before admission and does not persist them', async () => {
+    const registry = createSessionRegistry({ maxActive: 1 });
+    const syntheticBackend = backend({
+      reviewCode: vi.fn().mockResolvedValue(
+        ok({
+          verdict: 'approve',
+          summary: 'No changes to review.',
+          findings: [],
+          session_id: 'synthetic',
+          models: [],
+        }),
+      ),
+    });
+    const recordOutcome = vi.fn();
+    const lifecycle = createReviewLifecycle({
+      backend: syntheticBackend,
+      registry,
+      lookupSessionProvider: () => ({ status: 'unavailable' }),
+      storage: { db: {} as Database.Database, durability: 'durable', warning: null },
+      recordOutcome,
+    });
+
+    const result = await lifecycle.reviewCode({ diff: '', session_id: 'unroutable' });
+
+    expect(result.ok && result.data.models).toEqual([]);
+    expect(result.ok && result.data.provenance).toEqual({
+      persistence: 'not_recorded',
+      warning: null,
+    });
+    expect(registry.activeCount()).toBe(0);
+    expect(registry.getStatus('unroutable')).toBeNull();
+    expect(recordOutcome).not.toHaveBeenCalled();
+  });
+
+  it('rejects same-session overlap across different review tools', async () => {
+    const pending = deferred<ReturnType<typeof ok<PlanReviewResult>>>();
+    const client = backend({ reviewPlan: vi.fn(() => pending.promise) });
+    const lifecycle = createReviewLifecycle({
+      backend: client,
+      registry: createSessionRegistry(),
+      lookupSessionProvider: () => ({ status: 'absent' }),
+    });
+
+    const first = lifecycle.reviewPlan({ plan: 'plan', session_id: 'shared' });
+    const overlap = await lifecycle.reviewCode({ diff: 'short', session_id: 'shared' });
+
+    expect(overlap.ok).toBe(false);
+    if (!overlap.ok) expect(overlap.error).toMatch(/^REVIEW_BUSY:/);
+    pending.resolve(ok({ ...PLAN_RESULT, session_id: 'shared' }));
+    await first;
+  });
+
+  it('allows four different reviews, rejects the fifth, and releases admission after completion', async () => {
+    const pending = Array.from({ length: 4 }, () =>
+      deferred<ReturnType<typeof ok<PlanReviewResult>>>(),
+    );
+    let call = 0;
+    const client = backend({
+      reviewPlan: vi.fn(() => pending[call++]?.promise ?? Promise.resolve(ok(PLAN_RESULT))),
+    });
+    const registry = createSessionRegistry();
+    const lifecycle = createReviewLifecycle({
+      backend: client,
+      registry,
+      lookupSessionProvider: () => ({ status: 'absent' }),
+    });
+    const running = ['a', 'b', 'c', 'd'].map((session_id) =>
+      lifecycle.reviewPlan({ plan: 'plan', session_id }),
+    );
+
+    const fifth = await lifecycle.reviewPlan({ plan: 'plan', session_id: 'e' });
+    expect(fifth.ok).toBe(false);
+    if (!fifth.ok) expect(fifth.error).toMatch(/^REVIEW_BUSY:/);
+
+    pending.forEach((entry, index) =>
+      entry.resolve(ok({ ...PLAN_RESULT, session_id: ['a', 'b', 'c', 'd'][index] })),
+    );
+    await Promise.all(running);
+    expect(registry.activeCount()).toBe(0);
+    expect((await lifecycle.reviewPlan({ plan: 'next', session_id: 'e' })).ok).toBe(true);
+  });
+
+  it('returns a sanitized error and releases admission when a provider throws', async () => {
+    const log = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const registry = createSessionRegistry();
+    const lifecycle = createReviewLifecycle({
+      backend: backend({
+        reviewPlan: vi
+          .fn()
+          .mockRejectedValue(new Error('boom at /Users/alice/private.ts\nsecret=do-not-leak')),
+      }),
+      registry,
+      lookupSessionProvider: () => ({ status: 'absent' }),
+    });
+
+    const result = await lifecycle.reviewPlan({ plan: 'plan', session_id: 's1' });
+
+    expect(result).toEqual({
+      ok: false,
+      error: `${ErrorCode.UNKNOWN_ERROR}: review failed unexpectedly`,
+    });
+    expect(!result.ok && result.error).not.toContain('/Users/alice');
+    expect(!result.ok && result.error).not.toContain('do-not-leak');
+    expect(log).toHaveBeenCalledWith('[codex-bridge] review failed unexpectedly');
+    expect(log.mock.calls.flat().join(' ')).not.toContain('do-not-leak');
+    expect(registry.activeCount()).toBe(0);
+    expect(registry.getStatus('s1')?.status).toBe('failed');
+    log.mockRestore();
+  });
+
+  it('rejects unavailable ownership before calling any provider', async () => {
+    const client = backend();
+    const lifecycle = createReviewLifecycle({
+      backend: client,
+      registry: createSessionRegistry(),
+      lookupSessionProvider: () => ({ status: 'unavailable' }),
+    });
+
+    const result = await lifecycle.reviewPlan({ plan: 'plan', session_id: 's1' });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/^SESSION_ROUTING_UNAVAILABLE:/);
+    expect(client.reviewPlan).not.toHaveBeenCalled();
+  });
+
+  it('allows a Gemini-owned failed-over session to change model under a Codex-primary composite', async () => {
+    const reviewPlan = vi.fn().mockResolvedValue(
+      ok({
+        ...PLAN_RESULT,
+        session_id: 'failed-over',
+        provider: 'gemini' as const,
+        models: [GEMINI_MODEL],
+      }),
+    );
+    const client = backend({
+      provider: 'codex',
+      providers: ['codex', 'gemini'],
+      allowsModelOverrideOnResume: false,
+      allowsModelOverrideOnResumeFor: (provider) => provider === 'gemini',
+      reviewPlan,
+    });
+    const lifecycle = createReviewLifecycle({
+      backend: client,
+      registry: createSessionRegistry(),
+      lookupSessionProvider: () => ({ status: 'found', value: 'gemini' }),
+    });
+
+    const result = await lifecycle.reviewPlan({
+      plan: 'plan',
+      session_id: 'failed-over',
+      model: 'Gemini 3.1 Pro (High)',
+    });
+
+    expect(result.ok).toBe(true);
+    expect(reviewPlan).toHaveBeenCalledOnce();
+  });
+
+  it('rejects a Codex-owned model override under a Gemini-primary composite without mutating registry state', async () => {
+    const registry = createSessionRegistry();
+    registry.complete(undefined, 'codex-owned', 'codex', MODEL);
+    const before = registry.getStatus('codex-owned');
+    const reviewPlan = vi.fn();
+    const client = backend({
+      provider: 'gemini',
+      providers: ['gemini', 'codex'],
+      allowsModelOverrideOnResume: true,
+      allowsModelOverrideOnResumeFor: (provider) => provider === 'gemini',
+      reviewPlan,
+    });
+    const lifecycle = createReviewLifecycle({
+      backend: client,
+      registry,
+      lookupSessionProvider: () => ({ status: 'found', value: 'codex' }),
+    });
+
+    const result = await lifecycle.reviewPlan({
+      plan: 'plan',
+      session_id: 'codex-owned',
+      model: 'gpt-5.5',
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/^INVALID_INPUT:/);
+    expect(reviewPlan).not.toHaveBeenCalled();
+    expect(registry.getStatus('codex-owned')).toEqual(before);
+    expect(registry.activeCount()).toBe(0);
+  });
+});

--- a/src/review/lifecycle.ts
+++ b/src/review/lifecycle.ts
@@ -20,6 +20,8 @@ import type { RecordReviewOutcomeInput } from '../storage/review-outcome.js';
 import { recordReviewOutcomeWithRetry } from '../storage/review-outcome.js';
 import type { SessionRegistry } from '../storage/session-registry.js';
 import type { StorageDurability } from '../storage/db.js';
+import { getOrCreateSession, markSessionFailed } from '../storage/sessions.js';
+import { escapeTerminalControls } from '../utils/terminal.js';
 import { err, ErrorCode, ok } from '../utils/errors.js';
 import type { Result } from '../utils/errors.js';
 
@@ -209,6 +211,7 @@ export function createReviewLifecycle(options: ReviewLifecycleOptions): ReviewLi
     );
     if (!freshResult.ok) {
       registry.fail(input.session_id);
+      persistFailure(prepared.servingProvider, input.session_id);
       return err(freshResult.error);
     }
 
@@ -283,8 +286,41 @@ export function createReviewLifecycle(options: ReviewLifecycleOptions): ReviewLi
     for (const sessionId of prepared.discardAfterRelease) registry.discard(sessionId);
   }
 
-  function unexpectedFailure<R extends ReviewResult>(sessionId?: string): Result<R> {
+  // Memory state is authoritative for the live process, but a failure must ALSO
+  // reach the database: a resumed review that fails on a session SQLite still
+  // records as `completed` would report success from review_status after a
+  // restart or registry eviction. Best-effort — a write failure here must not
+  // mask the review failure being reported.
+  function persistFailure(
+    provider: ReviewProvider,
+    ...sessionIds: Array<string | undefined>
+  ): void {
+    if (!storage || storage.durability === 'memory_only') return;
+    for (const id of sessionIds) {
+      if (!id) continue;
+      try {
+        storage.db.transaction(() => {
+          const created = getOrCreateSession(storage.db, id, provider);
+          if (!created.ok) throw new Error(created.error);
+          const failed = markSessionFailed(storage.db, id);
+          if (!failed.ok) throw new Error(failed.error);
+        })();
+      } catch (e: unknown) {
+        console.error(
+          `[codex-bridge] could not persist review failure: ${escapeTerminalControls(
+            e instanceof Error ? e.message : String(e),
+          )}`,
+        );
+      }
+    }
+  }
+
+  function unexpectedFailure<R extends ReviewResult>(
+    provider: ReviewProvider,
+    sessionId?: string,
+  ): Result<R> {
     registry.fail(sessionId);
+    persistFailure(provider, sessionId);
     console.error('[codex-bridge] review failed unexpectedly');
     return err<R>(UNEXPECTED_REVIEW_ERROR);
   }
@@ -301,7 +337,7 @@ export function createReviewLifecycle(options: ReviewLifecycleOptions): ReviewLi
         const synthetic = await invoke();
         return synthetic.ok ? ok(notRecorded(synthetic.data)) : synthetic;
       } catch {
-        return unexpectedFailure<R>();
+        return unexpectedFailure<R>(backend.provider);
       }
     }
 
@@ -313,6 +349,7 @@ export function createReviewLifecycle(options: ReviewLifecycleOptions): ReviewLi
       const providerResult = await invoke();
       if (!providerResult.ok) {
         registry.fail(input.session_id, providerResult.session_id);
+        persistFailure(prepared.servingProvider, input.session_id, providerResult.session_id);
         return providerResult;
       }
 
@@ -327,7 +364,7 @@ export function createReviewLifecycle(options: ReviewLifecycleOptions): ReviewLi
       if (!provenance.ok) return err<R>(provenance.error);
       return ok({ ...normalized.data.result, provenance: provenance.data });
     } catch {
-      return unexpectedFailure<R>(input.session_id);
+      return unexpectedFailure<R>(prepared.servingProvider, input.session_id);
     } finally {
       releaseOrDiscardRoutingState(prepared);
     }

--- a/src/review/lifecycle.ts
+++ b/src/review/lifecycle.ts
@@ -1,0 +1,341 @@
+import type Database from 'better-sqlite3';
+import type {
+  CodeReviewInput,
+  PlanReviewInput,
+  PrecommitReviewInput,
+  ReviewBackend,
+} from '../backends/backend.js';
+import { canOverrideModelOnResume } from '../backends/backend.js';
+import { sessionModelConflictMessage } from '../backends/orchestrator.js';
+import type { SessionProviderLookup, SessionProviderLookupResult } from '../backends/failover.js';
+import type { ReviewProvider } from '../config/types.js';
+import type {
+  CodeReviewResult,
+  ModelIdentity,
+  PlanReviewResult,
+  PrecommitResult,
+  ReviewProvenance,
+} from './types.js';
+import type { RecordReviewOutcomeInput } from '../storage/review-outcome.js';
+import { recordReviewOutcomeWithRetry } from '../storage/review-outcome.js';
+import type { SessionRegistry } from '../storage/session-registry.js';
+import type { StorageDurability } from '../storage/db.js';
+import { err, ErrorCode, ok } from '../utils/errors.js';
+import type { Result } from '../utils/errors.js';
+
+type ReviewResult = PlanReviewResult | CodeReviewResult | PrecommitResult;
+type ReviewInput = PlanReviewInput | CodeReviewInput | PrecommitReviewInput;
+type ReviewType = 'plan' | 'code' | 'precommit';
+
+export interface ReviewLifecycleStorage {
+  db: Database.Database;
+  durability: StorageDurability;
+  warning: string | null;
+}
+
+export interface ReviewLifecycleOptions {
+  backend: ReviewBackend;
+  registry: SessionRegistry;
+  lookupSessionProvider?: SessionProviderLookup;
+  lookupResultSession?: SessionProviderLookup;
+  storage?: ReviewLifecycleStorage;
+  recordOutcome?: (db: Database.Database, input: RecordReviewOutcomeInput) => Promise<Result<void>>;
+  onOutcomePersistenceFailure?: (sessionId: string) => void;
+  onOutcomePersisted?: (sessionId: string) => void;
+}
+
+export interface ReviewLifecycle {
+  reviewPlan(input: PlanReviewInput): Promise<Result<PlanReviewResult>>;
+  reviewCode(input: CodeReviewInput): Promise<Result<CodeReviewResult>>;
+  reviewPrecommit(input: PrecommitReviewInput): Promise<Result<PrecommitResult>>;
+}
+
+const MEMORY_ONLY_WARNING =
+  'Durable review history is unavailable; session state is being kept in memory only.';
+const OUTCOME_WRITE_WARNING =
+  'Review succeeded, but its history could not be saved durably; session routing is memory-only.';
+const UNEXPECTED_REVIEW_ERROR = `${ErrorCode.UNKNOWN_ERROR}: review failed unexpectedly`;
+
+function notRecorded<R extends ReviewResult>(result: R): R {
+  return {
+    ...result,
+    models: result.models ?? [],
+    provenance: { persistence: 'not_recorded', warning: null },
+  };
+}
+
+function lookupOwner(
+  sessionId: string | undefined,
+  lookup: SessionProviderLookup | undefined,
+  providers: readonly ReviewProvider[],
+): Result<ReviewProvider | null> {
+  if (!sessionId || !lookup) return ok(null);
+  let found: SessionProviderLookupResult;
+  try {
+    found = lookup(sessionId);
+  } catch {
+    found = { status: 'unavailable' };
+  }
+  if (found.status === 'unavailable') {
+    return err(
+      `${ErrorCode.SESSION_ROUTING_UNAVAILABLE}: session ownership could not be established safely`,
+    );
+  }
+  const owner = found.status === 'found' ? found.value : null;
+  if (owner && !providers.includes(owner)) {
+    return err(
+      `${ErrorCode.PROVIDER_MISMATCH}: the session belongs to a provider that is not active`,
+    );
+  }
+  return ok(owner);
+}
+
+function reviewSnapshot(
+  type: ReviewType,
+  result: ReviewResult,
+): RecordReviewOutcomeInput['review'] {
+  if (type === 'precommit') {
+    const precommit = result as PrecommitResult;
+    return {
+      session_id: precommit.session_id,
+      type,
+      verdict: precommit.ready_to_commit ? 'approve' : 'reject',
+      summary: precommit.warnings.join('; ') || precommit.blockers.join('; ') || 'Clean',
+      findings_json: JSON.stringify(precommit.blockers),
+      models: precommit.models ?? [],
+    };
+  }
+  const review = result as PlanReviewResult | CodeReviewResult;
+  return {
+    session_id: review.session_id,
+    type,
+    verdict: review.verdict,
+    summary: review.summary,
+    findings_json: JSON.stringify(review.findings),
+    models: review.models ?? [],
+  };
+}
+
+function ownerModel(result: ReviewResult, provider: ReviewProvider): ModelIdentity | null {
+  return (
+    (result.models ?? []).find(
+      (identity) => identity.provider === provider && identity.role === 'review',
+    ) ?? null
+  );
+}
+
+const ROUTING_UNAVAILABLE_MESSAGE = `${ErrorCode.SESSION_ROUTING_UNAVAILABLE}: session ownership could not be established safely`;
+
+function ensureFreshResultSession(
+  inputSessionId: string | undefined,
+  resultSessionId: string,
+  registry: SessionRegistry,
+  lookup: SessionProviderLookup | undefined,
+  storage: ReviewLifecycleStorage | undefined,
+): Result<void> {
+  if (inputSessionId === resultSessionId) return ok(undefined);
+  if (registry.getStatus(resultSessionId)) return err(ROUTING_UNAVAILABLE_MESSAGE);
+
+  // The fallback database is intentionally hidden behind an unavailable
+  // routing lookup: its process registry is the ownership source of truth.
+  if (!storage || storage.durability === 'memory_only') return ok(undefined);
+  if (!lookup) return err(ROUTING_UNAVAILABLE_MESSAGE);
+
+  try {
+    return lookup(resultSessionId).status === 'absent'
+      ? ok(undefined)
+      : err(ROUTING_UNAVAILABLE_MESSAGE);
+  } catch {
+    return err(ROUTING_UNAVAILABLE_MESSAGE);
+  }
+}
+
+export function createReviewLifecycle(options: ReviewLifecycleOptions): ReviewLifecycle {
+  const { backend, registry, lookupSessionProvider, storage } = options;
+  const lookupResultSession = options.lookupResultSession ?? lookupSessionProvider;
+  const writeOutcome = options.recordOutcome ?? recordReviewOutcomeWithRetry;
+
+  interface PreparedReview {
+    owner: ReviewProvider | null;
+    servingProvider: ReviewProvider;
+    release: () => void;
+    discardAfterRelease: Set<string>;
+  }
+
+  interface NormalizedReview<R extends ReviewResult> {
+    result: R;
+    resultProvider: ReviewProvider;
+    identity: ModelIdentity | null;
+  }
+
+  function prepareReviewAdmission<I extends ReviewInput>(input: I): Result<PreparedReview> {
+    const owner = lookupOwner(input.session_id, lookupSessionProvider, backend.providers);
+    if (!owner.ok) return err(owner.error);
+
+    const servingProvider = owner.data ?? backend.provider;
+    if (input.session_id && input.model && !canOverrideModelOnResume(backend, servingProvider)) {
+      return err(sessionModelConflictMessage());
+    }
+
+    const admission = registry.admit(
+      input.session_id,
+      input.session_id ? servingProvider : undefined,
+    );
+    if (!admission.ok) return err(admission.error);
+    return ok({
+      owner: owner.data,
+      servingProvider,
+      release: admission.data.release,
+      discardAfterRelease: new Set<string>(),
+    });
+  }
+
+  function normalizeProviderSuccess<I extends ReviewInput, R extends ReviewResult>(
+    input: I,
+    providerData: R,
+    prepared: PreparedReview,
+  ): Result<NormalizedReview<R>> {
+    const result = { ...providerData, models: providerData.models ?? [] } as R;
+    const retainedOwner =
+      input.session_id === result.session_id && prepared.owner ? prepared.owner : null;
+    const resultProvider = retainedOwner ?? result.provider ?? backend.provider;
+    const identity = ownerModel(result, resultProvider);
+    const freshResult = ensureFreshResultSession(
+      input.session_id,
+      result.session_id,
+      registry,
+      lookupResultSession,
+      storage,
+    );
+    if (!freshResult.ok) {
+      registry.fail(input.session_id);
+      return err(freshResult.error);
+    }
+
+    // Memory state is authoritative for the live process and must update
+    // before persistence so a storage failure cannot erase a successful turn.
+    registry.complete(input.session_id, result.session_id, resultProvider, identity);
+    return ok({ result, resultProvider, identity });
+  }
+
+  async function persistOutcomeAndBuildProvenance<R extends ReviewResult>(
+    type: ReviewType,
+    input: ReviewInput,
+    normalized: NormalizedReview<R>,
+    prepared: PreparedReview,
+  ): Promise<Result<ReviewProvenance>> {
+    if (!storage) return ok({ persistence: 'not_recorded', warning: null });
+
+    let outcome: Result<void>;
+    try {
+      outcome = await writeOutcome(storage.db, {
+        preflightSessionId: input.session_id,
+        preflightProvider: input.session_id ? prepared.servingProvider : undefined,
+        resultSessionId: normalized.result.session_id,
+        servingProvider: normalized.resultProvider,
+        ownerModelIdentity: normalized.identity,
+        review: reviewSnapshot(type, normalized.result),
+      });
+    } catch {
+      outcome = err(`${ErrorCode.STORAGE_ERROR}: review outcome writer failed`);
+    }
+
+    if (!outcome.ok) {
+      if (outcome.error.startsWith(`${ErrorCode.SESSION_ROUTING_UNAVAILABLE}:`)) {
+        prepared.discardAfterRelease.add(normalized.result.session_id);
+        if (input.session_id) prepared.discardAfterRelease.add(input.session_id);
+        return err(ROUTING_UNAVAILABLE_MESSAGE);
+      }
+      try {
+        options.onOutcomePersistenceFailure?.(normalized.result.session_id);
+      } catch {
+        // Routing degradation is best-effort defensive state. A callback
+        // bug must not erase the already successful provider response.
+      }
+      console.error(
+        '[codex-bridge] review history persistence failed; continuing with memory-only session state',
+      );
+      return ok({ persistence: 'memory_only', warning: OUTCOME_WRITE_WARNING });
+    }
+
+    for (const persistedSessionId of new Set(
+      [input.session_id, normalized.result.session_id].filter(
+        (sessionId): sessionId is string => sessionId !== undefined,
+      ),
+    )) {
+      try {
+        options.onOutcomePersisted?.(persistedSessionId);
+      } catch {
+        // Persistence already succeeded; defensive routing cleanup cannot
+        // change the successful review response.
+      }
+    }
+    return storage.durability === 'memory_only'
+      ? ok({
+          persistence: 'memory_only',
+          warning: storage.warning === null ? null : MEMORY_ONLY_WARNING,
+        })
+      : ok({ persistence: 'durable', warning: null });
+  }
+
+  function releaseOrDiscardRoutingState(prepared: PreparedReview): void {
+    prepared.release();
+    for (const sessionId of prepared.discardAfterRelease) registry.discard(sessionId);
+  }
+
+  function unexpectedFailure<R extends ReviewResult>(sessionId?: string): Result<R> {
+    registry.fail(sessionId);
+    console.error('[codex-bridge] review failed unexpectedly');
+    return err<R>(UNEXPECTED_REVIEW_ERROR);
+  }
+
+  async function execute<I extends ReviewInput, R extends ReviewResult>(
+    type: ReviewType,
+    input: I,
+    invoke: () => Promise<Result<R>>,
+  ): Promise<Result<R>> {
+    // Empty inputs are provider-free synthetic results. Resolve them before
+    // ownership lookup, admission, or any session-state mutation.
+    if ('diff' in input && input.diff.trim().length === 0) {
+      try {
+        const synthetic = await invoke();
+        return synthetic.ok ? ok(notRecorded(synthetic.data)) : synthetic;
+      } catch {
+        return unexpectedFailure<R>();
+      }
+    }
+
+    const preparation = prepareReviewAdmission(input);
+    if (!preparation.ok) return err<R>(preparation.error);
+    const prepared = preparation.data;
+
+    try {
+      const providerResult = await invoke();
+      if (!providerResult.ok) {
+        registry.fail(input.session_id, providerResult.session_id);
+        return providerResult;
+      }
+
+      const normalized = normalizeProviderSuccess(input, providerResult.data, prepared);
+      if (!normalized.ok) return err<R>(normalized.error);
+      const provenance = await persistOutcomeAndBuildProvenance(
+        type,
+        input,
+        normalized.data,
+        prepared,
+      );
+      if (!provenance.ok) return err<R>(provenance.error);
+      return ok({ ...normalized.data.result, provenance: provenance.data });
+    } catch {
+      return unexpectedFailure<R>(input.session_id);
+    } finally {
+      releaseOrDiscardRoutingState(prepared);
+    }
+  }
+
+  return {
+    reviewPlan: (input) => execute('plan', input, () => backend.reviewPlan(input)),
+    reviewCode: (input) => execute('code', input, () => backend.reviewCode(input)),
+    reviewPrecommit: (input) => execute('precommit', input, () => backend.reviewPrecommit(input)),
+  };
+}

--- a/src/review/types.test.ts
+++ b/src/review/types.test.ts
@@ -9,9 +9,27 @@ import {
   PlanReviewResultSchema,
   CodeReviewResultSchema,
   PrecommitResultSchema,
+  CrossReviewResponseSchema,
+  CrossReviewResultSchema,
   ReviewStatusSchema,
   ReviewHistoryEntrySchema,
+  ModelIdentitySchema,
+  ReviewProvenanceSchema,
 } from './types.js';
+
+const validModelIdentity = {
+  provider: 'codex',
+  role: 'review',
+  requested: null,
+  resolved: 'gpt-5.6-sol',
+  observed: 'gpt-5.6-sol',
+  evidence: 'runtime_session_record',
+} as const;
+
+const validProvenance = {
+  persistence: 'durable',
+  warning: null,
+} as const;
 
 describe('PlanFindingSeveritySchema', () => {
   it('accepts plan-specific severities', () => {
@@ -186,9 +204,9 @@ describe('ReviewFindingSchema', () => {
   it('fails when required fields are missing', () => {
     expect(ReviewFindingSchema.safeParse({}).success).toBe(false);
     expect(ReviewFindingSchema.safeParse({ severity: 'critical' }).success).toBe(false);
-    expect(
-      ReviewFindingSchema.safeParse({ severity: 'critical', category: 'bug' }).success,
-    ).toBe(false);
+    expect(ReviewFindingSchema.safeParse({ severity: 'critical', category: 'bug' }).success).toBe(
+      false,
+    );
   });
 
   it('fails with invalid severity', () => {
@@ -201,7 +219,13 @@ describe('ReviewFindingSchema', () => {
   });
 
   it('accepts both suggestion and nitpick severities', () => {
-    const base = { category: 'test', description: 'test', file: null, line: null, suggestion: null };
+    const base = {
+      category: 'test',
+      description: 'test',
+      file: null,
+      line: null,
+      suggestion: null,
+    };
     expect(ReviewFindingSchema.safeParse({ ...base, severity: 'suggestion' }).success).toBe(true);
     expect(ReviewFindingSchema.safeParse({ ...base, severity: 'nitpick' }).success).toBe(true);
   });
@@ -236,7 +260,14 @@ describe('PlanReviewResultSchema', () => {
     verdict: 'approve',
     summary: 'Plan looks solid',
     findings: [
-      { severity: 'minor', category: 'style', description: 'Consider renaming', file: null, line: null, suggestion: null },
+      {
+        severity: 'minor',
+        category: 'style',
+        description: 'Consider renaming',
+        file: null,
+        line: null,
+        suggestion: null,
+      },
     ],
     session_id: 'sess_abc123',
   };
@@ -270,6 +301,19 @@ describe('PlanReviewResultSchema', () => {
     const result = PlanReviewResultSchema.safeParse({ ...validPlanResult, findings: [] });
     expect(result.success).toBe(true);
   });
+
+  it('accepts additive model identity and persistence provenance', () => {
+    const result = PlanReviewResultSchema.safeParse({
+      ...validPlanResult,
+      models: [validModelIdentity],
+      provenance: validProvenance,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.models).toEqual([validModelIdentity]);
+      expect(result.data.provenance).toEqual(validProvenance);
+    }
+  });
 });
 
 describe('CodeReviewResultSchema', () => {
@@ -277,7 +321,14 @@ describe('CodeReviewResultSchema', () => {
     verdict: 'request_changes',
     summary: 'Several issues found',
     findings: [
-      { severity: 'critical', category: 'bug', description: 'Null pointer dereference', file: null, line: null, suggestion: null },
+      {
+        severity: 'critical',
+        category: 'bug',
+        description: 'Null pointer dereference',
+        file: null,
+        line: null,
+        suggestion: null,
+      },
     ],
     session_id: 'sess_def456',
   };
@@ -327,9 +378,13 @@ describe('CodeReviewResultSchema', () => {
   // T-028: additive visibility fields.
   it('accepts review_mode on the result', () => {
     for (const mode of ['single', 'failover', 'deliberate', 'deliberate-deep']) {
-      expect(CodeReviewResultSchema.safeParse({ ...validCodeResult, review_mode: mode }).success).toBe(true);
+      expect(
+        CodeReviewResultSchema.safeParse({ ...validCodeResult, review_mode: mode }).success,
+      ).toBe(true);
     }
-    expect(CodeReviewResultSchema.safeParse({ ...validCodeResult, review_mode: 'bogus' }).success).toBe(false);
+    expect(
+      CodeReviewResultSchema.safeParse({ ...validCodeResult, review_mode: 'bogus' }).success,
+    ).toBe(false);
   });
 
   it('accepts a deliberation block with agreement:degraded, per-verdict chunks, and cross_review_failures', () => {
@@ -349,6 +404,25 @@ describe('CodeReviewResultSchema', () => {
       },
     };
     const result = CodeReviewResultSchema.safeParse(withDeliberation);
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts multiple reviewer and adjudicator model identities', () => {
+    const result = CodeReviewResultSchema.safeParse({
+      ...validCodeResult,
+      models: [
+        validModelIdentity,
+        {
+          provider: 'gemini',
+          role: 'adjudication',
+          requested: 'latest',
+          resolved: 'Gemini 3.5 Flash (High)',
+          observed: null,
+          evidence: 'bridge_selection',
+        },
+      ],
+      provenance: { persistence: 'memory_only', warning: 'History was not saved.' },
+    });
     expect(result.success).toBe(true);
   });
 });
@@ -382,9 +456,103 @@ describe('PrecommitResultSchema', () => {
 
   it('rejects missing required fields', () => {
     expect(PrecommitResultSchema.safeParse({}).success).toBe(false);
+    expect(PrecommitResultSchema.safeParse({ ready_to_commit: true }).success).toBe(false);
+  });
+
+  it('accepts empty model metadata for a synthetic result', () => {
+    const result = PrecommitResultSchema.safeParse({
+      ...validPrecommit,
+      models: [],
+      provenance: { persistence: 'not_recorded', warning: null },
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('model metadata schemas', () => {
+  it('accepts every supported identity role and evidence source', () => {
+    expect(ModelIdentitySchema.safeParse(validModelIdentity).success).toBe(true);
     expect(
-      PrecommitResultSchema.safeParse({ ready_to_commit: true }).success,
+      ModelIdentitySchema.safeParse({
+        ...validModelIdentity,
+        provider: 'gemini',
+        role: 'adjudication',
+        requested: 'latest',
+        observed: null,
+        evidence: 'bridge_selection',
+      }).success,
+    ).toBe(true);
+    expect(
+      ModelIdentitySchema.safeParse({
+        ...validModelIdentity,
+        requested: null,
+        resolved: null,
+        observed: null,
+        evidence: 'unavailable',
+      }).success,
+    ).toBe(true);
+  });
+
+  it('rejects unsupported providers, roles, and evidence sources', () => {
+    expect(
+      ModelIdentitySchema.safeParse({ ...validModelIdentity, provider: 'other' }).success,
     ).toBe(false);
+    expect(ModelIdentitySchema.safeParse({ ...validModelIdentity, role: 'fallback' }).success).toBe(
+      false,
+    );
+    expect(
+      ModelIdentitySchema.safeParse({ ...validModelIdentity, evidence: 'model_claim' }).success,
+    ).toBe(false);
+  });
+
+  it('rejects control characters and overlong model labels', () => {
+    expect(
+      ModelIdentitySchema.safeParse({ ...validModelIdentity, resolved: 'safe\nforged' }).success,
+    ).toBe(false);
+    expect(
+      ModelIdentitySchema.safeParse({
+        ...validModelIdentity,
+        observed: `safe${String.fromCharCode(0x85)}forged`,
+      }).success,
+    ).toBe(false);
+    expect(
+      ModelIdentitySchema.safeParse({ ...validModelIdentity, requested: 'x'.repeat(201) }).success,
+    ).toBe(false);
+  });
+
+  it('accepts every persistence status', () => {
+    for (const persistence of ['durable', 'memory_only', 'not_recorded']) {
+      expect(
+        ReviewProvenanceSchema.safeParse({
+          persistence,
+          warning: persistence === 'memory_only' ? 'DB unavailable' : null,
+        }).success,
+      ).toBe(true);
+    }
+  });
+});
+
+describe('cross-review response/result separation', () => {
+  const adjudications = [{ index: 0, verdict: 'confirmed', reason: 'The finding is valid.' }];
+
+  it('keeps host-only metadata out of the provider-facing response schema', () => {
+    expect(Object.keys(CrossReviewResponseSchema.shape)).toEqual(['adjudications']);
+    const parsed = CrossReviewResponseSchema.parse({
+      adjudications,
+      models: [validModelIdentity],
+      provenance: validProvenance,
+    });
+    expect(parsed).toEqual({ adjudications });
+  });
+
+  it('accepts host-enriched cross-review results', () => {
+    const parsed = CrossReviewResultSchema.parse({
+      adjudications,
+      models: [{ ...validModelIdentity, role: 'adjudication' }],
+      provenance: validProvenance,
+    });
+    expect(parsed.models).toHaveLength(1);
+    expect(parsed.provenance).toEqual(validProvenance);
   });
 });
 
@@ -431,6 +599,8 @@ describe('ReviewHistoryEntrySchema', () => {
     timestamp: '2026-02-18T10:00:00Z',
     summary: 'Plan approved',
     provider: 'codex',
+    models: [validModelIdentity],
+    model_metadata_status: 'recorded',
   };
 
   it('parses a valid history entry', () => {
@@ -449,6 +619,33 @@ describe('ReviewHistoryEntrySchema', () => {
     if (result.success) {
       expect(result.data.provider).toBeNull();
     }
+  });
+
+  it('accepts explicit legacy and invalid model metadata states', () => {
+    for (const model_metadata_status of ['legacy_unrecorded', 'invalid']) {
+      const result = ReviewHistoryEntrySchema.safeParse({
+        ...validEntry,
+        models: null,
+        model_metadata_status,
+      });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  it('rejects inconsistent history metadata states', () => {
+    expect(
+      ReviewHistoryEntrySchema.safeParse({
+        ...validEntry,
+        models: null,
+        model_metadata_status: 'recorded',
+      }).success,
+    ).toBe(false);
+    expect(
+      ReviewHistoryEntrySchema.safeParse({
+        ...validEntry,
+        model_metadata_status: 'legacy_unrecorded',
+      }).success,
+    ).toBe(false);
   });
 
   it('rejects a missing provider key', () => {

--- a/src/review/types.ts
+++ b/src/review/types.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { ModelSelectorSchema, SessionIdSchema } from '../utils/input-validation.js';
 
 // Separate severity enums: plan uses 'suggestion', code uses 'nitpick'
 export const PlanFindingSeveritySchema = z.enum(['critical', 'major', 'minor', 'suggestion']);
@@ -16,14 +17,11 @@ const BaseFindingFields = {
   category: z.string(),
   description: z.string(),
   file: z.string().nullable(),
-  line: z.preprocess(
-    v => {
-      if (v === '' || v === null || v === undefined) return null;
-      if (typeof v === 'string' || typeof v === 'number') return v;
-      return null;
-    },
-    z.coerce.number().int().positive().nullable(),
-  ),
+  line: z.preprocess((v) => {
+    if (v === '' || v === null || v === undefined) return null;
+    if (typeof v === 'string' || typeof v === 'number') return v;
+    return null;
+  }, z.coerce.number().int().positive().nullable()),
   suggestion: z.string().nullable(),
 };
 
@@ -46,8 +44,30 @@ export const ReviewFindingSchema = z.object({
 // The backend that actually produced this result. Set by each backend on its
 // own results; under provider failover it reflects the provider that served the
 // review (which may differ from the configured primary). Optional/additive.
-const ReviewProviderEnum = z.enum(['codex', 'gemini']);
+export const ReviewProviderSchema = z.enum(['codex', 'gemini']);
+const ReviewProviderEnum = ReviewProviderSchema;
 const ServingProviderSchema = ReviewProviderEnum.optional();
+
+export const ModelIdentitySchema = z.object({
+  provider: ReviewProviderSchema,
+  role: z.enum(['review', 'adjudication']),
+  requested: ModelSelectorSchema.nullable(),
+  resolved: ModelSelectorSchema.nullable(),
+  observed: ModelSelectorSchema.nullable(),
+  evidence: z.enum(['runtime_session_record', 'bridge_selection', 'unavailable']),
+});
+
+export const ReviewProvenanceSchema = z.object({
+  persistence: z.enum(['durable', 'memory_only', 'not_recorded']),
+  warning: z.string().nullable(),
+});
+
+const HostReviewMetadataFields = {
+  // Additive for backward-compatible decoding. New successful bridge responses
+  // always emit both fields; model-facing schemas must explicitly omit them.
+  models: z.array(ModelIdentitySchema).optional(),
+  provenance: ReviewProvenanceSchema.optional(),
+};
 
 // Deliberation metadata: when both providers review the same input, the bridge
 // reports each provider's verdict and splits findings into those BOTH flagged
@@ -102,44 +122,45 @@ function deliberationSchema<F extends z.ZodTypeAny>(findingSchema: F) {
 // never set it; the composite and the single-mode decorator stamp it so the
 // caller can tell single/failover/deliberate apart even when no deliberation
 // block is present.
-const ReviewModeSchema = z
-  .enum(['single', 'failover', 'deliberate', 'deliberate-deep'])
-  .optional();
+const ReviewModeSchema = z.enum(['single', 'failover', 'deliberate', 'deliberate-deep']).optional();
 
 export const PlanReviewResultSchema = z.object({
   verdict: z.enum(['approve', 'revise', 'reject']),
   summary: z.string(),
   findings: z.array(PlanFindingSchema),
-  session_id: z.string(),
+  session_id: SessionIdSchema,
   provider: ServingProviderSchema,
   review_mode: ReviewModeSchema,
   deliberation: deliberationSchema(PlanFindingSchema),
+  ...HostReviewMetadataFields,
 });
 
 export const CodeReviewResultSchema = z.object({
   verdict: z.enum(['approve', 'request_changes', 'reject']),
   summary: z.string(),
   findings: z.array(CodeFindingSchema),
-  session_id: z.string(),
+  session_id: SessionIdSchema,
   chunks_reviewed: z.number().int().positive().optional(),
   provider: ServingProviderSchema,
   review_mode: ReviewModeSchema,
   deliberation: deliberationSchema(CodeFindingSchema),
+  ...HostReviewMetadataFields,
 });
 
 export const PrecommitResultSchema = z.object({
   ready_to_commit: z.boolean(),
   blockers: z.array(z.string()),
   warnings: z.array(z.string()),
-  session_id: z.string(),
+  session_id: SessionIdSchema,
   chunks_reviewed: z.number().int().positive().optional(),
   provider: ServingProviderSchema,
   review_mode: ReviewModeSchema,
+  ...HostReviewMetadataFields,
 });
 
 // Cross-review (deliberate-deep): a provider's adjudication of another reviewer's
 // findings. `index` refers to the position of the finding in the input list.
-export const CrossReviewResultSchema = z.object({
+export const CrossReviewResponseSchema = z.object({
   adjudications: z.array(
     z.object({
       index: z.number().int(),
@@ -149,17 +170,21 @@ export const CrossReviewResultSchema = z.object({
   ),
 });
 
+export const CrossReviewResultSchema = CrossReviewResponseSchema.extend({
+  ...HostReviewMetadataFields,
+});
+
 export const ReviewStatusSchema = z.object({
   status: z.enum(['in_progress', 'completed', 'failed', 'not_found']),
-  session_id: z.string(),
+  session_id: SessionIdSchema,
   progress: z.string().optional(),
   elapsed_seconds: z.number().optional(),
 });
 
 export const VerdictSchema = z.enum(['approve', 'revise', 'reject', 'request_changes']);
 
-export const ReviewHistoryEntrySchema = z.object({
-  session_id: z.string(),
+const ReviewHistoryEntryBaseSchema = z.object({
+  session_id: SessionIdSchema,
   type: z.enum(['plan', 'code', 'precommit']),
   verdict: VerdictSchema,
   timestamp: z.string(),
@@ -169,6 +194,21 @@ export const ReviewHistoryEntrySchema = z.object({
   provider: z.string().nullable(),
 });
 
+export const ReviewHistoryEntrySchema = z.discriminatedUnion('model_metadata_status', [
+  ReviewHistoryEntryBaseSchema.extend({
+    models: z.array(ModelIdentitySchema),
+    model_metadata_status: z.literal('recorded'),
+  }),
+  ReviewHistoryEntryBaseSchema.extend({
+    models: z.null(),
+    model_metadata_status: z.literal('legacy_unrecorded'),
+  }),
+  ReviewHistoryEntryBaseSchema.extend({
+    models: z.null(),
+    model_metadata_status: z.literal('invalid'),
+  }),
+]);
+
 // Inferred types for use across the codebase
 export type PlanFindingSeverity = z.infer<typeof PlanFindingSeveritySchema>;
 export type CodeFindingSeverity = z.infer<typeof CodeFindingSeveritySchema>;
@@ -176,9 +216,13 @@ export type FindingSeverity = z.infer<typeof FindingSeveritySchema>;
 export type PlanFinding = z.infer<typeof PlanFindingSchema>;
 export type CodeFinding = z.infer<typeof CodeFindingSchema>;
 export type ReviewFinding = z.infer<typeof ReviewFindingSchema>;
+export type ReviewProvider = z.infer<typeof ReviewProviderSchema>;
+export type ModelIdentity = z.infer<typeof ModelIdentitySchema>;
+export type ReviewProvenance = z.infer<typeof ReviewProvenanceSchema>;
 export type PlanReviewResult = z.infer<typeof PlanReviewResultSchema>;
 export type CodeReviewResult = z.infer<typeof CodeReviewResultSchema>;
 export type PrecommitResult = z.infer<typeof PrecommitResultSchema>;
+export type CrossReviewResponse = z.infer<typeof CrossReviewResponseSchema>;
 export type CrossReviewResult = z.infer<typeof CrossReviewResultSchema>;
 export type ReviewStatus = z.infer<typeof ReviewStatusSchema>;
 export type Verdict = z.infer<typeof VerdictSchema>;

--- a/src/server.integration.test.ts
+++ b/src/server.integration.test.ts
@@ -48,13 +48,31 @@ import { getStagedDiff } from './utils/git.js';
 const validPlanResponse = {
   verdict: 'approve',
   summary: 'Plan looks solid',
-  findings: [{ severity: 'minor', category: 'style', description: 'Consider renaming', file: null, line: null, suggestion: null }],
+  findings: [
+    {
+      severity: 'minor',
+      category: 'style',
+      description: 'Consider renaming',
+      file: null,
+      line: null,
+      suggestion: null,
+    },
+  ],
 };
 
 const validCodeResponse = {
   verdict: 'request_changes',
   summary: 'Issues found',
-  findings: [{ severity: 'critical', category: 'bug', description: 'Null pointer', file: 'src/foo.ts', line: 42, suggestion: null }],
+  findings: [
+    {
+      severity: 'critical',
+      category: 'bug',
+      description: 'Null pointer',
+      file: 'src/foo.ts',
+      line: 42,
+      suggestion: null,
+    },
+  ],
 };
 
 const validPrecommitResponse = {
@@ -66,6 +84,7 @@ const validPrecommitResponse = {
 // --- Helpers ---
 let client: Client;
 const savedEnv: Record<string, string | undefined> = {};
+const temporaryDatabaseDirs: string[] = [];
 
 async function startServer(): Promise<Client> {
   // Dynamic import to get a fresh module with current mock state
@@ -112,6 +131,9 @@ afterEach(async () => {
   } else {
     process.env.REVIEW_BRIDGE_DB = savedEnv.REVIEW_BRIDGE_DB;
   }
+  await Promise.all(
+    temporaryDatabaseDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })),
+  );
 });
 
 describe('MCP integration — review_plan', () => {
@@ -119,13 +141,27 @@ describe('MCP integration — review_plan', () => {
     mockRun.mockResolvedValue({ finalResponse: JSON.stringify(validPlanResponse) });
     client = await startServer();
 
-    const result = await client.callTool({ name: 'review_plan', arguments: { plan: 'My implementation plan' } });
+    const result = await client.callTool({
+      name: 'review_plan',
+      arguments: { plan: 'My implementation plan' },
+    });
 
     const parsed = parseToolResult(result) as Record<string, unknown>;
     expect(parsed.verdict).toBe('approve');
     expect(parsed.summary).toBe('Plan looks solid');
     expect(parsed.findings).toHaveLength(1);
     expect(parsed.session_id).toBe('thread_integ_001');
+    expect(parsed.models).toEqual([
+      {
+        provider: 'codex',
+        role: 'review',
+        requested: null,
+        resolved: 'gpt-5.6-sol',
+        observed: null,
+        evidence: 'bridge_selection',
+      },
+    ]);
+    expect(parsed.provenance).toEqual({ persistence: 'memory_only', warning: null });
   });
 
   it('Codex SDK init failure returns MCP error without crashing server', async () => {
@@ -157,6 +193,8 @@ describe('MCP integration — review_code', () => {
     expect(finding.file).toBe('src/foo.ts');
     expect(finding.line).toBe(42);
     expect(parsed.session_id).toBe('thread_integ_001');
+    expect(parsed.models).toHaveLength(1);
+    expect(parsed.provenance).toEqual({ persistence: 'memory_only', warning: null });
   });
 
   it('session_id threads from review_plan to review_code', async () => {
@@ -165,7 +203,10 @@ describe('MCP integration — review_code', () => {
       .mockResolvedValueOnce({ finalResponse: JSON.stringify(validCodeResponse) });
     client = await startServer();
 
-    const planResult = await client.callTool({ name: 'review_plan', arguments: { plan: 'My plan' } });
+    const planResult = await client.callTool({
+      name: 'review_plan',
+      arguments: { plan: 'My plan' },
+    });
     const planParsed = parseToolResult(planResult) as Record<string, unknown>;
     const sessionId = planParsed.session_id as string;
 
@@ -190,6 +231,8 @@ describe('MCP integration — review_precommit', () => {
     const parsed = parseToolResult(result) as Record<string, unknown>;
     expect(parsed.ready_to_commit).toBe(true);
     expect(parsed.session_id).toBe('thread_integ_001');
+    expect(parsed.models).toHaveLength(1);
+    expect(parsed.provenance).toEqual({ persistence: 'memory_only', warning: null });
   });
 
   it('empty staged diff returns warning', async () => {
@@ -199,11 +242,32 @@ describe('MCP integration — review_precommit', () => {
     const result = await client.callTool({ name: 'review_precommit', arguments: {} });
 
     const parsed = parseToolResult(result) as Record<string, unknown>;
-    expect((parsed.warnings as string[])).toContain('No staged changes found');
+    expect(parsed.warnings as string[]).toContain('No staged changes found');
+    expect(parsed.models).toEqual([]);
+    expect(parsed.provenance).toEqual({ persistence: 'not_recorded', warning: null });
   });
 });
 
 describe('MCP integration — review_history', () => {
+  it('round-trips durable provenance and model metadata through a file-backed database', async () => {
+    const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'rb-durable-int-'));
+    temporaryDatabaseDirs.push(directory);
+    process.env.REVIEW_BRIDGE_DB = path.join(directory, 'reviews.db');
+    mockRun.mockResolvedValue({ finalResponse: JSON.stringify(validPlanResponse) });
+    client = await startServer();
+
+    const review = parseToolResult(
+      await client.callTool({ name: 'review_plan', arguments: { plan: 'Durable plan' } }),
+    ) as Record<string, unknown>;
+    const history = parseToolResult(
+      await client.callTool({ name: 'review_history', arguments: { last_n: 1 } }),
+    ) as { reviews: Array<Record<string, unknown>> };
+
+    expect(review.provenance).toEqual({ persistence: 'durable', warning: null });
+    expect(history.reviews[0].models).toEqual(review.models);
+    expect(history.reviews[0].model_metadata_status).toBe('recorded');
+  });
+
   it('returns saved reviews after review_plan completes', async () => {
     mockRun.mockResolvedValue({ finalResponse: JSON.stringify(validPlanResponse) });
     client = await startServer();
@@ -219,6 +283,53 @@ describe('MCP integration — review_history', () => {
     expect(parsed.reviews[0].type).toBe('plan');
     expect(parsed.reviews[0].verdict).toBe('approve');
     expect(parsed.reviews[0].session_id).toBe('thread_integ_001');
+    expect(parsed.reviews[0].model_metadata_status).toBe('recorded');
+    expect(parsed.reviews[0].models).toHaveLength(1);
+  });
+
+  it('round-trips identical model snapshots for plan, code, and precommit', async () => {
+    mockRun
+      .mockResolvedValueOnce({ finalResponse: JSON.stringify(validPlanResponse) })
+      .mockResolvedValueOnce({ finalResponse: JSON.stringify(validCodeResponse) })
+      .mockResolvedValueOnce({ finalResponse: JSON.stringify(validPrecommitResponse) });
+    client = await startServer();
+
+    const plan = parseToolResult(
+      await client.callTool({ name: 'review_plan', arguments: { plan: 'My plan' } }),
+    ) as Record<string, unknown>;
+    const code = parseToolResult(
+      await client.callTool({
+        name: 'review_code',
+        arguments: { diff: 'short diff', session_id: plan.session_id },
+      }),
+    ) as Record<string, unknown>;
+    const precommit = parseToolResult(
+      await client.callTool({
+        name: 'review_precommit',
+        arguments: {
+          diff: 'short staged diff',
+          auto_diff: false,
+          session_id: plan.session_id,
+        },
+      }),
+    ) as Record<string, unknown>;
+    const history = parseToolResult(
+      await client.callTool({
+        name: 'review_history',
+        arguments: { session_id: 'thread_integ_001' },
+      }),
+    ) as { reviews: Array<Record<string, unknown>>; next_cursor: string | null };
+
+    expect(history.reviews.map((review) => review.type)).toEqual(['plan', 'code', 'precommit']);
+    expect(history.reviews.map((review) => review.models)).toEqual([
+      plan.models,
+      code.models,
+      precommit.models,
+    ]);
+    expect(history.reviews.every((review) => review.model_metadata_status === 'recorded')).toBe(
+      true,
+    );
+    expect(history.next_cursor).toBeNull();
   });
 });
 
@@ -277,14 +388,15 @@ describe('MCP integration — session lifecycle', () => {
     expect(parsed1.elapsed_seconds).toBe(parsed2.elapsed_seconds);
   });
 
-  it('review_status shows failed after Codex error on resumed session', async () => {
+  it('rejects an unknown memory-only resume without inventing failed session state', async () => {
     mockRun.mockRejectedValue(new Error('network timeout'));
     client = await startServer();
 
-    await client.callTool({
+    const review = await client.callTool({
       name: 'review_plan',
       arguments: { plan: 'My plan', session_id: 'thread_integ_001' },
     });
+    expect(getErrorText(review)).toContain('SESSION_ROUTING_UNAVAILABLE');
 
     const result = await client.callTool({
       name: 'review_status',
@@ -292,7 +404,7 @@ describe('MCP integration — session lifecycle', () => {
     });
 
     const parsed = parseToolResult(result) as Record<string, unknown>;
-    expect(parsed.status).toBe('failed');
+    expect(parsed.status).toBe('not_found');
   });
 
   it('review_history accumulates across plan and code phases', async () => {
@@ -322,7 +434,10 @@ describe('MCP integration — session lifecycle', () => {
       .mockResolvedValueOnce({ finalResponse: JSON.stringify(validPlanResponse) });
     client = await startServer();
 
-    const failResult = await client.callTool({ name: 'review_plan', arguments: { plan: 'Plan A' } });
+    const failResult = await client.callTool({
+      name: 'review_plan',
+      arguments: { plan: 'Plan A' },
+    });
     const failText = getErrorText(failResult);
     expect(failText).toContain('transient failure');
 
@@ -342,7 +457,10 @@ describe('MCP integration — review_code multi-chunk session failure (T-001)', 
   // diffBudget=500 the chunker emits 2 pieces (one per file).
   function makeMultiChunkDiff(): string {
     const padLines = (prefix: string, count: number): string[] =>
-      Array.from({ length: count }, (_, i) => `${prefix}${i} padding-text-here-extra-words-for-volume`);
+      Array.from(
+        { length: count },
+        (_, i) => `${prefix}${i} padding-text-here-extra-words-for-volume`,
+      );
     const fileOne = [
       'diff --git a/a.ts b/a.ts',
       '--- a/a.ts',
@@ -365,7 +483,10 @@ describe('MCP integration — review_code multi-chunk session failure (T-001)', 
   beforeEach(async () => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'rb-int-'));
     configDir = dir;
-    await fs.writeFile(path.join(dir, '.reviewbridge.json'), JSON.stringify({ max_chunk_tokens: 2200 }));
+    await fs.writeFile(
+      path.join(dir, '.reviewbridge.json'),
+      JSON.stringify({ max_chunk_tokens: 2200 }),
+    );
     savedEnv.RB_CONFIG_PATH = process.env.RB_CONFIG_PATH;
     process.env.RB_CONFIG_PATH = path.join(dir, '.reviewbridge.json');
   });

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -19,6 +19,9 @@ vi.mock('@modelcontextprotocol/sdk/server/mcp.js', () => {
 
 vi.mock('./backends/index.js', () => ({
   createBackend: vi.fn(() => ({
+    provider: 'codex',
+    providers: ['codex'],
+    allowsModelOverrideOnResume: false,
     reviewPlan: vi.fn(),
     reviewCode: vi.fn(),
     reviewPrecommit: vi.fn(),
@@ -45,7 +48,16 @@ vi.mock('better-sqlite3', () => {
       shouldThrow = false;
       throw new Error('SQLITE_CANTOPEN');
     }
-    return { exec: vi.fn(), prepare: vi.fn(), close: vi.fn(), pragma: vi.fn() };
+    return {
+      exec: vi.fn(),
+      prepare: vi.fn(),
+      close: vi.fn(),
+      pragma: vi.fn((query: string) => {
+        if (query === 'table_info(reviews)') return [{ name: 'models_json' }];
+        if (query === 'table_info(sessions)') return [{ name: 'model_identity_json' }];
+        return [];
+      }),
+    };
   });
   return { default: MockDatabase };
 });
@@ -94,9 +106,7 @@ describe('createServer', () => {
     const registerTool = (server as any).registerTool as ReturnType<typeof vi.fn>;
     expect(registerTool).toHaveBeenCalledTimes(5);
 
-    const toolNames = registerTool.mock.calls.map(
-      (call: unknown[]) => call[0] as string,
-    );
+    const toolNames = registerTool.mock.calls.map((call: unknown[]) => call[0] as string);
     expect(toolNames).toContain('review_plan');
     expect(toolNames).toContain('review_code');
     expect(toolNames).toContain('review_precommit');
@@ -105,7 +115,9 @@ describe('createServer', () => {
   });
 
   it('config error aborts startup', () => {
-    vi.mocked(loadConfig).mockReturnValue(err('CONFIG_ERROR: invalid JSON in /repo/.reviewbridge.json'));
+    vi.mocked(loadConfig).mockReturnValue(
+      err('CONFIG_ERROR: invalid JSON in /repo/.reviewbridge.json'),
+    );
 
     expect(() => createServer()).toThrow(/CONFIG_ERROR/);
   });
@@ -117,7 +129,9 @@ describe('createServer', () => {
   });
 
   it('table init failure logs warning but server still starts', () => {
-    vi.mocked(initDb).mockImplementationOnce(() => { throw new Error('SQLITE_READONLY'); });
+    vi.mocked(initDb).mockImplementationOnce(() => {
+      throw new Error('SQLITE_READONLY');
+    });
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     const server = createServer();
@@ -179,9 +193,9 @@ describe('createServer', () => {
   it('advertises the package.json version (no hardcoded drift)', async () => {
     const { readFileSync } = await import('node:fs');
     const expectedVersion = (
-      JSON.parse(
-        readFileSync(new URL('../package.json', import.meta.url), 'utf-8'),
-      ) as { version: string }
+      JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf-8')) as {
+        version: string;
+      }
     ).version;
 
     createServer();

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,12 +5,20 @@ import { loadConfig, formatConfigSource } from './config/loader.js';
 import { createBackend } from './backends/index.js';
 import { loadCopilotInstructions } from './config/copilot-instructions.js';
 import type { CopilotInstructions } from './config/copilot-instructions.js';
-import { openReviewDb, makeSessionProviderLookup } from './storage/db.js';
+import {
+  makeSessionModelLookup,
+  makeSessionProviderLookup,
+  openReviewDbWithMetadata,
+} from './storage/db.js';
+import { createSessionRegistry } from './storage/session-registry.js';
+import { createSessionRouting } from './storage/session-routing.js';
+import { createReviewLifecycle } from './review/lifecycle.js';
 import { registerReviewPlanTool } from './tools/review-plan.js';
 import { registerReviewCodeTool } from './tools/review-code.js';
 import { registerReviewPrecommitTool } from './tools/review-precommit.js';
 import { registerReviewHistoryTool } from './tools/review-history.js';
 import { registerReviewStatusTool } from './tools/review-status.js';
+import { escapeTerminalControls } from './utils/terminal.js';
 
 export const SERVER_INSTRUCTIONS = `codex-claude-bridge — automated code review.
 
@@ -50,6 +58,11 @@ TIPS:
 - Every result carries a 'review_mode' field (single/failover/deliberate/deliberate-deep) naming the
   composition that ran, so you can tell whether deliberation actually happened even without a
   'deliberation' block.
+- Every successful review also carries 'models' (successful reviewer/adjudicator contributions with
+  requested/resolved/observed identity evidence) and 'provenance' (durable, memory_only, or
+  not_recorded). Runtime labels are control-plane evidence, not proof of underlying weights.
+- review_history returns immutable model snapshots in bounded pages. Pass its next_cursor into the
+  next call to continue without overlap.
 - Under deliberate-deep, the top-level 'verdict' reflects both providers' INDEPENDENT reviews; the
   per-finding adjudications in deliberation.divergent[] are advisory for YOUR synthesis and are not
   folded back into the verdict. Weigh disputed findings yourself.`;
@@ -60,7 +73,9 @@ TIPS:
 // tsup-bundled dist, and npm-installed consumers — package.json is always
 // adjacent to the running file's parent dir.
 const PACKAGE_VERSION = (
-  JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf-8')) as { version: string }
+  JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf-8')) as {
+    version: string;
+  }
 ).version;
 
 export function createServer(): McpServer {
@@ -72,7 +87,9 @@ export function createServer(): McpServer {
     throw new Error(configResult.error);
   }
   const { config, source } = configResult.data;
-  console.error(`[codex-bridge] config source: ${formatConfigSource(source)}`);
+  console.error(
+    `[codex-bridge] config source: ${escapeTerminalControls(formatConfigSource(source))}`,
+  );
 
   let copilotInstr: CopilotInstructions | undefined;
   if (config.copilot_instructions) {
@@ -81,15 +98,33 @@ export function createServer(): McpServer {
     if (instrResult.ok) {
       copilotInstr = instrResult.data;
     } else {
-      console.error(`Copilot instructions load failed, skipping: ${instrResult.error}`);
+      console.error(
+        `Copilot instructions load failed, skipping: ${escapeTerminalControls(instrResult.error)}`,
+      );
     }
   }
 
   // Open the db before building the backend so resume routing can consult session
   // ownership. The read-write open always returns a usable db (in-memory on
   // failure); the tools and lookup accept an optional db regardless.
-  const db = openReviewDb();
-  const client = createBackend(config, copilotInstr, makeSessionProviderLookup(db));
+  const storage = openReviewDbWithMetadata();
+  const registry = createSessionRegistry();
+  const routing = createSessionRouting({
+    registry,
+    durability: storage.durability,
+    providerLookup: makeSessionProviderLookup(storage.db),
+    modelLookup: makeSessionModelLookup(storage.db),
+  });
+  const client = createBackend(config, copilotInstr, routing.lookupProvider, routing.lookupModel);
+  const lifecycle = createReviewLifecycle({
+    backend: client,
+    registry,
+    lookupSessionProvider: routing.lookupProvider,
+    lookupResultSession: routing.lookupResultSession,
+    storage,
+    onOutcomePersistenceFailure: routing.markOutcomePersistenceFailure,
+    onOutcomePersisted: routing.markOutcomePersisted,
+  });
 
   try {
     const server = new McpServer(
@@ -97,14 +132,17 @@ export function createServer(): McpServer {
       { instructions: SERVER_INSTRUCTIONS },
     );
 
-    registerReviewPlanTool(server, client, db);
-    registerReviewCodeTool(server, client, db);
-    registerReviewPrecommitTool(server, client, db, config);
-    registerReviewHistoryTool(server, db);
-    registerReviewStatusTool(server, db);
+    registerReviewPlanTool(server, client, storage.db, lifecycle);
+    registerReviewCodeTool(server, client, storage.db, lifecycle);
+    registerReviewPrecommitTool(server, client, storage.db, config, lifecycle);
+    registerReviewHistoryTool(server, storage.db);
+    registerReviewStatusTool(server, storage.db, registry);
 
     return server;
   } catch (e) {
-    throw new Error(`Failed to initialize MCP server: ${e instanceof Error ? e.message : String(e)}`, { cause: e });
+    throw new Error(
+      `Failed to initialize MCP server: ${e instanceof Error ? e.message : String(e)}`,
+      { cause: e },
+    );
   }
 }

--- a/src/storage/db-process-migration.test.ts
+++ b/src/storage/db-process-migration.test.ts
@@ -1,0 +1,230 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import Database from 'better-sqlite3';
+import { describe, expect, it } from 'vitest';
+
+const TEST_TIMEOUT_MS = 20_000;
+const BARRIER_TIMEOUT_MS = TEST_TIMEOUT_MS - 2_000;
+const migrationModuleUrl = new URL('./db.ts', import.meta.url).href;
+const MIGRATION_CHILD_SOURCE = `
+  import { openReviewDbWithMetadata } from ${JSON.stringify(migrationModuleUrl)};
+
+  const timeoutMs = Number(process.env.REVIEW_BRIDGE_MIGRATION_TIMEOUT_MS);
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    throw new Error('migration child timeout is not configured');
+  }
+  if (typeof process.send !== 'function') {
+    throw new Error('migration child IPC is not configured');
+  }
+
+  function signalReadyAndWaitForGo() {
+    return new Promise((resolve, reject) => {
+      let settled = false;
+      const cleanup = () => {
+        clearTimeout(timer);
+        process.off('message', onMessage);
+        process.off('disconnect', onDisconnect);
+      };
+      const finish = (error) => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        if (error) reject(error);
+        else resolve();
+      };
+      const onMessage = (message) => {
+        if (message && message.type === 'go') finish();
+      };
+      const onDisconnect = () => finish(new Error('migration parent disconnected'));
+      const timer = setTimeout(
+        () => finish(new Error('timed out waiting for migration IPC barrier')),
+        timeoutMs,
+      );
+
+      process.on('message', onMessage);
+      process.once('disconnect', onDisconnect);
+      process.send({ type: 'ready' }, (error) => {
+        if (error) finish(error);
+      });
+    });
+  }
+
+  try {
+    await signalReadyAndWaitForGo();
+    const opened = openReviewDbWithMetadata();
+    if (opened.durability !== 'durable' || opened.warning !== null) {
+      opened.db.close();
+      throw new Error('migration child did not open durable storage');
+    }
+    opened.db.close();
+  } finally {
+    if (process.connected) process.disconnect();
+  }
+`;
+
+interface ChildResult {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+interface ChildHandle {
+  child: ChildProcess;
+  ready: Promise<void>;
+  result: Promise<ChildResult>;
+}
+
+function startMigrationChild(databasePath: string): ChildHandle {
+  const child = spawn(
+    process.execPath,
+    ['--import', 'tsx', '--input-type=module', '--eval', MIGRATION_CHILD_SOURCE],
+    {
+      env: {
+        ...process.env,
+        REVIEW_BRIDGE_DB: databasePath,
+        REVIEW_BRIDGE_MIGRATION_TIMEOUT_MS: String(BARRIER_TIMEOUT_MS),
+      },
+      stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
+    },
+  );
+  let stdout = '';
+  let stderr = '';
+  child.stdout?.on('data', (chunk: Buffer) => {
+    stdout += chunk.toString();
+  });
+  child.stderr?.on('data', (chunk: Buffer) => {
+    stderr += chunk.toString();
+  });
+  child.on('error', (error) => {
+    stderr += `${error.message}\n`;
+  });
+
+  const result = new Promise<ChildResult>((resolve) => {
+    child.once('close', (code) => resolve({ code, stdout, stderr }));
+  });
+
+  const ready = new Promise<void>((resolve, reject) => {
+    const cleanup = (): void => {
+      clearTimeout(timer);
+      child.off('message', onMessage);
+      child.off('error', onError);
+      child.off('close', onClose);
+    };
+    const onMessage = (message: unknown): void => {
+      if (
+        typeof message === 'object' &&
+        message !== null &&
+        'type' in message &&
+        message.type === 'ready'
+      ) {
+        cleanup();
+        resolve();
+      }
+    };
+    const onError = (error: Error): void => {
+      cleanup();
+      reject(error);
+    };
+    const onClose = (code: number | null): void => {
+      cleanup();
+      reject(new Error(`migration child exited before readiness (code ${String(code)})`));
+    };
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error(`timed out after ${BARRIER_TIMEOUT_MS}ms waiting for child readiness`));
+    }, BARRIER_TIMEOUT_MS);
+
+    child.on('message', onMessage);
+    child.once('error', onError);
+    child.once('close', onClose);
+  });
+
+  return { child, ready, result };
+}
+
+function sendGo(handle: ChildHandle): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (!handle.child.connected) {
+      reject(new Error('migration child disconnected before barrier release'));
+      return;
+    }
+    handle.child.send({ type: 'go' }, (error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}
+
+async function stopChild(handle: ChildHandle): Promise<void> {
+  if (handle.child.exitCode === null && handle.child.signalCode === null) {
+    handle.child.kill();
+  }
+  const forceKill = setTimeout(() => {
+    if (handle.child.exitCode === null && handle.child.signalCode === null) {
+      handle.child.kill('SIGKILL');
+    }
+  }, 1_000);
+  forceKill.unref();
+  try {
+    await handle.result;
+  } finally {
+    clearTimeout(forceKill);
+  }
+}
+
+describe('two-process concurrent storage migration', () => {
+  it(
+    'atomically initializes one legacy database from two independent processes',
+    async () => {
+      const directory = await mkdtemp(join(tmpdir(), 'rb-two-process-migration-'));
+      const databasePath = join(directory, 'reviews.db');
+      const legacy = new Database(databasePath);
+      legacy.exec(`
+        CREATE TABLE sessions (
+          session_id TEXT PRIMARY KEY,
+          status TEXT NOT NULL DEFAULT 'in_progress',
+          created_at TEXT NOT NULL DEFAULT (datetime('now')),
+          completed_at TEXT,
+          provider TEXT
+        );
+        CREATE TABLE reviews (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          session_id TEXT NOT NULL,
+          type TEXT NOT NULL,
+          verdict TEXT NOT NULL,
+          summary TEXT NOT NULL,
+          findings_json TEXT NOT NULL,
+          timestamp TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+      `);
+      legacy.close();
+      const children = [startMigrationChild(databasePath), startMigrationChild(databasePath)];
+
+      try {
+        await Promise.all(children.map(({ ready }) => ready));
+        await Promise.all(children.map(sendGo));
+        const results = await Promise.all(children.map(({ result }) => result));
+
+        for (const result of results) {
+          expect(result.code, `${result.stdout}\n${result.stderr}`).toBe(0);
+        }
+
+        const db = new Database(databasePath, { readonly: true, fileMustExist: true });
+        try {
+          const sessionColumns = db.pragma('table_info(sessions)') as Array<{ name: string }>;
+          const reviewColumns = db.pragma('table_info(reviews)') as Array<{ name: string }>;
+          expect(sessionColumns.map((column) => column.name)).toContain('model_identity_json');
+          expect(reviewColumns.map((column) => column.name)).toContain('models_json');
+        } finally {
+          db.close();
+        }
+      } finally {
+        await Promise.all(children.map(stopChild));
+        await rm(directory, { recursive: true, force: true });
+      }
+    },
+    TEST_TIMEOUT_MS,
+  );
+});

--- a/src/storage/db.test.ts
+++ b/src/storage/db.test.ts
@@ -1,13 +1,23 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { isAbsolute, join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { rmSync } from 'node:fs';
-import { reviewDbPath, openReviewDb, makeSessionProviderLookup } from './db.js';
+import { mkdirSync, rmSync } from 'node:fs';
+import Database from 'better-sqlite3';
+import {
+  reviewDbPath,
+  openReviewDb,
+  openReviewDbWithMetadata,
+  initializeStorageSchema,
+  makeSessionModelLookup,
+  makeSessionProviderLookup,
+} from './db.js';
 import { getOrCreateSession } from './sessions.js';
 
 describe('reviewDbPath', () => {
   let saved: string | undefined;
-  beforeEach(() => { saved = process.env.REVIEW_BRIDGE_DB; });
+  beforeEach(() => {
+    saved = process.env.REVIEW_BRIDGE_DB;
+  });
   afterEach(() => {
     if (saved === undefined) delete process.env.REVIEW_BRIDGE_DB;
     else process.env.REVIEW_BRIDGE_DB = saved;
@@ -41,7 +51,11 @@ describe('openReviewDb', () => {
     if (saved === undefined) delete process.env.REVIEW_BRIDGE_DB;
     else process.env.REVIEW_BRIDGE_DB = saved;
     for (const suffix of ['', '-wal', '-shm']) {
-      try { rmSync(dbPath + suffix); } catch { /* ignore */ }
+      try {
+        rmSync(dbPath + suffix, { recursive: true, force: true });
+      } catch {
+        /* ignore */
+      }
     }
   });
 
@@ -66,13 +80,407 @@ describe('openReviewDb', () => {
 
     const ro = openReviewDb({ readonly: true });
     expect(ro).toBeDefined();
-    expect(makeSessionProviderLookup(ro)('s2')).toBe('gemini');
+    expect(makeSessionProviderLookup(ro)('s2')).toEqual({ status: 'found', value: 'gemini' });
     ro?.close();
+  });
+
+  it('returns durable metadata for a successfully initialized persistent db', () => {
+    const opened = openReviewDbWithMetadata();
+    expect(opened.durability).toBe('durable');
+    expect(opened.warning).toBeNull();
+    expect(opened.db.pragma('busy_timeout', { simple: true })).toBe(100);
+    opened.db.close();
+  });
+
+  it('marks an intentional in-memory db as memory_only and fully initializes it', () => {
+    process.env.REVIEW_BRIDGE_DB = ':memory:';
+    const opened = openReviewDbWithMetadata();
+
+    expect(opened.durability).toBe('memory_only');
+    expect(opened.db.pragma('busy_timeout', { simple: true })).toBe(100);
+    expect(
+      opened.db
+        .prepare(
+          "SELECT name FROM sqlite_master WHERE type = 'table' AND name IN ('sessions', 'reviews')",
+        )
+        .all(),
+    ).toHaveLength(2);
+    opened.db.close();
+  });
+
+  it('closes a persistent db whose schema init fails and returns a fully initialized memory db', () => {
+    const broken = new Database(dbPath);
+    broken.exec('CREATE VIEW sessions AS SELECT 1 AS session_id');
+    broken.close();
+
+    const opened = openReviewDbWithMetadata();
+
+    expect(opened.durability).toBe('memory_only');
+    expect(opened.warning).toContain('initialization failed');
+    const sessionsColumns = opened.db.pragma('table_info(sessions)') as Array<{ name: string }>;
+    const reviewsColumns = opened.db.pragma('table_info(reviews)') as Array<{ name: string }>;
+    expect(sessionsColumns.map((column) => column.name)).toContain('model_identity_json');
+    expect(reviewsColumns.map((column) => column.name)).toContain('models_json');
+    opened.db.close();
+
+    // The failed persistent handle was closed, so another connection can take
+    // an exclusive transaction immediately.
+    const reopened = new Database(dbPath, { timeout: 100 });
+    expect(() => reopened.exec('BEGIN EXCLUSIVE; ROLLBACK')).not.toThrow();
+    reopened.close();
+  });
+
+  it('falls back to initialized memory with metadata when the persistent file cannot open', () => {
+    mkdirSync(dbPath);
+
+    const opened = openReviewDbWithMetadata();
+
+    expect(opened.durability).toBe('memory_only');
+    expect(opened.warning).toContain('open failed');
+    expect(opened.db.pragma('table_info(sessions)')).not.toEqual([]);
+    expect(opened.db.pragma('table_info(reviews)')).not.toEqual([]);
+    opened.db.close();
+  });
+
+  it('best-effort closes a persistent handle when startup configuration throws', () => {
+    const close = vi.fn(() => {
+      throw new Error('injected close failure');
+    });
+    const opened = openReviewDbWithMetadata({
+      openPersistentDatabase: () => ({ close }) as unknown as Database.Database,
+      configureStartup: () => {
+        throw new Error('injected startup configuration failure');
+      },
+    });
+
+    expect(close).toHaveBeenCalledOnce();
+    expect(opened.durability).toBe('memory_only');
+    expect(opened.warning).toContain('open failed');
+    opened.db.close();
   });
 });
 
 describe('makeSessionProviderLookup', () => {
-  it('returns null when no db is supplied (fail-open)', () => {
-    expect(makeSessionProviderLookup(undefined)('anything')).toBeNull();
+  it('distinguishes an unavailable db from an absent session', () => {
+    expect(makeSessionProviderLookup(undefined)('anything')).toEqual({ status: 'unavailable' });
+
+    const db = new Database(':memory:');
+    initializeStorageSchema(db);
+    expect(makeSessionProviderLookup(db)('anything')).toEqual({ status: 'absent' });
+    db.close();
+  });
+
+  it('keeps provider and model lookups separate on an unmigrated readonly db', () => {
+    const db = new Database(':memory:');
+    db.exec(`
+      CREATE TABLE sessions (
+        session_id TEXT PRIMARY KEY,
+        status TEXT NOT NULL DEFAULT 'in_progress',
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        completed_at TEXT,
+        provider TEXT
+      );
+      INSERT INTO sessions (session_id, provider) VALUES ('legacy', 'gemini');
+    `);
+
+    expect(makeSessionProviderLookup(db)('legacy')).toEqual({ status: 'found', value: 'gemini' });
+    expect(makeSessionModelLookup(db)('legacy')).toEqual({ status: 'unavailable' });
+    db.close();
+  });
+
+  it('treats only SQL NULL as legacy and fails closed on an unrecognized owner', () => {
+    const db = new Database(':memory:');
+    initializeStorageSchema(db);
+    db.prepare('INSERT INTO sessions (session_id, provider) VALUES (?, ?)').run(
+      'future-owner',
+      'unknown',
+    );
+    db.prepare('INSERT INTO sessions (session_id, provider) VALUES (?, NULL)').run('legacy');
+    const lookup = makeSessionProviderLookup(db);
+
+    expect(lookup('future-owner')).toEqual({ status: 'unavailable' });
+    expect(lookup('legacy')).toEqual({ status: 'found', value: null });
+    db.close();
+  });
+
+  it('returns parsed legacy, recorded, and invalid model states for existing sessions', () => {
+    const db = new Database(':memory:');
+    initializeStorageSchema(db);
+    getOrCreateSession(db, 'model-state', 'codex');
+    const lookup = makeSessionModelLookup(db);
+
+    expect(lookup('model-state')).toEqual({
+      status: 'found',
+      value: { status: 'legacy_unrecorded' },
+    });
+    const identity = {
+      provider: 'codex',
+      role: 'review',
+      requested: null,
+      resolved: 'gpt-5.6-sol',
+      observed: 'gpt-5.6-sol',
+      evidence: 'runtime_session_record',
+    };
+    db.prepare('UPDATE sessions SET model_identity_json = ? WHERE session_id = ?').run(
+      JSON.stringify(identity),
+      'model-state',
+    );
+    expect(lookup('model-state')).toEqual({
+      status: 'found',
+      value: { status: 'recorded', model: identity },
+    });
+    db.prepare('UPDATE sessions SET model_identity_json = ? WHERE session_id = ?').run(
+      '{broken',
+      'model-state',
+    );
+    expect(lookup('model-state')).toEqual({
+      status: 'found',
+      value: { status: 'invalid' },
+    });
+    db.close();
+  });
+
+  it('rejects owner model metadata with an adjudication role or a different row provider', () => {
+    const db = new Database(':memory:');
+    initializeStorageSchema(db);
+    getOrCreateSession(db, 'model-state', 'codex');
+    const lookup = makeSessionModelLookup(db);
+    const identity = {
+      provider: 'codex',
+      role: 'review',
+      requested: null,
+      resolved: 'gpt-5.6-sol',
+      observed: 'gpt-5.6-sol',
+      evidence: 'runtime_session_record',
+    } as const;
+
+    for (const invalidIdentity of [
+      { ...identity, role: 'adjudication' as const },
+      { ...identity, provider: 'gemini' as const },
+    ]) {
+      db.prepare('UPDATE sessions SET model_identity_json = ? WHERE session_id = ?').run(
+        JSON.stringify(invalidIdentity),
+        'model-state',
+      );
+      expect(lookup('model-state')).toEqual({
+        status: 'found',
+        value: { status: 'invalid' },
+      });
+    }
+    db.close();
+  });
+});
+
+describe('initializeStorageSchema', () => {
+  it('atomically migrates both populated legacy tables and is idempotent', () => {
+    const db = new Database(':memory:');
+    db.exec(`
+      CREATE TABLE sessions (
+        session_id TEXT PRIMARY KEY,
+        status TEXT NOT NULL DEFAULT 'in_progress',
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        completed_at TEXT,
+        provider TEXT
+      );
+      CREATE TABLE reviews (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        session_id TEXT NOT NULL,
+        type TEXT NOT NULL,
+        verdict TEXT NOT NULL,
+        summary TEXT NOT NULL,
+        findings_json TEXT NOT NULL,
+        timestamp TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+      INSERT INTO sessions (session_id, provider) VALUES ('legacy', 'codex');
+      INSERT INTO reviews (session_id, type, verdict, summary, findings_json)
+      VALUES ('legacy', 'plan', 'approve', 'old', '[]');
+    `);
+
+    expect(() => initializeStorageSchema(db)).not.toThrow();
+    expect(() => initializeStorageSchema(db)).not.toThrow();
+    expect(
+      db.prepare('SELECT model_identity_json FROM sessions WHERE session_id = ?').get('legacy'),
+    ).toEqual({ model_identity_json: null });
+    expect(db.prepare('SELECT models_json FROM reviews').get()).toEqual({ models_json: null });
+    db.close();
+  });
+
+  it.each([
+    {
+      name: 'reviews metadata present and sessions metadata absent',
+      sessionHasMetadata: false,
+      reviewHasMetadata: true,
+      expectedSessionMetadata: null,
+      expectedReviewMetadata: '[]',
+    },
+    {
+      name: 'sessions metadata present and reviews metadata absent',
+      sessionHasMetadata: true,
+      reviewHasMetadata: false,
+      expectedSessionMetadata: '{"provider":"codex"}',
+      expectedReviewMetadata: null,
+    },
+  ])(
+    'migrates a populated partial schema with $name without disturbing future columns',
+    ({
+      sessionHasMetadata,
+      reviewHasMetadata,
+      expectedSessionMetadata,
+      expectedReviewMetadata,
+    }) => {
+      const db = new Database(':memory:');
+      db.exec(`
+        CREATE TABLE sessions (
+          session_id TEXT PRIMARY KEY,
+          status TEXT NOT NULL DEFAULT 'in_progress',
+          created_at TEXT NOT NULL DEFAULT (datetime('now')),
+          completed_at TEXT,
+          provider TEXT,
+          ${sessionHasMetadata ? 'model_identity_json TEXT,' : ''}
+          future_session_marker TEXT
+        );
+        CREATE TABLE reviews (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          session_id TEXT NOT NULL,
+          type TEXT NOT NULL,
+          verdict TEXT NOT NULL,
+          summary TEXT NOT NULL,
+          findings_json TEXT NOT NULL,
+          timestamp TEXT NOT NULL DEFAULT (datetime('now')),
+          ${reviewHasMetadata ? 'models_json TEXT,' : ''}
+          future_review_marker TEXT
+        );
+      `);
+      if (sessionHasMetadata) {
+        db.prepare(
+          `INSERT INTO sessions
+           (session_id, provider, model_identity_json, future_session_marker)
+           VALUES (?, ?, ?, ?)`,
+        ).run('partial', 'codex', '{"provider":"codex"}', 'keep-session');
+      } else {
+        db.prepare(
+          `INSERT INTO sessions (session_id, provider, future_session_marker)
+           VALUES (?, ?, ?)`,
+        ).run('partial', 'codex', 'keep-session');
+      }
+      if (reviewHasMetadata) {
+        db.prepare(
+          `INSERT INTO reviews
+           (session_id, type, verdict, summary, findings_json, models_json, future_review_marker)
+           VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        ).run('partial', 'plan', 'approve', 'old', '[]', '[]', 'keep-review');
+      } else {
+        db.prepare(
+          `INSERT INTO reviews
+           (session_id, type, verdict, summary, findings_json, future_review_marker)
+           VALUES (?, ?, ?, ?, ?, ?)`,
+        ).run('partial', 'plan', 'approve', 'old', '[]', 'keep-review');
+      }
+
+      expect(() => initializeStorageSchema(db)).not.toThrow();
+
+      expect(
+        db
+          .prepare(
+            `SELECT model_identity_json, future_session_marker
+             FROM sessions WHERE session_id = ?`,
+          )
+          .get('partial'),
+      ).toEqual({
+        model_identity_json: expectedSessionMetadata,
+        future_session_marker: 'keep-session',
+      });
+      expect(
+        db
+          .prepare(
+            `SELECT models_json, future_review_marker
+             FROM reviews WHERE session_id = ?`,
+          )
+          .get('partial'),
+      ).toEqual({
+        models_json: expectedReviewMetadata,
+        future_review_marker: 'keep-review',
+      });
+      db.close();
+    },
+  );
+
+  it('rolls back the first metadata column when the second ALTER fails', () => {
+    const db = new Database(':memory:');
+    const core = [
+      'session_id TEXT PRIMARY KEY',
+      "status TEXT NOT NULL DEFAULT 'in_progress'",
+      "created_at TEXT NOT NULL DEFAULT (datetime('now'))",
+      'completed_at TEXT',
+      'provider TEXT',
+    ];
+    // Fill sessions to this SQLite build's MAX_COLUMN limit so the second
+    // metadata ALTER fails after reviews.models_json was added.
+    const compileOptions = db.pragma('compile_options') as Array<{ compile_options: string }>;
+    const maxColumnOption = compileOptions.find((option) =>
+      option.compile_options.startsWith('MAX_COLUMN='),
+    );
+    const maxColumns = Number(maxColumnOption?.compile_options.split('=')[1] ?? 2000);
+    const padding = Array.from(
+      { length: maxColumns - core.length },
+      (_, index) => `pad_${index} TEXT`,
+    );
+    db.exec(`
+      CREATE TABLE sessions (${[...core, ...padding].join(',')});
+      CREATE TABLE reviews (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        session_id TEXT NOT NULL,
+        type TEXT NOT NULL,
+        verdict TEXT NOT NULL,
+        summary TEXT NOT NULL,
+        findings_json TEXT NOT NULL,
+        timestamp TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+    `);
+
+    expect(() => initializeStorageSchema(db)).toThrow();
+    const reviewColumns = db.pragma('table_info(reviews)') as Array<{ name: string }>;
+    expect(reviewColumns.map((column) => column.name)).not.toContain('models_json');
+    db.close();
+  });
+
+  it('fails cleanly under a concurrent startup lock and succeeds after release', () => {
+    const lockedPath = join(tmpdir(), `db-lock-${process.pid}-${Date.now()}.db`);
+    const first = new Database(lockedPath, { timeout: 100 });
+    const second = new Database(lockedPath, { timeout: 100 });
+    first.exec(`
+      CREATE TABLE sessions (
+        session_id TEXT PRIMARY KEY,
+        status TEXT NOT NULL DEFAULT 'in_progress',
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        completed_at TEXT,
+        provider TEXT
+      );
+      CREATE TABLE reviews (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        session_id TEXT NOT NULL,
+        type TEXT NOT NULL,
+        verdict TEXT NOT NULL,
+        summary TEXT NOT NULL,
+        findings_json TEXT NOT NULL,
+        timestamp TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+      BEGIN IMMEDIATE;
+    `);
+
+    expect(() => initializeStorageSchema(second)).toThrow(/locked|busy/i);
+    first.exec('ROLLBACK');
+    const before = second.pragma('table_info(reviews)') as Array<{ name: string }>;
+    expect(before.map((column) => column.name)).not.toContain('models_json');
+    expect(() => initializeStorageSchema(second)).not.toThrow();
+    first.close();
+    second.close();
+    for (const suffix of ['', '-wal', '-shm']) {
+      try {
+        rmSync(lockedPath + suffix);
+      } catch {
+        /* ignore */
+      }
+    }
   });
 });

--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -1,89 +1,208 @@
 import { resolve } from 'node:path';
 import Database from 'better-sqlite3';
 import { initDb } from './reviews.js';
-import { initSessionsDb, getSession } from './sessions.js';
+import { initSessionsDb, parseSessionModelIdentityJson } from './sessions.js';
+import type { SessionModelMetadata } from './sessions.js';
 import { toReviewProvider } from '../config/types.js';
 import type { ReviewProvider } from '../config/types.js';
+import { escapeTerminalControls } from '../utils/terminal.js';
 
-// Milliseconds better-sqlite3 waits on a locked db before throwing SQLITE_BUSY.
-// Lets a CLI reader coexist with the MCP server writer during brief contention.
-const BUSY_TIMEOUT_MS = 5000;
+// Keep lock waits short: the outcome writer performs one explicit retry after
+// yielding, rather than blocking the synchronous server for seconds.
+export const BUSY_TIMEOUT_MS = 100;
+export const STARTUP_BUSY_TIMEOUT_MS = 2_000;
 
-// The review database path, resolved to ABSOLUTE so the server and the CLI open
-// the SAME file regardless of how each interprets a relative cwd. REVIEW_BRIDGE_DB
-// wins (tests pass an absolute path); otherwise a cwd-relative 'reviews.db'.
-//
-// NOTE (ISS-018): the default is still cwd-anchored, so the CLI's cross-provider
-// guard is only effective when the CLI runs from the same cwd as the MCP server
-// (the project root — the documented workflow) or when REVIEW_BRIDGE_DB is set to
-// an absolute path. Otherwise the readonly open below finds no file and the guard
-// fails open. A stable global/app-data location is deferred to ISS-018.
-export function reviewDbPath(): string {
-  const p = process.env.REVIEW_BRIDGE_DB ?? 'reviews.db';
-  return p === ':memory:' ? p : resolve(p);
+export type StorageDurability = 'durable' | 'memory_only';
+
+export interface OpenReviewDbMetadata {
+  db: Database.Database;
+  durability: StorageDurability;
+  warning: string | null;
 }
 
-// Open the review database.
-//
-// Default (server): read-write. Falls back to an in-memory db if the file can't
-// be opened, then initializes the schema and enables WAL so a concurrent CLI
-// reader doesn't block the writer. Always returns a usable db.
-//
-// { readonly: true } (CLI): opens the existing file read-only and never creates
-// one (fileMustExist). Returns undefined on any failure — no file, no schema, a
-// lock, etc. — so callers fail open rather than crash. Never writes, so a CLI run
-// records nothing.
+export interface OpenReviewDbDependencies {
+  openPersistentDatabase?: (path: string, timeoutMs: number) => Database.Database;
+  configureStartup?: (db: Database.Database) => void;
+}
+
+export type LookupResult<T> =
+  | { status: 'found'; value: T }
+  | { status: 'absent' }
+  | { status: 'unavailable' };
+
+export function reviewDbPath(): string {
+  const path = process.env.REVIEW_BRIDGE_DB ?? 'reviews.db';
+  return path === ':memory:' ? path : resolve(path);
+}
+
+function columns(db: Database.Database, table: 'sessions' | 'reviews'): Set<string> {
+  const rows = db.pragma(`table_info(${table})`) as Array<{ name: string }>;
+  return new Set(rows.map((row) => row.name));
+}
+
+// The two model-metadata columns migrate in one BEGIN IMMEDIATE transaction.
+// initDb/initSessionsDb detect the enclosing transaction and do not create
+// nested commits, so a failure in either table rolls the whole upgrade back.
+export function initializeStorageSchema(db: Database.Database): void {
+  db.exec('BEGIN IMMEDIATE');
+  try {
+    // Reviews first is intentional: a later sessions migration failure must
+    // prove reviews.models_json rolls back with it.
+    initDb(db);
+    initSessionsDb(db);
+
+    if (!columns(db, 'reviews').has('models_json')) {
+      throw new Error('storage migration verification failed: reviews.models_json missing');
+    }
+    if (!columns(db, 'sessions').has('model_identity_json')) {
+      throw new Error(
+        'storage migration verification failed: sessions.model_identity_json missing',
+      );
+    }
+    db.exec('COMMIT');
+  } catch (error) {
+    if (db.inTransaction) db.exec('ROLLBACK');
+    throw error;
+  }
+}
+
+function configureConnection(db: Database.Database): void {
+  db.pragma(`busy_timeout = ${BUSY_TIMEOUT_MS}`);
+}
+
+function configureStartupConnection(db: Database.Database): void {
+  db.pragma(`busy_timeout = ${STARTUP_BUSY_TIMEOUT_MS}`);
+}
+
+function closeBestEffort(db: Database.Database): void {
+  try {
+    db.close();
+  } catch {
+    // The original open/configuration error is the useful failure. A close
+    // error must not prevent the fully initialized memory fallback.
+  }
+}
+
+function openConfiguredPersistentDatabase(
+  path: string,
+  dependencies: OpenReviewDbDependencies,
+): Database.Database {
+  const openPersistentDatabase =
+    dependencies.openPersistentDatabase ??
+    ((databasePath: string, timeoutMs: number) =>
+      new Database(databasePath, { timeout: timeoutMs }));
+  const db = openPersistentDatabase(path, STARTUP_BUSY_TIMEOUT_MS);
+  try {
+    (dependencies.configureStartup ?? configureStartupConnection)(db);
+    return db;
+  } catch (error) {
+    closeBestEffort(db);
+    throw error;
+  }
+}
+
+function openInitializedMemory(warning: string | null): OpenReviewDbMetadata {
+  const db = new Database(':memory:', { timeout: BUSY_TIMEOUT_MS });
+  configureConnection(db);
+  initializeStorageSchema(db);
+  return { db, durability: 'memory_only', warning };
+}
+
+export function openReviewDbWithMetadata(
+  dependencies: OpenReviewDbDependencies = {},
+): OpenReviewDbMetadata {
+  const path = reviewDbPath();
+  if (path === ':memory:') return openInitializedMemory(null);
+
+  let db: Database.Database;
+  try {
+    db = openConfiguredPersistentDatabase(path, dependencies);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const warning = `Database open failed (${path}); using in-memory storage: ${message}`;
+    console.error(escapeTerminalControls(warning));
+    return openInitializedMemory(warning);
+  }
+
+  try {
+    initializeStorageSchema(db);
+    db.pragma('journal_mode = WAL');
+    configureConnection(db);
+    return { db, durability: 'durable', warning: null };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    closeBestEffort(db);
+    const warning = `Database initialization failed (${path}); using in-memory storage: ${message}`;
+    console.error(escapeTerminalControls(warning));
+    return openInitializedMemory(warning);
+  }
+}
+
 export function openReviewDb(opts?: { readonly?: false }): Database.Database;
 export function openReviewDb(opts: { readonly: true }): Database.Database | undefined;
-// General overload so a dynamically-computed `readonly` still type-checks (it
-// widens the return to include undefined, matching the readonly branch).
 export function openReviewDb(opts?: { readonly?: boolean }): Database.Database | undefined;
 export function openReviewDb(opts?: { readonly?: boolean }): Database.Database | undefined {
-  const path = reviewDbPath();
-
   if (opts?.readonly) {
     try {
-      return new Database(path, { readonly: true, fileMustExist: true, timeout: BUSY_TIMEOUT_MS });
+      const db = new Database(reviewDbPath(), {
+        readonly: true,
+        fileMustExist: true,
+        timeout: BUSY_TIMEOUT_MS,
+      });
+      configureConnection(db);
+      return db;
     } catch {
       return undefined;
     }
   }
-
-  let db: Database.Database;
-  try {
-    db = new Database(path, { timeout: BUSY_TIMEOUT_MS });
-  } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e);
-    console.error(`Database open failed (${path}), falling back to in-memory: ${msg}`);
-    db = new Database(':memory:', { timeout: BUSY_TIMEOUT_MS });
-  }
-  try {
-    initDb(db);
-    initSessionsDb(db);
-    // WAL lets a readonly CLI connection read while the server writes. Harmless
-    // (and ignored) for :memory:.
-    if (path !== ':memory:') db.pragma('journal_mode = WAL');
-  } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e);
-    console.error(`Database table initialization failed: ${msg}`);
-  }
-  return db;
+  return openReviewDbWithMetadata().db;
 }
 
-// Build a session→owning-provider lookup for resume routing. Returns null for an
-// absent db, an unknown session, a read error, or a legacy/unknown provider —
-// every branch fails open so routing falls back to the primary rather than
-// throwing. Shared by the MCP server and the CLI.
+// Provider lookup intentionally selects only the legacy provider column. It
+// remains usable on a readonly database whose model migration has not run.
 export function makeSessionProviderLookup(
   db: Database.Database | undefined,
-): (sessionId: string) => ReviewProvider | null {
+): (sessionId: string) => LookupResult<ReviewProvider | null> {
   return (sessionId) => {
-    if (!db) return null;
+    if (!db) return { status: 'unavailable' };
     try {
-      const r = getSession(db, sessionId);
-      return r.ok && r.data ? toReviewProvider(r.data.provider) : null;
+      const row = db
+        .prepare('SELECT provider FROM sessions WHERE session_id = ?')
+        .get(sessionId) as { provider: string | null } | undefined;
+      if (!row) return { status: 'absent' };
+      const provider = toReviewProvider(row.provider);
+      // SQL NULL is the only legacy/untagged state. A non-null value that this
+      // binary does not recognize may be corruption or a future provider; never
+      // route it through the configured primary by pretending it is legacy.
+      if (row.provider !== null && provider === null) return { status: 'unavailable' };
+      return { status: 'found', value: provider };
     } catch {
-      return null;
+      return { status: 'unavailable' };
+    }
+  };
+}
+
+// Model lookup is separate so an unmigrated/locked model column reports
+// unavailable without weakening the legacy provider mismatch guard.
+export function makeSessionModelLookup(
+  db: Database.Database | undefined,
+): (sessionId: string) => LookupResult<SessionModelMetadata> {
+  return (sessionId) => {
+    if (!db) return { status: 'unavailable' };
+    try {
+      const row = db
+        .prepare('SELECT provider, model_identity_json FROM sessions WHERE session_id = ?')
+        .get(sessionId) as
+        | { provider: string | null; model_identity_json: string | null }
+        | undefined;
+      return row
+        ? {
+            status: 'found',
+            value: parseSessionModelIdentityJson(row.model_identity_json, row.provider),
+          }
+        : { status: 'absent' };
+    } catch {
+      return { status: 'unavailable' };
     }
   };
 }

--- a/src/storage/review-outcome.test.ts
+++ b/src/storage/review-outcome.test.ts
@@ -1,0 +1,449 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import Database from 'better-sqlite3';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { rmSync } from 'node:fs';
+import { initializeStorageSchema } from './db.js';
+import { getReviewsBySession } from './reviews.js';
+import { getOrCreateSession, getSession, markSessionCompleted } from './sessions.js';
+import { recordReviewOutcome, recordReviewOutcomeWithRetry } from './review-outcome.js';
+import type { RecordReviewOutcomeInput } from './review-outcome.js';
+
+const OLD_MODEL = {
+  provider: 'codex',
+  role: 'review',
+  requested: 'gpt-5.5',
+  resolved: 'gpt-5.5',
+  observed: 'gpt-5.5',
+  evidence: 'runtime_session_record',
+} as const;
+
+const NEW_MODEL = {
+  provider: 'codex',
+  role: 'review',
+  requested: null,
+  resolved: 'gpt-5.6-sol',
+  observed: 'gpt-5.6-sol',
+  evidence: 'runtime_session_record',
+} as const;
+
+function input(overrides: Partial<RecordReviewOutcomeInput> = {}): RecordReviewOutcomeInput {
+  return {
+    resultSessionId: 'result-session',
+    servingProvider: 'codex',
+    ownerModelIdentity: NEW_MODEL,
+    review: {
+      session_id: 'result-session',
+      type: 'plan' as const,
+      verdict: 'approve',
+      summary: 'complete',
+      findings_json: '[]',
+      models: [NEW_MODEL],
+    },
+    ...overrides,
+  };
+}
+
+describe('recordReviewOutcome', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    initializeStorageSchema(db);
+  });
+
+  afterEach(() => db.close());
+
+  it('atomically creates, tags, snapshots, and completes a fresh session', () => {
+    const result = recordReviewOutcome(db, input());
+
+    expect(result.ok).toBe(true);
+    const session = getSession(db, 'result-session');
+    expect(session.ok && session.data).toMatchObject({
+      status: 'completed',
+      provider: 'codex',
+      model_identity_json: JSON.stringify(NEW_MODEL),
+    });
+    const reviews = getReviewsBySession(db, 'result-session');
+    expect(reviews.ok && reviews.data[0].models).toEqual([NEW_MODEL]);
+  });
+
+  it('merges known fields over unknown refresh fields', () => {
+    getOrCreateSession(db, 'result-session', 'codex', JSON.stringify(OLD_MODEL));
+
+    const result = recordReviewOutcome(
+      db,
+      input({
+        preflightSessionId: 'result-session',
+        ownerModelIdentity: {
+          ...OLD_MODEL,
+          requested: null,
+          resolved: null,
+          observed: null,
+          evidence: 'unavailable',
+        },
+      }),
+    );
+
+    expect(result.ok).toBe(true);
+    const stored = db
+      .prepare('SELECT model_identity_json FROM sessions WHERE session_id = ?')
+      .get('result-session') as { model_identity_json: string };
+    expect(JSON.parse(stored.model_identity_json)).toMatchObject({
+      requested: 'gpt-5.5',
+      resolved: 'gpt-5.5',
+      observed: 'gpt-5.5',
+      evidence: 'runtime_session_record',
+    });
+  });
+
+  it('never merges fields from a stored identity owned by another provider', () => {
+    getOrCreateSession(
+      db,
+      'result-session',
+      'codex',
+      JSON.stringify({ ...OLD_MODEL, provider: 'gemini', resolved: 'Gemini foreign model' }),
+    );
+    const unknownCodex = {
+      ...NEW_MODEL,
+      requested: null,
+      resolved: null,
+      observed: null,
+      evidence: 'unavailable',
+    } as const;
+
+    const result = recordReviewOutcome(
+      db,
+      input({
+        preflightSessionId: 'result-session',
+        ownerModelIdentity: unknownCodex,
+      }),
+    );
+
+    expect(result.ok).toBe(true);
+    const stored = db
+      .prepare('SELECT model_identity_json FROM sessions WHERE session_id = ?')
+      .get('result-session') as { model_identity_json: string };
+    expect(JSON.parse(stored.model_identity_json)).toEqual(unknownCodex);
+    expect(stored.model_identity_json).not.toContain('Gemini foreign model');
+  });
+
+  it('allows a successful provider resume to replace known model fields', () => {
+    getOrCreateSession(
+      db,
+      'result-session',
+      'gemini',
+      JSON.stringify({ ...OLD_MODEL, provider: 'gemini' }),
+    );
+
+    const geminiNew = {
+      ...NEW_MODEL,
+      provider: 'gemini',
+      observed: null,
+      evidence: 'bridge_selection',
+    } as const;
+    const result = recordReviewOutcome(
+      db,
+      input({
+        preflightSessionId: 'result-session',
+        servingProvider: 'gemini',
+        ownerModelIdentity: geminiNew,
+      }),
+    );
+
+    expect(result.ok).toBe(true);
+    const stored = db
+      .prepare('SELECT model_identity_json FROM sessions WHERE session_id = ?')
+      .get('result-session') as { model_identity_json: string };
+    expect(JSON.parse(stored.model_identity_json).resolved).toBe('gpt-5.6-sol');
+  });
+
+  it('rejects and rolls back when a survivor session is already owned by another provider', () => {
+    getOrCreateSession(db, 'result-session', 'codex', JSON.stringify(OLD_MODEL));
+    markSessionCompleted(db, 'result-session');
+    const before = getSession(db, 'result-session');
+    const geminiModel = {
+      ...NEW_MODEL,
+      provider: 'gemini',
+      observed: null,
+      evidence: 'bridge_selection',
+    } as const;
+
+    const result = recordReviewOutcome(
+      db,
+      input({ servingProvider: 'gemini', ownerModelIdentity: geminiModel }),
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/^SESSION_ROUTING_UNAVAILABLE:/);
+    expect(getSession(db, 'result-session')).toEqual(before);
+    expect(getReviewsBySession(db, 'result-session')).toMatchObject({ ok: true, data: [] });
+  });
+
+  it('rejects invalid serving providers and contradictory owner identities at the transaction boundary', () => {
+    const invalidProvider = recordReviewOutcome(
+      db,
+      input({ servingProvider: 'future-provider' as never }),
+    );
+    const wrongProviderIdentity = recordReviewOutcome(
+      db,
+      input({ ownerModelIdentity: { ...NEW_MODEL, provider: 'gemini' } }),
+    );
+    const wrongRoleIdentity = recordReviewOutcome(
+      db,
+      input({ ownerModelIdentity: { ...NEW_MODEL, role: 'adjudication' } }),
+    );
+
+    for (const result of [invalidProvider, wrongProviderIdentity, wrongRoleIdentity]) {
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toMatch(/^STORAGE_ERROR:/);
+    }
+    expect(getSession(db, 'result-session')).toEqual({ ok: true, data: null });
+    expect(getReviewsBySession(db, 'result-session')).toMatchObject({ ok: true, data: [] });
+  });
+
+  it('fails the old owner and completes/attaches history to a different survivor session', () => {
+    getOrCreateSession(db, 'old-owner', 'codex', JSON.stringify(OLD_MODEL));
+    markSessionCompleted(db, 'old-owner');
+
+    const result = recordReviewOutcome(
+      db,
+      input({
+        preflightSessionId: 'old-owner',
+        preflightProvider: 'codex',
+        resultSessionId: 'survivor',
+      }),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(getSession(db, 'old-owner')).toMatchObject({ ok: true, data: { status: 'failed' } });
+    expect(getSession(db, 'survivor')).toMatchObject({
+      ok: true,
+      data: { status: 'completed', provider: 'codex' },
+    });
+    const survivorReviews = getReviewsBySession(db, 'survivor');
+    expect(survivorReviews.ok && survivorReviews.data).toHaveLength(1);
+    const oldReviews = getReviewsBySession(db, 'old-owner');
+    expect(oldReviews.ok && oldReviews.data).toEqual([]);
+  });
+
+  it('creates an absent preflight owner as failed with the attempted provider', () => {
+    const result = recordReviewOutcome(
+      db,
+      input({
+        preflightSessionId: 'absent-owner',
+        preflightProvider: 'gemini',
+        resultSessionId: 'survivor',
+      }),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(getSession(db, 'absent-owner')).toMatchObject({
+      ok: true,
+      data: { status: 'failed', provider: 'gemini' },
+    });
+  });
+
+  it('rejects a conflicting preflight owner transactionally', () => {
+    getOrCreateSession(db, 'old-owner', 'gemini');
+    const before = getSession(db, 'old-owner');
+
+    const result = recordReviewOutcome(
+      db,
+      input({
+        preflightSessionId: 'old-owner',
+        preflightProvider: 'codex',
+        resultSessionId: 'survivor',
+      }),
+    );
+
+    expect(result.ok).toBe(false);
+    expect(getSession(db, 'old-owner')).toEqual(before);
+    expect(getSession(db, 'survivor')).toEqual({ ok: true, data: null });
+    expect(getReviewsBySession(db, 'survivor')).toMatchObject({ ok: true, data: [] });
+  });
+
+  it('rejects a fresh result id that already exists even under the same provider', () => {
+    getOrCreateSession(db, 'survivor', 'codex', JSON.stringify(OLD_MODEL));
+    markSessionCompleted(db, 'survivor');
+    const before = getSession(db, 'survivor');
+
+    const result = recordReviewOutcome(
+      db,
+      input({
+        preflightSessionId: 'old-owner',
+        preflightProvider: 'codex',
+        resultSessionId: 'survivor',
+      }),
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/^SESSION_ROUTING_UNAVAILABLE:/);
+    expect(getSession(db, 'survivor')).toEqual(before);
+    expect(getSession(db, 'old-owner')).toEqual({ ok: true, data: null });
+    expect(getReviewsBySession(db, 'survivor')).toMatchObject({ ok: true, data: [] });
+  });
+
+  it('rolls back an identity update when the review insert fails', () => {
+    getOrCreateSession(db, 'result-session', 'codex', JSON.stringify(OLD_MODEL));
+    db.exec(`
+      CREATE TRIGGER fail_review_insert
+      BEFORE INSERT ON reviews
+      BEGIN
+        SELECT RAISE(ABORT, 'injected review failure');
+      END;
+    `);
+
+    const result = recordReviewOutcome(db, input({ preflightSessionId: 'result-session' }));
+
+    expect(result.ok).toBe(false);
+    const stored = db
+      .prepare('SELECT model_identity_json FROM sessions WHERE session_id = ?')
+      .get('result-session') as { model_identity_json: string };
+    expect(stored.model_identity_json).toBe(JSON.stringify(OLD_MODEL));
+    expect(db.prepare('SELECT COUNT(*) AS count FROM reviews').get()).toEqual({ count: 0 });
+  });
+
+  it('rolls back when the result-session upsert fails', () => {
+    getOrCreateSession(db, 'old-owner', 'codex', JSON.stringify(OLD_MODEL));
+    const before = getSession(db, 'old-owner');
+    db.exec(`
+      CREATE TRIGGER fail_result_session_upsert
+      BEFORE INSERT ON sessions
+      WHEN NEW.session_id = 'survivor'
+      BEGIN
+        SELECT RAISE(ABORT, 'injected result-session failure');
+      END;
+    `);
+
+    const result = recordReviewOutcome(
+      db,
+      input({
+        preflightSessionId: 'old-owner',
+        preflightProvider: 'codex',
+        resultSessionId: 'survivor',
+      }),
+    );
+
+    expect(result.ok).toBe(false);
+    expect(getSession(db, 'old-owner')).toEqual(before);
+    expect(getSession(db, 'survivor')).toEqual({ ok: true, data: null });
+    expect(db.prepare('SELECT COUNT(*) AS count FROM reviews').get()).toEqual({ count: 0 });
+  });
+
+  it('rolls back the new survivor when marking the prior owner failed errors', () => {
+    getOrCreateSession(db, 'old-owner', 'codex', JSON.stringify(OLD_MODEL));
+    const before = getSession(db, 'old-owner');
+    db.exec(`
+      CREATE TRIGGER fail_prior_owner_update
+      BEFORE UPDATE OF status ON sessions
+      WHEN OLD.session_id = 'old-owner' AND NEW.status = 'failed'
+      BEGIN
+        SELECT RAISE(ABORT, 'injected prior-owner failure');
+      END;
+    `);
+
+    const result = recordReviewOutcome(
+      db,
+      input({
+        preflightSessionId: 'old-owner',
+        preflightProvider: 'codex',
+        resultSessionId: 'survivor',
+      }),
+    );
+
+    expect(result.ok).toBe(false);
+    expect(getSession(db, 'old-owner')).toEqual(before);
+    expect(getSession(db, 'survivor')).toEqual({ ok: true, data: null });
+    expect(db.prepare('SELECT COUNT(*) AS count FROM reviews').get()).toEqual({ count: 0 });
+  });
+
+  it('rolls back the identity and review insert when final completion fails', () => {
+    db.exec(`
+      CREATE TRIGGER fail_completion
+      BEFORE UPDATE OF status ON sessions
+      WHEN NEW.status = 'completed'
+      BEGIN
+        SELECT RAISE(ABORT, 'injected completion failure');
+      END;
+    `);
+
+    const result = recordReviewOutcome(db, input());
+
+    expect(result.ok).toBe(false);
+    expect(getSession(db, 'result-session')).toEqual({ ok: true, data: null });
+    expect(db.prepare('SELECT COUNT(*) AS count FROM reviews').get()).toEqual({ count: 0 });
+  });
+
+  it('rolls back every mutation when COMMIT itself fails', () => {
+    const exec = db.exec.bind(db);
+    vi.spyOn(db, 'exec').mockImplementation((sql) => {
+      if (sql === 'COMMIT') throw new Error('injected commit failure');
+      return exec(sql);
+    });
+    const result = recordReviewOutcome(db, input());
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/^STORAGE_ERROR:/);
+    expect(db.inTransaction).toBe(false);
+    expect(getSession(db, 'result-session')).toEqual({ ok: true, data: null });
+    expect(db.prepare('SELECT COUNT(*) AS count FROM reviews').get()).toEqual({ count: 0 });
+  });
+});
+
+describe('recordReviewOutcomeWithRetry', () => {
+  let dbPath: string;
+  let writer: Database.Database;
+  let locker: Database.Database;
+
+  beforeEach(() => {
+    dbPath = join(tmpdir(), `review-outcome-${process.pid}-${Date.now()}.db`);
+    writer = new Database(dbPath, { timeout: 100 });
+    locker = new Database(dbPath, { timeout: 100 });
+    writer.pragma('busy_timeout = 100');
+    locker.pragma('busy_timeout = 100');
+    initializeStorageSchema(writer);
+  });
+
+  afterEach(() => {
+    if (locker.inTransaction) locker.exec('ROLLBACK');
+    writer.close();
+    locker.close();
+    for (const suffix of ['', '-wal', '-shm']) {
+      try {
+        rmSync(dbPath + suffix);
+      } catch {
+        /* ignore */
+      }
+    }
+  });
+
+  it('retries SQLITE_BUSY exactly once after yielding, then succeeds', async () => {
+    locker.exec('BEGIN IMMEDIATE');
+    const sleep = vi.fn(async () => {
+      locker.exec('COMMIT');
+    });
+
+    const result = await recordReviewOutcomeWithRetry(writer, input(), { sleep });
+
+    expect(result.ok).toBe(true);
+    expect(sleep).toHaveBeenCalledTimes(1);
+    expect(sleep).toHaveBeenCalledWith(25);
+  });
+
+  it('does not retry a non-busy storage error', async () => {
+    writer.exec(`
+      CREATE TRIGGER fail_review_insert
+      BEFORE INSERT ON reviews
+      BEGIN
+        SELECT RAISE(ABORT, 'permanent');
+      END;
+    `);
+    const sleep = vi.fn(async () => {});
+
+    const result = await recordReviewOutcomeWithRetry(writer, input(), { sleep });
+
+    expect(result.ok).toBe(false);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+});

--- a/src/storage/review-outcome.ts
+++ b/src/storage/review-outcome.ts
@@ -1,0 +1,262 @@
+import type Database from 'better-sqlite3';
+import { ModelIdentitySchema } from '../review/types.js';
+import type { ModelIdentity } from '../review/types.js';
+import { err, ErrorCode, ok } from '../utils/errors.js';
+import type { Result } from '../utils/errors.js';
+import { saveReview } from './reviews.js';
+import type { SaveReviewInput } from './reviews.js';
+import { parseSessionModelIdentityJson } from './sessions.js';
+import { toReviewProvider } from '../config/types.js';
+import type { ReviewProvider } from '../config/types.js';
+
+export interface RecordReviewOutcomeInput {
+  preflightSessionId?: string;
+  preflightProvider?: ReviewProvider;
+  resultSessionId: string;
+  servingProvider: ReviewProvider;
+  ownerModelIdentity?: unknown;
+  review: SaveReviewInput;
+}
+
+export interface RecordReviewRetryOptions {
+  sleep?: (milliseconds: number) => Promise<void>;
+}
+
+export const BUSY_RETRY_DELAY_MS = 25;
+
+function parseIdentity(value: unknown): ModelIdentity | null {
+  const parsed = ModelIdentitySchema.safeParse(value);
+  return parsed.success ? parsed.data : null;
+}
+
+function evidenceRank(evidence: ModelIdentity['evidence']): number {
+  switch (evidence) {
+    case 'runtime_session_record':
+      return 2;
+    case 'bridge_selection':
+      return 1;
+    case 'unavailable':
+      return 0;
+  }
+}
+
+function mergeOwnerIdentity(
+  existingJson: string | null,
+  incoming: ModelIdentity | null,
+  servingProvider: ReviewProvider,
+): string | null {
+  const existingState = parseSessionModelIdentityJson(existingJson, servingProvider);
+  if (!incoming) return existingState.status === 'recorded' ? existingJson : null;
+  if (existingState.status !== 'recorded') return JSON.stringify(incoming);
+  const existing = existingState.model;
+
+  // Gemini applies a model each call, so its latest successful identity owns
+  // the conversation even when observed remains honestly null.
+  if (incoming.provider === 'gemini') return JSON.stringify(incoming);
+
+  const evidence =
+    evidenceRank(incoming.evidence) >= evidenceRank(existing.evidence)
+      ? incoming.evidence
+      : existing.evidence;
+  return JSON.stringify({
+    provider: incoming.provider,
+    role: incoming.role,
+    requested: incoming.requested ?? existing.requested,
+    resolved: incoming.resolved ?? existing.resolved,
+    observed: incoming.observed ?? existing.observed,
+    evidence,
+  } satisfies ModelIdentity);
+}
+
+function storageError(error: unknown): string {
+  if (error instanceof Error) {
+    for (const code of [ErrorCode.STORAGE_ERROR, ErrorCode.SESSION_ROUTING_UNAVAILABLE]) {
+      if (error.message.startsWith(`${code}:`)) return error.message;
+    }
+  }
+  const code =
+    typeof error === 'object' && error !== null && 'code' in error && typeof error.code === 'string'
+      ? `${error.code}: `
+      : '';
+  const message = error instanceof Error ? error.message : String(error);
+  return `${ErrorCode.STORAGE_ERROR}: ${code}${message}`;
+}
+
+function requireOk(result: Result<unknown>): void {
+  if (!result.ok) throw new Error(result.error);
+}
+
+function storageInvariant(message: string): never {
+  throw new Error(`${ErrorCode.STORAGE_ERROR}: ${message}`);
+}
+
+function routingInvariant(message: string): never {
+  throw new Error(`${ErrorCode.SESSION_ROUTING_UNAVAILABLE}: ${message}`);
+}
+
+function validateServingProvider(value: string): ReviewProvider {
+  const provider = toReviewProvider(value);
+  if (!provider) storageInvariant('invalid serving provider for review outcome');
+  return provider;
+}
+
+function validateOwnerIdentity(
+  value: unknown,
+  servingProvider: ReviewProvider,
+): ModelIdentity | null {
+  if (value === undefined || value === null) return null;
+  const identity = parseIdentity(value);
+  if (!identity) storageInvariant('invalid owner model identity for review outcome');
+  if (identity.provider !== servingProvider || identity.role !== 'review') {
+    storageInvariant('owner model identity contradicts the serving provider');
+  }
+  return identity;
+}
+
+interface PriorOwner {
+  sessionId: string;
+  provider: ReviewProvider;
+}
+
+interface PreparedOutcome {
+  servingProvider: ReviewProvider;
+  identityJson: string | null;
+  priorOwner?: PriorOwner;
+}
+
+function prepareResultIdentity(
+  db: Database.Database,
+  input: RecordReviewOutcomeInput,
+  servingProvider: ReviewProvider,
+  incomingIdentity: ModelIdentity | null,
+): string | null {
+  const existing = db
+    .prepare('SELECT provider, model_identity_json FROM sessions WHERE session_id = ?')
+    .get(input.resultSessionId) as
+    | { provider: string | null; model_identity_json: string | null }
+    | undefined;
+  const isFreshResult = input.preflightSessionId !== input.resultSessionId;
+  if (isFreshResult && existing) {
+    routingInvariant('returned session id is already recorded');
+  }
+  if (existing?.provider !== null && existing?.provider !== undefined) {
+    if (existing.provider !== servingProvider) {
+      routingInvariant('result session is already owned by another provider');
+    }
+  }
+  return mergeOwnerIdentity(
+    existing?.model_identity_json ?? null,
+    incomingIdentity,
+    servingProvider,
+  );
+}
+
+function preparePriorOwner(
+  db: Database.Database,
+  input: RecordReviewOutcomeInput,
+): PriorOwner | undefined {
+  const sessionId = input.preflightSessionId;
+  if (sessionId === undefined || sessionId === input.resultSessionId) return undefined;
+  if (!input.preflightProvider) {
+    storageInvariant('missing preflight provider for survivor transition');
+  }
+  const provider = validateServingProvider(input.preflightProvider);
+  const preflight = db
+    .prepare('SELECT provider FROM sessions WHERE session_id = ?')
+    .get(sessionId) as { provider: string | null } | undefined;
+  if (preflight && preflight.provider !== null && preflight.provider !== provider) {
+    routingInvariant('preflight session is already owned by another provider');
+  }
+  return { sessionId, provider };
+}
+
+function prepareOutcome(db: Database.Database, input: RecordReviewOutcomeInput): PreparedOutcome {
+  const servingProvider = validateServingProvider(input.servingProvider);
+  const incomingIdentity = validateOwnerIdentity(input.ownerModelIdentity, servingProvider);
+  return {
+    servingProvider,
+    identityJson: prepareResultIdentity(db, input, servingProvider, incomingIdentity),
+    priorOwner: preparePriorOwner(db, input),
+  };
+}
+
+function upsertResultSession(
+  db: Database.Database,
+  input: RecordReviewOutcomeInput,
+  prepared: PreparedOutcome,
+): void {
+  db.prepare(
+    `
+    INSERT INTO sessions
+      (session_id, status, completed_at, provider, model_identity_json)
+    VALUES (?, 'in_progress', NULL, ?, ?)
+    ON CONFLICT(session_id) DO UPDATE SET
+      status = 'in_progress',
+      completed_at = NULL,
+      provider = COALESCE(sessions.provider, excluded.provider),
+      model_identity_json = excluded.model_identity_json
+  `,
+  ).run(input.resultSessionId, prepared.servingProvider, prepared.identityJson);
+}
+
+function failPriorOwner(db: Database.Database, priorOwner: PriorOwner | undefined): void {
+  if (!priorOwner) return;
+  db.prepare(
+    `
+      INSERT INTO sessions (session_id, status, completed_at, provider, model_identity_json)
+      VALUES (?, 'failed', datetime('now'), ?, NULL)
+      ON CONFLICT(session_id) DO UPDATE SET
+        status = 'failed',
+        completed_at = datetime('now'),
+        provider = COALESCE(sessions.provider, excluded.provider)
+    `,
+  ).run(priorOwner.sessionId, priorOwner.provider);
+}
+
+function saveSnapshotAndComplete(db: Database.Database, input: RecordReviewOutcomeInput): void {
+  requireOk(saveReview(db, { ...input.review, session_id: input.resultSessionId }));
+  db.prepare(
+    "UPDATE sessions SET status = 'completed', completed_at = datetime('now') WHERE session_id = ?",
+  ).run(input.resultSessionId);
+}
+
+function recordInTransaction(db: Database.Database, input: RecordReviewOutcomeInput): void {
+  const prepared = prepareOutcome(db, input);
+  upsertResultSession(db, input, prepared);
+  failPriorOwner(db, prepared.priorOwner);
+  saveSnapshotAndComplete(db, input);
+}
+
+export function recordReviewOutcome(
+  db: Database.Database,
+  input: RecordReviewOutcomeInput,
+): Result<void> {
+  try {
+    db.exec('BEGIN IMMEDIATE');
+    recordInTransaction(db, input);
+    db.exec('COMMIT');
+    return ok(undefined);
+  } catch (error) {
+    if (db.inTransaction) db.exec('ROLLBACK');
+    return err(storageError(error));
+  }
+}
+
+function isBusyError(error: string): boolean {
+  return /SQLITE_BUSY(?:_SNAPSHOT)?\b/.test(error);
+}
+
+const defaultSleep = (milliseconds: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, milliseconds));
+
+export async function recordReviewOutcomeWithRetry(
+  db: Database.Database,
+  input: RecordReviewOutcomeInput,
+  options: RecordReviewRetryOptions = {},
+): Promise<Result<void>> {
+  const first = recordReviewOutcome(db, input);
+  if (first.ok || !isBusyError(first.error)) return first;
+
+  await (options.sleep ?? defaultSleep)(BUSY_RETRY_DELAY_MS);
+  return recordReviewOutcome(db, input);
+}

--- a/src/storage/reviews.test.ts
+++ b/src/storage/reviews.test.ts
@@ -1,11 +1,28 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { z } from 'zod';
 import Database from 'better-sqlite3';
-import { initDb, saveReview, getReviewsBySession, getRecentReviews } from './reviews.js';
+import {
+  initDb,
+  saveReview,
+  getReviewsBySession,
+  getRecentReviews,
+  getReviewsBySessionPage,
+  getRecentReviewsPage,
+  parseModelsJson,
+} from './reviews.js';
 import { initSessionsDb, getOrCreateSession } from './sessions.js';
 import { ReviewHistoryEntrySchema } from '../review/types.js';
 
 let db: InstanceType<typeof Database>;
+
+const MODEL = {
+  provider: 'codex',
+  role: 'review',
+  requested: 'gpt-5.5',
+  resolved: 'gpt-5.5',
+  observed: 'gpt-5.5',
+  evidence: 'runtime_session_record',
+} as const;
 
 beforeEach(() => {
   db = new Database(':memory:');
@@ -23,6 +40,32 @@ describe('initDb', () => {
 
   it('is idempotent (safe to call twice)', () => {
     expect(() => initDb(db)).not.toThrow();
+  });
+
+  it('creates the nullable models snapshot column', () => {
+    const columns = db.pragma('table_info(reviews)') as Array<{ name: string }>;
+    expect(columns.map((column) => column.name)).toContain('models_json');
+  });
+
+  it('creates a session/id index that SQLite uses for cursor history pages', () => {
+    const indexColumns = db.pragma('index_info(reviews_session_id_id_idx)') as Array<{
+      seqno: number;
+      name: string;
+    }>;
+    expect(
+      indexColumns.sort((left, right) => left.seqno - right.seqno).map(({ name }) => name),
+    ).toEqual(['session_id', 'id']);
+
+    const plan = db
+      .prepare(
+        `EXPLAIN QUERY PLAN
+         SELECT id FROM reviews
+         WHERE session_id = ? AND id > ?
+         ORDER BY id ASC LIMIT ?`,
+      )
+      .all('paged', 0, 3) as Array<{ detail: string }>;
+
+    expect(plan.some(({ detail }) => detail.includes('reviews_session_id_id_idx'))).toBe(true);
   });
 });
 
@@ -56,6 +99,76 @@ describe('saveReview', () => {
       expect(result.data[0].verdict).toBe('request_changes');
       expect(result.data[0].summary).toBe('Issues found');
     }
+  });
+
+  it('persists the exact models snapshot and surfaces parsed models', () => {
+    const modelsJson = JSON.stringify([MODEL]);
+    saveReview(db, {
+      session_id: 'models-exact',
+      type: 'plan',
+      verdict: 'approve',
+      summary: 'models',
+      findings_json: '[]',
+      models_json: modelsJson,
+    });
+
+    expect(db.prepare('SELECT models_json FROM reviews').get()).toEqual({
+      models_json: modelsJson,
+    });
+    const result = getReviewsBySession(db, 'models-exact');
+    expect(result.ok && result.data[0].models).toEqual([MODEL]);
+  });
+});
+
+describe('model snapshot parsing', () => {
+  it('distinguishes recorded, legacy-unrecorded, and invalid snapshots', () => {
+    expect(parseModelsJson(JSON.stringify([MODEL]))).toEqual({
+      status: 'recorded',
+      models: [MODEL],
+    });
+    expect(parseModelsJson(null)).toEqual({ status: 'legacy_unrecorded' });
+    expect(parseModelsJson('{broken')).toEqual({ status: 'invalid' });
+    expect(parseModelsJson(JSON.stringify([{ provider: 'codex' }]))).toEqual({ status: 'invalid' });
+  });
+
+  it('maps malformed stored JSON to public history null without failing the query', () => {
+    const warning = vi.spyOn(console, 'error').mockImplementation(() => {});
+    saveReview(db, {
+      session_id: 'malformed-models',
+      type: 'code',
+      verdict: 'approve',
+      summary: 'old',
+      findings_json: '[]',
+    });
+    db.prepare('UPDATE reviews SET models_json = ?').run('{broken');
+
+    const result = getRecentReviews(db, 1);
+    expect(result.ok && result.data[0].models).toBeNull();
+    expect(result.ok && result.data[0].model_metadata_status).toBe('invalid');
+    expect(warning).toHaveBeenCalledWith(
+      '[codex-bridge] invalid model metadata found in stored review history',
+    );
+    expect(warning.mock.calls.flat().join(' ')).not.toContain('{broken');
+    warning.mockRestore();
+  });
+
+  it('keeps an old review snapshot immutable when the session owner identity changes', () => {
+    getOrCreateSession(db, 'immutable', 'codex');
+    saveReview(db, {
+      session_id: 'immutable',
+      type: 'plan',
+      verdict: 'approve',
+      summary: 'old model',
+      findings_json: '[]',
+      models_json: JSON.stringify([MODEL]),
+    });
+    db.prepare('UPDATE sessions SET model_identity_json = ? WHERE session_id = ?').run(
+      JSON.stringify({ ...MODEL, resolved: 'gpt-5.6-sol', observed: 'gpt-5.6-sol' }),
+      'immutable',
+    );
+
+    const result = getReviewsBySession(db, 'immutable');
+    expect(result.ok && result.data[0].models).toEqual([MODEL]);
   });
 });
 
@@ -163,6 +276,68 @@ describe('getRecentReviews', () => {
   });
 });
 
+describe('paginated history queries', () => {
+  beforeEach(() => {
+    for (let i = 1; i <= 5; i++) {
+      saveReview(db, {
+        session_id: 'paged',
+        type: 'plan',
+        verdict: 'approve',
+        summary: `Review ${i}`,
+        findings_json: '[]',
+        models_json: '[]',
+      });
+    }
+  });
+
+  it('paginates one session in stable oldest-first order without duplicates', () => {
+    const first = getReviewsBySessionPage(db, 'paged', { limit: 2 });
+    expect(first.ok && first.data.items.map((item) => item.summary)).toEqual([
+      'Review 1',
+      'Review 2',
+    ]);
+    expect(first.ok && first.data.nextCursor).not.toBeNull();
+
+    if (!first.ok || first.data.nextCursor === null) return;
+    const second = getReviewsBySessionPage(db, 'paged', {
+      limit: 2,
+      cursor: first.data.nextCursor,
+    });
+    expect(second.ok && second.data.items.map((item) => item.summary)).toEqual([
+      'Review 3',
+      'Review 4',
+    ]);
+
+    if (!second.ok || second.data.nextCursor === null) return;
+    const third = getReviewsBySessionPage(db, 'paged', {
+      limit: 2,
+      cursor: second.data.nextCursor,
+    });
+    expect(third.ok && third.data.items.map((item) => item.summary)).toEqual(['Review 5']);
+    expect(third.ok && third.data.nextCursor).toBeNull();
+  });
+
+  it('paginates recent history in stable newest-first order', () => {
+    const first = getRecentReviewsPage(db, { limit: 2 });
+    expect(first.ok && first.data.items.map((item) => item.summary)).toEqual([
+      'Review 5',
+      'Review 4',
+    ]);
+    if (!first.ok || first.data.nextCursor === null) return;
+
+    const second = getRecentReviewsPage(db, { limit: 2, cursor: first.data.nextCursor });
+    expect(second.ok && second.data.items.map((item) => item.summary)).toEqual([
+      'Review 3',
+      'Review 2',
+    ]);
+  });
+
+  it('rejects invalid limits and cursors instead of silently restarting a page', () => {
+    expect(getRecentReviewsPage(db, { limit: 0 }).ok).toBe(false);
+    expect(getRecentReviewsPage(db, { limit: 2, cursor: 'not-a-cursor' }).ok).toBe(false);
+  });
+});
+
 describe('provider provenance in history', () => {
   it('getReviewsBySession surfaces the session provider', () => {
     getOrCreateSession(db, 'thread_g', 'gemini');
@@ -223,9 +398,21 @@ describe('provider provenance in history', () => {
 describe('history rows satisfy ReviewHistoryEntrySchema', () => {
   it('getRecentReviews returns rows that parse (tagged + legacy)', () => {
     getOrCreateSession(db, 'thread_tagged', 'gemini');
-    saveReview(db, { session_id: 'thread_tagged', type: 'code', verdict: 'approve', summary: 'tagged', findings_json: '[]' });
+    saveReview(db, {
+      session_id: 'thread_tagged',
+      type: 'code',
+      verdict: 'approve',
+      summary: 'tagged',
+      findings_json: '[]',
+    });
     // No session row → provider joins as NULL (legacy).
-    saveReview(db, { session_id: 'orphan', type: 'plan', verdict: 'approve', summary: 'legacy', findings_json: '[]' });
+    saveReview(db, {
+      session_id: 'orphan',
+      type: 'plan',
+      verdict: 'approve',
+      summary: 'legacy',
+      findings_json: '[]',
+    });
 
     const result = getRecentReviews(db, 10);
     expect(result.ok).toBe(true);
@@ -240,7 +427,13 @@ describe('history rows satisfy ReviewHistoryEntrySchema', () => {
 
   it('getReviewsBySession returns rows that parse', () => {
     getOrCreateSession(db, 'thread_s', 'codex');
-    saveReview(db, { session_id: 'thread_s', type: 'precommit', verdict: 'approve', summary: 's', findings_json: '[]' });
+    saveReview(db, {
+      session_id: 'thread_s',
+      type: 'precommit',
+      verdict: 'approve',
+      summary: 's',
+      findings_json: '[]',
+    });
 
     const result = getReviewsBySession(db, 'thread_s');
     expect(result.ok).toBe(true);

--- a/src/storage/reviews.ts
+++ b/src/storage/reviews.ts
@@ -1,7 +1,8 @@
 import type Database from 'better-sqlite3';
+import { ModelIdentitySchema } from '../review/types.js';
+import type { ModelIdentity, ReviewHistoryEntry } from '../review/types.js';
 import { ok, err, ErrorCode } from '../utils/errors.js';
 import type { Result } from '../utils/errors.js';
-import type { ReviewHistoryEntry } from '../review/types.js';
 
 export interface SaveReviewInput {
   session_id: string;
@@ -9,9 +10,67 @@ export interface SaveReviewInput {
   verdict: string;
   summary: string;
   findings_json: string;
+  // Older callers omit this and intentionally produce a legacy-unrecorded row.
+  // New callers may pass an already-serialized snapshot or structural models.
+  models_json?: string | null;
+  models?: unknown;
 }
 
-export function initDb(db: Database.Database): void {
+export type ModelsMetadata =
+  | { status: 'recorded'; models: ModelIdentity[] }
+  | { status: 'legacy_unrecorded' }
+  | { status: 'invalid' };
+
+export interface ReviewPage {
+  items: ReviewHistoryEntry[];
+  nextCursor: string | null;
+}
+
+export interface ReviewPageOptions {
+  limit: number;
+  cursor?: string;
+}
+
+interface ReviewRow {
+  id: number;
+  session_id: string;
+  type: 'plan' | 'code' | 'precommit';
+  verdict: 'approve' | 'revise' | 'reject' | 'request_changes';
+  summary: string;
+  timestamp: string;
+  provider: string | null;
+  models_json: string | null;
+}
+
+export function parseModelsJson(value: string | null): ModelsMetadata {
+  if (value === null) return { status: 'legacy_unrecorded' };
+  try {
+    const parsed = ModelIdentitySchema.array().safeParse(JSON.parse(value));
+    return parsed.success ? { status: 'recorded', models: parsed.data } : { status: 'invalid' };
+  } catch {
+    return { status: 'invalid' };
+  }
+}
+
+function reviewColumns(db: Database.Database): Set<string> {
+  const rows = db.pragma('table_info(reviews)') as Array<{ name: string }>;
+  return new Set(rows.map((row) => row.name));
+}
+
+const REVIEW_SESSION_CURSOR_INDEX = 'reviews_session_id_id_idx';
+
+function verifySessionCursorIndex(db: Database.Database): void {
+  const rows = db.pragma(`index_info(${REVIEW_SESSION_CURSOR_INDEX})`) as Array<{
+    seqno: number;
+    name: string;
+  }>;
+  const actual = rows.sort((left, right) => left.seqno - right.seqno).map((row) => row.name);
+  if (actual.length !== 2 || actual[0] !== 'session_id' || actual[1] !== 'id') {
+    throw new Error('reviews migration verification failed: invalid session cursor index');
+  }
+}
+
+function initializeReviewsTable(db: Database.Database): void {
   db.exec(`
     CREATE TABLE IF NOT EXISTS reviews (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -20,16 +79,71 @@ export function initDb(db: Database.Database): void {
       verdict TEXT NOT NULL,
       summary TEXT NOT NULL,
       findings_json TEXT NOT NULL,
-      timestamp TEXT NOT NULL DEFAULT (datetime('now'))
+      timestamp TEXT NOT NULL DEFAULT (datetime('now')),
+      models_json TEXT
     )
   `);
+
+  let columns = reviewColumns(db);
+  if (!columns.has('models_json')) {
+    db.exec('ALTER TABLE reviews ADD COLUMN models_json TEXT');
+    columns = reviewColumns(db);
+  }
+  if (!columns.has('models_json')) {
+    throw new Error('reviews migration verification failed: missing models_json');
+  }
+
+  db.exec(`CREATE INDEX IF NOT EXISTS ${REVIEW_SESSION_CURSOR_INDEX} ON reviews(session_id, id)`);
+  verifySessionCursorIndex(db);
+}
+
+export function initDb(db: Database.Database): void {
+  if (db.inTransaction) {
+    initializeReviewsTable(db);
+    return;
+  }
+  db.exec('BEGIN IMMEDIATE');
+  try {
+    initializeReviewsTable(db);
+    db.exec('COMMIT');
+  } catch (error) {
+    if (db.inTransaction) db.exec('ROLLBACK');
+    throw error;
+  }
+}
+
+function modelsJsonFromInput(input: SaveReviewInput): Result<string | null> {
+  if (input.models_json !== undefined) {
+    if (input.models_json === null) return ok(null);
+    return parseModelsJson(input.models_json).status === 'recorded'
+      ? ok(input.models_json)
+      : err(`${ErrorCode.STORAGE_ERROR}: invalid models_json snapshot`);
+  }
+  if (input.models !== undefined) {
+    const parsed = ModelIdentitySchema.array().safeParse(input.models);
+    return parsed.success
+      ? ok(JSON.stringify(parsed.data))
+      : err(`${ErrorCode.STORAGE_ERROR}: invalid models snapshot`);
+  }
+  return ok(null);
 }
 
 export function saveReview(db: Database.Database, input: SaveReviewInput): Result<void> {
   try {
+    const modelsJson = modelsJsonFromInput(input);
+    if (!modelsJson.ok) return modelsJson;
     db.prepare(
-      'INSERT INTO reviews (session_id, type, verdict, summary, findings_json) VALUES (?, ?, ?, ?, ?)',
-    ).run(input.session_id, input.type, input.verdict, input.summary, input.findings_json);
+      `INSERT INTO reviews
+       (session_id, type, verdict, summary, findings_json, models_json)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run(
+      input.session_id,
+      input.type,
+      input.verdict,
+      input.summary,
+      input.findings_json,
+      modelsJson.data,
+    );
     return ok(undefined);
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
@@ -37,20 +151,110 @@ export function saveReview(db: Database.Database, input: SaveReviewInput): Resul
   }
 }
 
+function toHistoryEntry(row: ReviewRow): ReviewHistoryEntry {
+  const metadata = parseModelsJson(row.models_json);
+  const base = {
+    session_id: row.session_id,
+    type: row.type,
+    verdict: row.verdict,
+    summary: row.summary,
+    timestamp: row.timestamp,
+    provider: row.provider,
+  };
+  if (metadata.status === 'recorded') {
+    return { ...base, models: metadata.models, model_metadata_status: 'recorded' };
+  }
+  if (metadata.status === 'invalid') {
+    console.error('[codex-bridge] invalid model metadata found in stored review history');
+  }
+  return { ...base, models: null, model_metadata_status: metadata.status };
+}
+
+const HISTORY_SELECT = `
+  SELECT r.id, r.session_id, r.type, r.verdict, r.summary, r.timestamp,
+         r.models_json, s.provider
+  FROM reviews r
+  LEFT JOIN sessions s ON s.session_id = r.session_id`;
+
+function validatePageOptions(options: ReviewPageOptions): Result<number | null> {
+  if (!Number.isInteger(options.limit) || options.limit <= 0) {
+    return err(`${ErrorCode.INVALID_INPUT}: limit must be a positive integer`);
+  }
+  if (options.cursor === undefined) return ok(null);
+  if (!/^[1-9]\d*$/.test(options.cursor)) {
+    return err(`${ErrorCode.INVALID_INPUT}: invalid review cursor`);
+  }
+  const cursor = Number(options.cursor);
+  return Number.isSafeInteger(cursor)
+    ? ok(cursor)
+    : err(`${ErrorCode.INVALID_INPUT}: invalid review cursor`);
+}
+
+function pageFromRows(rows: ReviewRow[], limit: number): ReviewPage {
+  const hasMore = rows.length > limit;
+  const visible = hasMore ? rows.slice(0, limit) : rows;
+  return {
+    items: visible.map(toHistoryEntry),
+    nextCursor: hasMore ? String(visible[visible.length - 1].id) : null,
+  };
+}
+
+export function getReviewsBySessionPage(
+  db: Database.Database,
+  sessionId: string,
+  options: ReviewPageOptions,
+): Result<ReviewPage> {
+  try {
+    const cursor = validatePageOptions(options);
+    if (!cursor.ok) return cursor;
+    const rows =
+      cursor.data === null
+        ? db
+            .prepare(`${HISTORY_SELECT} WHERE r.session_id = ? ORDER BY r.id ASC LIMIT ?`)
+            .all(sessionId, options.limit + 1)
+        : db
+            .prepare(
+              `${HISTORY_SELECT} WHERE r.session_id = ? AND r.id > ? ORDER BY r.id ASC LIMIT ?`,
+            )
+            .all(sessionId, cursor.data, options.limit + 1);
+    return ok(pageFromRows(rows as ReviewRow[], options.limit));
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return err(`${ErrorCode.STORAGE_ERROR}: ${msg}`);
+  }
+}
+
+export function getRecentReviewsPage(
+  db: Database.Database,
+  options: ReviewPageOptions,
+): Result<ReviewPage> {
+  try {
+    const cursor = validatePageOptions(options);
+    if (!cursor.ok) return cursor;
+    const rows =
+      cursor.data === null
+        ? db.prepare(`${HISTORY_SELECT} ORDER BY r.id DESC LIMIT ?`).all(options.limit + 1)
+        : db
+            .prepare(`${HISTORY_SELECT} WHERE r.id < ? ORDER BY r.id DESC LIMIT ?`)
+            .all(cursor.data, options.limit + 1);
+    return ok(pageFromRows(rows as ReviewRow[], options.limit));
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return err(`${ErrorCode.STORAGE_ERROR}: ${msg}`);
+  }
+}
+
+// Compatibility queries retained for existing tool callers. New pagination
+// surfaces should use the keyset variants above.
 export function getReviewsBySession(
   db: Database.Database,
   sessionId: string,
 ): Result<ReviewHistoryEntry[]> {
   try {
     const rows = db
-      .prepare(
-        `SELECT r.session_id, r.type, r.verdict, r.summary, r.timestamp, s.provider
-         FROM reviews r
-         LEFT JOIN sessions s ON s.session_id = r.session_id
-         WHERE r.session_id = ? ORDER BY r.id ASC`,
-      )
-      .all(sessionId) as ReviewHistoryEntry[];
-    return ok(rows);
+      .prepare(`${HISTORY_SELECT} WHERE r.session_id = ? ORDER BY r.id ASC`)
+      .all(sessionId) as ReviewRow[];
+    return ok(rows.map(toHistoryEntry));
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
     return err(`${ErrorCode.STORAGE_ERROR}: ${msg}`);
@@ -61,18 +265,6 @@ export function getRecentReviews(
   db: Database.Database,
   limit: number,
 ): Result<ReviewHistoryEntry[]> {
-  try {
-    const rows = db
-      .prepare(
-        `SELECT r.session_id, r.type, r.verdict, r.summary, r.timestamp, s.provider
-         FROM reviews r
-         LEFT JOIN sessions s ON s.session_id = r.session_id
-         ORDER BY r.id DESC LIMIT ?`,
-      )
-      .all(limit) as ReviewHistoryEntry[];
-    return ok(rows);
-  } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e);
-    return err(`${ErrorCode.STORAGE_ERROR}: ${msg}`);
-  }
+  const page = getRecentReviewsPage(db, { limit });
+  return page.ok ? ok(page.data.items) : page;
 }

--- a/src/storage/session-registry.test.ts
+++ b/src/storage/session-registry.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createSessionRegistry } from './session-registry.js';
+import type { ModelIdentity } from '../review/types.js';
+
+const MODEL: ModelIdentity = {
+  provider: 'codex',
+  role: 'review',
+  requested: null,
+  resolved: 'gpt-5.6-sol',
+  observed: 'gpt-5.6-sol',
+  evidence: 'runtime_session_record',
+};
+
+describe('session registry admission', () => {
+  it('rejects overlapping work for the same session and releases the key', () => {
+    const registry = createSessionRegistry();
+    const first = registry.admit('session-1');
+    expect(first.ok).toBe(true);
+
+    const overlap = registry.admit('session-1');
+    expect(overlap.ok).toBe(false);
+    if (!overlap.ok) expect(overlap.error).toMatch(/^REVIEW_BUSY:/);
+
+    if (first.ok) first.data.release();
+    expect(registry.admit('session-1').ok).toBe(true);
+  });
+
+  it('permits four different logical reviews and rejects the fifth immediately', () => {
+    const registry = createSessionRegistry();
+    const admissions = ['a', 'b', 'c', 'd'].map((id) => registry.admit(id));
+    expect(admissions.every((entry) => entry.ok)).toBe(true);
+    const fifth = registry.admit('e');
+    expect(fifth.ok).toBe(false);
+    if (!fifth.ok) expect(fifth.error).toMatch(/^REVIEW_BUSY:/);
+  });
+
+  it('release is idempotent', () => {
+    const registry = createSessionRegistry();
+    const admission = registry.admit('session-1');
+    if (!admission.ok) throw new Error(admission.error);
+    admission.data.release();
+    admission.data.release();
+    expect(registry.activeCount()).toBe(0);
+  });
+});
+
+describe('session registry identity and eviction', () => {
+  it('exposes completed memory-only owner, model, and status', () => {
+    const registry = createSessionRegistry();
+    registry.complete('old-id', 'new-id', 'codex', MODEL);
+
+    expect(registry.lookupProvider('new-id')).toEqual({ status: 'found', value: 'codex' });
+    expect(registry.lookupModel('new-id')).toEqual({ status: 'found', value: MODEL });
+    expect(registry.getStatus('new-id')).toMatchObject({ status: 'completed', provider: 'codex' });
+    expect(registry.getStatus('old-id')).toMatchObject({ status: 'failed' });
+  });
+
+  it('never evicts an active entry and evicts the least-recent inactive entry', () => {
+    let now = 0;
+    const registry = createSessionRegistry({ maxEntries: 3, now: () => now });
+    const active = registry.admit('active');
+    registry.complete(undefined, 'oldest', 'codex', MODEL);
+    now += 1;
+    registry.complete(undefined, 'newer', 'codex', MODEL);
+    now += 1;
+    registry.complete(undefined, 'newest', 'codex', MODEL);
+
+    expect(registry.getStatus('active')).not.toBeNull();
+    expect(registry.getStatus('oldest')).toBeNull();
+    expect(registry.getStatus('newer')).not.toBeNull();
+    if (active.ok) active.data.release();
+  });
+
+  it('expires inactive entries after the TTL but retains active entries', () => {
+    let now = 0;
+    const registry = createSessionRegistry({ ttlMs: 10, now: () => now });
+    registry.complete(undefined, 'done', 'codex', MODEL);
+    const active = registry.admit('active');
+    now = 11;
+
+    expect(registry.getStatus('done')).toBeNull();
+    expect(registry.getStatus('active')).not.toBeNull();
+    if (active.ok) active.data.release();
+  });
+
+  it('does not hide durable ownership while an admitted entry has no owner yet', () => {
+    const registry = createSessionRegistry();
+    const admission = registry.admit('legacy-or-durable');
+    expect(registry.lookupProvider('legacy-or-durable')).toEqual({ status: 'absent' });
+    expect(registry.lookupModel('legacy-or-durable')).toEqual({ status: 'absent' });
+    if (admission.ok) admission.data.release();
+  });
+
+  it('marks a provider failure and always clears admission through finally-style release', () => {
+    const registry = createSessionRegistry();
+    const admission = registry.admit('session-1');
+    registry.fail('session-1');
+    if (admission.ok) admission.data.release();
+    expect(registry.getStatus('session-1')).toMatchObject({ status: 'failed' });
+    expect(registry.activeCount()).toBe(0);
+  });
+
+  it('uses the injected clock for deterministic status timing', () => {
+    const now = vi.fn(() => 5_000);
+    const registry = createSessionRegistry({ now });
+    const admission = registry.admit('session-1');
+    expect(registry.getStatus('session-1')?.startedAt).toBe(5_000);
+    if (admission.ok) admission.data.release();
+  });
+
+  it('seeds a resumed admission with its known durable owner', () => {
+    const registry = createSessionRegistry();
+    const admission = registry.admit('durable-owner', 'gemini');
+
+    expect(registry.lookupProvider('durable-owner')).toEqual({
+      status: 'found',
+      value: 'gemini',
+    });
+    registry.fail('durable-owner');
+    if (admission.ok) admission.data.release();
+    expect(registry.getStatus('durable-owner')).toMatchObject({
+      status: 'failed',
+      provider: 'gemini',
+    });
+  });
+});

--- a/src/storage/session-registry.ts
+++ b/src/storage/session-registry.ts
@@ -1,0 +1,187 @@
+import type { ReviewProvider } from '../config/types.js';
+import type { ModelIdentity } from '../review/types.js';
+import { err, ErrorCode, ok } from '../utils/errors.js';
+import type { Result } from '../utils/errors.js';
+
+const DEFAULT_MAX_ACTIVE = 4;
+const DEFAULT_MAX_ENTRIES = 1_024;
+const DEFAULT_TTL_MS = 24 * 60 * 60 * 1_000;
+
+export type RegistryLookup<T> = { status: 'found'; value: T } | { status: 'absent' };
+
+export interface RegistryStatus {
+  sessionId: string;
+  status: 'in_progress' | 'completed' | 'failed';
+  provider: ReviewProvider | null;
+  model: ModelIdentity | null;
+  startedAt: number;
+  completedAt: number | null;
+}
+
+interface RegistryEntry extends RegistryStatus {
+  active: boolean;
+  lastAccess: number;
+}
+
+export interface ReviewAdmission {
+  release(): void;
+}
+
+export interface SessionRegistry {
+  admit(
+    sessionId?: string,
+    provider?: ReviewProvider,
+    model?: ModelIdentity | null,
+  ): Result<ReviewAdmission>;
+  complete(
+    inputSessionId: string | undefined,
+    resultSessionId: string,
+    provider: ReviewProvider,
+    model: ModelIdentity | null,
+  ): void;
+  fail(...sessionIds: Array<string | undefined>): void;
+  discard(sessionId: string): void;
+  lookupProvider(sessionId: string): RegistryLookup<ReviewProvider>;
+  lookupModel(sessionId: string): RegistryLookup<ModelIdentity>;
+  getStatus(sessionId: string): RegistryStatus | null;
+  activeCount(): number;
+}
+
+export interface SessionRegistryOptions {
+  maxActive?: number;
+  maxEntries?: number;
+  ttlMs?: number;
+  now?: () => number;
+}
+
+export function createSessionRegistry(options: SessionRegistryOptions = {}): SessionRegistry {
+  const maxActive = options.maxActive ?? DEFAULT_MAX_ACTIVE;
+  const maxEntries = options.maxEntries ?? DEFAULT_MAX_ENTRIES;
+  const ttlMs = options.ttlMs ?? DEFAULT_TTL_MS;
+  const now = options.now ?? Date.now;
+  const entries = new Map<string, RegistryEntry>();
+  const admissionKeys = new Set<string>();
+  let active = 0;
+
+  const prune = (): void => {
+    const cutoff = now() - ttlMs;
+    for (const [id, entry] of entries) {
+      if (!entry.active && entry.lastAccess < cutoff) entries.delete(id);
+    }
+  };
+
+  const makeRoom = (incomingId: string): void => {
+    prune();
+    if (entries.has(incomingId) || entries.size < maxEntries) return;
+    let oldest: [string, RegistryEntry] | undefined;
+    for (const candidate of entries) {
+      if (candidate[1].active) continue;
+      if (!oldest || candidate[1].lastAccess < oldest[1].lastAccess) oldest = candidate;
+    }
+    if (oldest) entries.delete(oldest[0]);
+  };
+
+  const upsertStatus = (
+    sessionId: string,
+    status: RegistryStatus['status'],
+    provider?: ReviewProvider | null,
+    model?: ModelIdentity | null,
+  ): RegistryEntry => {
+    makeRoom(sessionId);
+    const timestamp = now();
+    const previous = entries.get(sessionId);
+    const entry: RegistryEntry = {
+      sessionId,
+      status,
+      provider: provider === undefined ? (previous?.provider ?? null) : provider,
+      model: model === undefined ? (previous?.model ?? null) : model,
+      startedAt: status === 'in_progress' ? timestamp : (previous?.startedAt ?? timestamp),
+      completedAt: status === 'in_progress' ? null : timestamp,
+      active: previous?.active ?? false,
+      lastAccess: timestamp,
+    };
+    entries.set(sessionId, entry);
+    return entry;
+  };
+
+  return {
+    admit(sessionId, provider, model) {
+      prune();
+      if (active >= maxActive) {
+        return err(`${ErrorCode.REVIEW_BUSY}: four reviews are already active`);
+      }
+      if (sessionId && admissionKeys.has(sessionId)) {
+        return err(`${ErrorCode.REVIEW_BUSY}: a review is already active for this session`);
+      }
+
+      active += 1;
+      if (sessionId) {
+        admissionKeys.add(sessionId);
+        const entry = upsertStatus(sessionId, 'in_progress', provider, model);
+        entry.active = true;
+      }
+
+      let released = false;
+      return ok({
+        release() {
+          if (released) return;
+          released = true;
+          active -= 1;
+          if (!sessionId) return;
+          admissionKeys.delete(sessionId);
+          const entry = entries.get(sessionId);
+          if (entry) {
+            entry.active = false;
+            entry.lastAccess = now();
+          }
+        },
+      });
+    },
+
+    complete(inputSessionId, resultSessionId, provider, model) {
+      if (inputSessionId && inputSessionId !== resultSessionId) {
+        upsertStatus(inputSessionId, 'failed');
+      }
+      const completed = upsertStatus(resultSessionId, 'completed', provider, model);
+      completed.active = inputSessionId === resultSessionId && admissionKeys.has(resultSessionId);
+    },
+
+    fail(...sessionIds) {
+      for (const sessionId of new Set(sessionIds.filter((id): id is string => Boolean(id)))) {
+        upsertStatus(sessionId, 'failed');
+      }
+    },
+
+    discard(sessionId) {
+      if (admissionKeys.has(sessionId)) return;
+      entries.delete(sessionId);
+    },
+
+    lookupProvider(sessionId) {
+      prune();
+      const entry = entries.get(sessionId);
+      if (!entry?.provider) return { status: 'absent' };
+      entry.lastAccess = now();
+      return { status: 'found', value: entry.provider };
+    },
+
+    lookupModel(sessionId) {
+      prune();
+      const entry = entries.get(sessionId);
+      if (!entry?.model) return { status: 'absent' };
+      entry.lastAccess = now();
+      return { status: 'found', value: entry.model };
+    },
+
+    getStatus(sessionId) {
+      prune();
+      const entry = entries.get(sessionId);
+      if (!entry) return null;
+      entry.lastAccess = now();
+      const { active: _active, lastAccess: _lastAccess, ...status } = entry;
+      return status;
+    },
+
+    activeCount: () => active,
+  };
+}

--- a/src/storage/session-routing.test.ts
+++ b/src/storage/session-routing.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createSessionRegistry } from './session-registry.js';
+import { createSessionRouting } from './session-routing.js';
+import type { ModelIdentity } from '../review/types.js';
+
+const MODEL: ModelIdentity = {
+  provider: 'gemini',
+  role: 'review',
+  requested: 'Gemini 3.5 Pro (High)',
+  resolved: 'Gemini 3.5 Pro (High)',
+  observed: null,
+  evidence: 'bridge_selection',
+};
+
+describe('session routing composition', () => {
+  it('prefers live registry ownership and identity over durable rows', () => {
+    const registry = createSessionRegistry();
+    registry.complete(undefined, 'live', 'gemini', MODEL);
+    const providerLookup = vi.fn().mockReturnValue({ status: 'found', value: 'codex' });
+    const modelLookup = vi
+      .fn()
+      .mockReturnValue({ status: 'found', value: { status: 'legacy_unrecorded' } });
+    const routing = createSessionRouting({
+      registry,
+      durability: 'durable',
+      providerLookup,
+      modelLookup,
+    });
+
+    expect(routing.lookupProvider('live')).toEqual({ status: 'found', value: 'gemini' });
+    expect(routing.lookupModel('live')).toEqual(MODEL);
+    expect(providerLookup).not.toHaveBeenCalled();
+    expect(modelLookup).not.toHaveBeenCalled();
+  });
+
+  it('falls back to durable ownership and recorded identity', () => {
+    const routing = createSessionRouting({
+      registry: createSessionRegistry(),
+      durability: 'durable',
+      providerLookup: () => ({ status: 'found', value: 'codex' }),
+      modelLookup: () => ({
+        status: 'found',
+        value: { status: 'recorded', model: { ...MODEL, provider: 'codex' } },
+      }),
+    });
+
+    expect(routing.lookupProvider('durable')).toEqual({ status: 'found', value: 'codex' });
+    expect(routing.lookupModel('durable')).toEqual({ ...MODEL, provider: 'codex' });
+  });
+
+  it('reports unavailable for unknown memory-only sessions instead of guessing a provider', () => {
+    const routing = createSessionRouting({
+      registry: createSessionRegistry(),
+      durability: 'memory_only',
+      providerLookup: () => ({ status: 'absent' }),
+      modelLookup: () => ({ status: 'found', value: { status: 'legacy_unrecorded' } }),
+    });
+
+    expect(routing.lookupProvider('unknown')).toEqual({ status: 'unavailable' });
+    expect(routing.lookupModel('unknown')).toBeNull();
+  });
+
+  it('fails closed on a durable miss after an unpersisted outcome survives registry eviction', () => {
+    let now = 0;
+    const registry = createSessionRegistry({ ttlMs: 10, now: () => now });
+    registry.complete(undefined, 'volatile-survivor', 'gemini', MODEL);
+    const providerLookup = vi.fn().mockReturnValue({ status: 'absent' });
+    const routing = createSessionRouting({
+      registry,
+      durability: 'durable',
+      providerLookup,
+      modelLookup: () => ({ status: 'absent' }),
+    });
+
+    routing.markOutcomePersistenceFailure('volatile-survivor');
+    expect(routing.lookupProvider('volatile-survivor')).toEqual({
+      status: 'found',
+      value: 'gemini',
+    });
+
+    now = 11;
+    expect(routing.lookupProvider('volatile-survivor')).toEqual({ status: 'unavailable' });
+    expect(routing.lookupProvider('unrelated-new')).toEqual({ status: 'absent' });
+    expect(routing.lookupResultSession('genuinely-new')).toEqual({ status: 'absent' });
+    expect(providerLookup).toHaveBeenCalledWith('volatile-survivor');
+  });
+
+  it('still routes durable rows after an outcome persistence failure', () => {
+    const routing = createSessionRouting({
+      registry: createSessionRegistry(),
+      durability: 'durable',
+      providerLookup: (sessionId) =>
+        sessionId === 'persisted' ? { status: 'found', value: 'codex' } : { status: 'absent' },
+      modelLookup: () => ({ status: 'absent' }),
+      maxTombstones: 1,
+    });
+
+    routing.markOutcomePersistenceFailure('persisted');
+    routing.markOutcomePersistenceFailure('volatile');
+
+    expect(routing.lookupProvider('persisted')).toEqual({ status: 'found', value: 'codex' });
+    expect(routing.lookupProvider('unrelated')).toEqual({ status: 'absent' });
+  });
+
+  it('preserves absent and legacy fallback for ids unrelated to an unpersisted outcome', () => {
+    const routing = createSessionRouting({
+      registry: createSessionRegistry(),
+      durability: 'durable',
+      providerLookup: (sessionId) =>
+        sessionId === 'legacy' ? { status: 'found', value: null } : { status: 'absent' },
+      modelLookup: () => ({ status: 'absent' }),
+    });
+
+    routing.markOutcomePersistenceFailure('volatile');
+
+    expect(routing.lookupProvider('volatile')).toEqual({ status: 'unavailable' });
+    expect(routing.lookupProvider('unrelated')).toEqual({ status: 'absent' });
+    expect(routing.lookupProvider('legacy')).toEqual({ status: 'found', value: null });
+  });
+
+  it('clears an exact tombstone after that result id is persisted', () => {
+    const routing = createSessionRouting({
+      registry: createSessionRegistry(),
+      durability: 'durable',
+      providerLookup: () => ({ status: 'absent' }),
+      modelLookup: () => ({ status: 'absent' }),
+    });
+    routing.markOutcomePersistenceFailure('recovered');
+    expect(routing.lookupProvider('recovered')).toEqual({ status: 'unavailable' });
+
+    routing.markOutcomePersisted('recovered');
+
+    expect(routing.lookupProvider('recovered')).toEqual({ status: 'absent' });
+  });
+
+  it('fails all ambiguous misses closed after a bounded tombstone is evicted', () => {
+    const routing = createSessionRouting({
+      registry: createSessionRegistry(),
+      durability: 'durable',
+      providerLookup: () => ({ status: 'absent' }),
+      modelLookup: () => ({ status: 'absent' }),
+      maxTombstones: 1,
+    });
+
+    routing.markOutcomePersistenceFailure('first');
+    routing.markOutcomePersistenceFailure('second');
+
+    expect(routing.lookupProvider('unrelated')).toEqual({ status: 'unavailable' });
+  });
+
+  it('keeps legacy/invalid model metadata unknown without substituting a default', () => {
+    for (const status of ['legacy_unrecorded', 'invalid'] as const) {
+      const routing = createSessionRouting({
+        registry: createSessionRegistry(),
+        durability: 'durable',
+        providerLookup: () => ({ status: 'found', value: 'codex' }),
+        modelLookup: () => ({ status: 'found', value: { status } }),
+      });
+      expect(routing.lookupModel(status)).toBeNull();
+    }
+  });
+});

--- a/src/storage/session-routing.ts
+++ b/src/storage/session-routing.ts
@@ -1,0 +1,133 @@
+import type { SessionProviderLookup } from '../backends/failover.js';
+import type { ModelIdentity } from '../review/types.js';
+import type { LookupResult, StorageDurability } from './db.js';
+import type { SessionModelMetadata } from './sessions.js';
+import type { SessionRegistry } from './session-registry.js';
+import type { ReviewProvider } from '../config/types.js';
+
+export interface SessionRoutingOptions {
+  registry: SessionRegistry;
+  durability: StorageDurability;
+  providerLookup: (sessionId: string) => LookupResult<ReviewProvider | null>;
+  modelLookup: (sessionId: string) => LookupResult<SessionModelMetadata>;
+  maxTombstones?: number;
+  tombstoneTtlMs?: number;
+  now?: () => number;
+}
+
+export interface SessionRouting {
+  lookupProvider: SessionProviderLookup;
+  lookupResultSession: SessionProviderLookup;
+  lookupModel(sessionId: string): ModelIdentity | null;
+  markOutcomePersistenceFailure(sessionId: string): void;
+  markOutcomePersisted(sessionId: string): void;
+}
+
+export function createSessionRouting(options: SessionRoutingOptions): SessionRouting {
+  const { registry, durability, providerLookup, modelLookup } = options;
+  const maxTombstones = Math.max(1, options.maxTombstones ?? 1_024);
+  const tombstoneTtlMs = options.tombstoneTtlMs ?? 24 * 60 * 60 * 1_000;
+  const now = options.now ?? Date.now;
+  const tombstones = new Map<string, number>();
+  let hasLostTombstone = false;
+
+  const pruneTombstones = (): void => {
+    const cutoff = now() - tombstoneTtlMs;
+    for (const [sessionId, lastAccess] of tombstones) {
+      if (lastAccess >= cutoff) continue;
+      tombstones.delete(sessionId);
+      hasLostTombstone = true;
+    }
+  };
+
+  const rememberTombstone = (sessionId: string): void => {
+    pruneTombstones();
+    if (tombstones.has(sessionId)) tombstones.delete(sessionId);
+    while (tombstones.size >= maxTombstones) {
+      const oldest = tombstones.keys().next().value as string | undefined;
+      if (oldest === undefined) break;
+      tombstones.delete(oldest);
+      hasLostTombstone = true;
+    }
+    tombstones.set(sessionId, now());
+  };
+
+  const hasTombstone = (sessionId: string): boolean => {
+    pruneTombstones();
+    if (!tombstones.has(sessionId)) return false;
+    tombstones.delete(sessionId);
+    tombstones.set(sessionId, now());
+    return true;
+  };
+
+  return {
+    lookupProvider(sessionId) {
+      const memory = registry.lookupProvider(sessionId);
+      if (memory.status === 'found') return memory;
+      if (durability === 'memory_only') return { status: 'unavailable' };
+      const persisted = providerLookup(sessionId);
+      if (persisted.status === 'unavailable') return persisted;
+      if (persisted.status === 'found' && persisted.value !== null) {
+        tombstones.delete(sessionId);
+        return persisted;
+      }
+      // An exact tombstone identifies a successful result that never reached
+      // durable storage. If bounded retention ever loses such an id, all raw
+      // absent/legacy misses become ambiguous and therefore fail closed.
+      if (hasTombstone(sessionId) || hasLostTombstone) {
+        return { status: 'unavailable' };
+      }
+      return persisted;
+    },
+
+    lookupResultSession(sessionId) {
+      const memory = registry.getStatus(sessionId);
+      if (memory) return { status: 'found', value: memory.provider };
+      // A configured in-memory database has no ownership beyond the registry,
+      // so registry absence is sufficient proof that a generated result id is
+      // fresh. Durable storage performs a raw existence lookup, then also
+      // rejects exact retained tombstones so an evicted unpersisted id cannot
+      // be reused as a supposedly fresh provider result.
+      if (durability === 'memory_only') return { status: 'absent' };
+      const persisted = providerLookup(sessionId);
+      if (persisted.status === 'unavailable') return persisted;
+      if (persisted.status === 'found' && persisted.value !== null) {
+        tombstones.delete(sessionId);
+        return persisted;
+      }
+      if (hasTombstone(sessionId) || hasLostTombstone) {
+        return { status: 'unavailable' };
+      }
+      return persisted;
+    },
+
+    lookupModel(sessionId) {
+      const memory = registry.lookupModel(sessionId);
+      if (memory.status === 'found') return memory.value;
+      if (durability === 'memory_only') return null;
+      const stored = modelLookup(sessionId);
+      if (stored.status !== 'found' || stored.value.status !== 'recorded') return null;
+      return stored.value.model;
+    },
+
+    markOutcomePersistenceFailure(sessionId) {
+      if (durability === 'memory_only') return;
+      try {
+        const persisted = providerLookup(sessionId);
+        // A resumed durable row still owns this id even though its latest
+        // history snapshot failed; registry eviction cannot misroute it.
+        if (persisted.status === 'found' && persisted.value !== null) {
+          tombstones.delete(sessionId);
+          return;
+        }
+      } catch {
+        // An unavailable existence check is ambiguous, so retain the id.
+      }
+      rememberTombstone(sessionId);
+    },
+
+    markOutcomePersisted(sessionId) {
+      tombstones.delete(sessionId);
+    },
+  };
+}

--- a/src/storage/session-tracker.integration.test.ts
+++ b/src/storage/session-tracker.integration.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import Database from 'better-sqlite3';
-import { createSessionTracker } from './session-tracker.js';
+import { checkSessionProvider, createSessionTracker } from './session-tracker.js';
 import { initSessionsDb, getOrCreateSession, getSession } from './sessions.js';
 import { initDb } from './reviews.js';
 
-// Real SQLite, no mocks. Reviews table is deliberately omitted so saveReview
-// fails — exercising the actual atomicity contract recordSuccess must satisfy.
+// Real SQLite, no mocks. Reviews table is deliberately omitted so the outcome
+// transaction fails after attempting session work.
 
 describe('createSessionTracker — recordSuccess atomicity (T-002)', () => {
   let db: Database.Database;
@@ -20,6 +20,7 @@ describe('createSessionTracker — recordSuccess atomicity (T-002)', () => {
   });
 
   it('does not mark session completed when saveReview fails (preflight path)', () => {
+    getOrCreateSession(db, 'sess_atomicity_preflight', 'codex');
     const tracker = createSessionTracker(db, ['codex'], 'codex');
     tracker.preflight('sess_atomicity_preflight');
 
@@ -39,7 +40,7 @@ describe('createSessionTracker — recordSuccess atomicity (T-002)', () => {
     expect(row?.status).toBe('in_progress');
   });
 
-  it('does not mark session completed when saveReview fails (fresh path)', () => {
+  it('rolls back creation entirely when saveReview fails (fresh path)', () => {
     const tracker = createSessionTracker(db, ['codex'], 'codex');
 
     tracker.recordSuccess('sess_atomicity_fresh', {
@@ -54,8 +55,27 @@ describe('createSessionTracker — recordSuccess atomicity (T-002)', () => {
       .prepare('SELECT status FROM sessions WHERE session_id = ?')
       .get('sess_atomicity_fresh') as { status: string } | undefined;
 
-    expect(row).toBeDefined();
-    expect(row?.status).toBe('in_progress');
+    expect(row).toBeUndefined();
+  });
+
+  it('rolls back a best-effort failure row when the terminal status update fails', () => {
+    db.exec(`
+      CREATE TRIGGER fail_failed_status
+      BEFORE UPDATE OF status ON sessions
+      WHEN NEW.status = 'failed'
+      BEGIN
+        SELECT RAISE(ABORT, 'injected failure status error');
+      END;
+    `);
+    const tracker = createSessionTracker(db, ['codex'], 'codex');
+    tracker.preflight('sess_best_effort_atomic');
+
+    expect(() => tracker.recordFailureBestEffort()).not.toThrow();
+
+    const row = db
+      .prepare('SELECT status FROM sessions WHERE session_id = ?')
+      .get('sess_best_effort_atomic');
+    expect(row).toBeUndefined();
   });
 });
 
@@ -98,14 +118,45 @@ describe('createSessionTracker — cross-provider resume guard (T-017)', () => {
     expect(result.ok).toBe(true);
   });
 
-  it('preflight on a session not yet in the DB persists its provider, so the guard holds on the next resume (m1)', () => {
-    // Backend session exists (in ~/.gemini) but no bridge row yet — the first
-    // touch is a resume under gemini. Pre-fix this persisted provider=NULL.
-    const first = createSessionTracker(db, ['gemini'], 'gemini').preflight('sess_new_resume');
+  it('still enforces provider mismatch on an unmigrated database', () => {
+    const legacy = new Database(':memory:');
+    legacy.exec(`
+      CREATE TABLE sessions (
+        session_id TEXT PRIMARY KEY,
+        status TEXT NOT NULL DEFAULT 'in_progress',
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        completed_at TEXT,
+        provider TEXT
+      );
+      INSERT INTO sessions (session_id, provider) VALUES ('legacy-gemini', 'gemini');
+    `);
+
+    const result = checkSessionProvider(legacy, 'legacy-gemini', ['codex']);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain('PROVIDER_MISMATCH');
+    legacy.close();
+  });
+
+  it('preflight is non-durable; successful outcome persists provider for the next guard', () => {
+    const tracker = createSessionTracker(db, ['gemini'], 'gemini');
+    const first = tracker.preflight('sess_new_resume');
     expect(first.ok).toBe(true);
 
-    const row = getSession(db, 'sess_new_resume');
-    expect(row.ok && row.data?.provider).toBe('gemini');
+    const before = getSession(db, 'sess_new_resume');
+    expect(before.ok && before.data).toBeNull();
+
+    const persisted = tracker.recordSuccess('sess_new_resume', {
+      session_id: 'sess_new_resume',
+      type: 'plan',
+      verdict: 'approve',
+      summary: 'done',
+      findings_json: '[]',
+      models_json: '[]',
+    });
+    expect(persisted.ok).toBe(true);
+    const after = getSession(db, 'sess_new_resume');
+    expect(after.ok && after.data?.provider).toBe('gemini');
 
     // A later resume of the same id under codex is now correctly rejected.
     const second = createSessionTracker(db, ['codex'], 'codex').preflight('sess_new_resume');

--- a/src/storage/session-tracker.test.ts
+++ b/src/storage/session-tracker.test.ts
@@ -1,36 +1,34 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createSessionTracker, checkSessionProvider } from './session-tracker.js';
 import { ok, err, ErrorCode } from '../utils/errors.js';
 
-vi.mock('./reviews.js', () => ({
-  saveReview: vi.fn(),
+vi.mock('./review-outcome.js', () => ({
+  recordReviewOutcome: vi.fn(),
 }));
 
 vi.mock('./sessions.js', () => ({
-  activateSession: vi.fn(),
   getOrCreateSession: vi.fn(),
-  getSession: vi.fn(),
-  markSessionCompleted: vi.fn(),
+  getSessionProvider: vi.fn(),
   markSessionFailed: vi.fn(),
 }));
 
-import { saveReview } from './reviews.js';
-import { activateSession, getOrCreateSession, getSession, markSessionCompleted, markSessionFailed } from './sessions.js';
+import { recordReviewOutcome } from './review-outcome.js';
+import { getOrCreateSession, getSessionProvider, markSessionFailed } from './sessions.js';
 
-// Minimal db stub: transaction(fn) returns a callable that invokes fn — matches
-// better-sqlite3's API surface that recordSuccess relies on for atomicity.
 const mockDb = {
-  transaction: <T>(fn: () => T) => () => fn(),
+  transaction:
+    <T>(fn: () => T) =>
+    () =>
+      fn(),
 } as never;
 
-beforeEach(() => {
-  vi.clearAllMocks();
-  vi.mocked(activateSession).mockReturnValue(ok({ session_id: 'sess_1', status: 'in_progress' as const, created_at: '2026-01-01', completed_at: null, provider: null }));
-  vi.mocked(getOrCreateSession).mockReturnValue(ok({ session_id: 'sess_1', status: 'in_progress' as const, created_at: '2026-01-01', completed_at: null, provider: null }));
-  vi.mocked(getSession).mockReturnValue(ok(null));
-  vi.mocked(markSessionCompleted).mockReturnValue(ok(undefined));
-  vi.mocked(markSessionFailed).mockReturnValue(ok(undefined));
-  vi.mocked(saveReview).mockReturnValue(ok(undefined));
+const session = (provider: string | null) => ({
+  session_id: 'sess_1',
+  status: 'completed' as const,
+  created_at: '2026-01-01',
+  completed_at: '2026-01-02',
+  provider,
+  model_identity_json: null,
 });
 
 const review = {
@@ -39,194 +37,140 @@ const review = {
   verdict: 'approve',
   summary: 'Looks good',
   findings_json: '[]',
+  models_json: '[]',
 };
 
-describe('checkSessionProvider — cross-provider guard (read-only, fail-open)', () => {
-  const row = (provider: string | null) =>
-    ok({ session_id: 's', status: 'completed' as const, created_at: 'x', completed_at: 'y', provider });
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getSessionProvider).mockReturnValue(ok(null));
+  vi.mocked(getOrCreateSession).mockReturnValue(ok(session(null)));
+  vi.mocked(markSessionFailed).mockReturnValue(ok(undefined));
+  vi.mocked(recordReviewOutcome).mockReturnValue(ok(undefined));
+});
 
-  it('fails open when db is undefined', () => {
+describe('checkSessionProvider — safe resume ownership guard', () => {
+  it('distinguishes unavailable lookup from absent or legacy ownership', () => {
+    // No database at all fails open (CLI without a reviews.db, ISS-018); only a
+    // database that exists but cannot be read is unavailable.
     expect(checkSessionProvider(undefined, 's', ['codex']).ok).toBe(true);
-    expect(getSession).not.toHaveBeenCalled();
-  });
-
-  it('fails open when sessionId is undefined', () => {
     expect(checkSessionProvider(mockDb, undefined, ['codex']).ok).toBe(true);
-  });
-
-  it('fails open when the session is unknown (no row)', () => {
-    vi.mocked(getSession).mockReturnValue(ok(null));
     expect(checkSessionProvider(mockDb, 's', ['codex']).ok).toBe(true);
-  });
-
-  it('fails open on a legacy row with a null provider', () => {
-    vi.mocked(getSession).mockReturnValue(row(null));
+    vi.mocked(getSessionProvider).mockReturnValue(ok({ provider: null }));
     expect(checkSessionProvider(mockDb, 's', ['codex']).ok).toBe(true);
-  });
-
-  it('fails open on a storage read error', () => {
-    vi.mocked(getSession).mockReturnValue(err(`${ErrorCode.STORAGE_ERROR}: boom`));
-    expect(checkSessionProvider(mockDb, 's', ['codex']).ok).toBe(true);
-  });
-
-  it('rejects when the owner is not among the active providers', () => {
-    vi.mocked(getSession).mockReturnValue(row('gemini'));
-    const res = checkSessionProvider(mockDb, 's', ['codex']);
-    expect(res.ok).toBe(false);
-    if (!res.ok) {
-      expect(res.error).toContain(ErrorCode.PROVIDER_MISMATCH);
-      expect(res.error).toContain('gemini');
+    vi.mocked(getSessionProvider).mockReturnValue(err(`${ErrorCode.STORAGE_ERROR}: boom`));
+    const readFailure = checkSessionProvider(mockDb, 's', ['codex']);
+    expect(readFailure.ok).toBe(false);
+    if (!readFailure.ok) {
+      expect(readFailure.error).toContain(ErrorCode.SESSION_ROUTING_UNAVAILABLE);
     }
   });
 
-  it('allows when the owner is a member of the active providers (composite)', () => {
-    vi.mocked(getSession).mockReturnValue(row('gemini'));
+  it('rejects a known foreign owner and allows an active owner', () => {
+    vi.mocked(getSessionProvider).mockReturnValue(ok({ provider: 'gemini' }));
+    const rejected = checkSessionProvider(mockDb, 's', ['codex']);
+    expect(rejected.ok).toBe(false);
+    if (!rejected.ok) expect(rejected.error).toContain(ErrorCode.PROVIDER_MISMATCH);
+
     expect(checkSessionProvider(mockDb, 's', ['codex', 'gemini']).ok).toBe(true);
   });
 
-  it('allows when the owner matches a single active provider', () => {
-    vi.mocked(getSession).mockReturnValue(row('codex'));
-    expect(checkSessionProvider(mockDb, 's', ['codex']).ok).toBe(true);
-  });
-});
+  it('treats an unrecognized stored owner as unavailable instead of guessing', () => {
+    vi.mocked(getSessionProvider).mockReturnValue(ok({ provider: 'future-provider' }));
 
-describe('createSessionTracker — null tracker (no db)', () => {
-  it('all methods are no-ops', () => {
-    const tracker = createSessionTracker(undefined, ['codex'], 'codex');
-    tracker.preflight('sess_1');
-    tracker.recordSuccess('sess_1', review);
-    tracker.recordFailure();
-    tracker.recordFailureBestEffort();
-
-    expect(activateSession).not.toHaveBeenCalled();
-    expect(getOrCreateSession).not.toHaveBeenCalled();
-    expect(saveReview).not.toHaveBeenCalled();
-    expect(markSessionCompleted).not.toHaveBeenCalled();
-    expect(markSessionFailed).not.toHaveBeenCalled();
-  });
-});
-
-describe('createSessionTracker — with db', () => {
-  it('preflight calls activateSession', () => {
-    const tracker = createSessionTracker(mockDb, ['codex'], 'codex');
-    tracker.preflight('sess_1');
-
-    expect(activateSession).toHaveBeenCalledWith(mockDb, 'sess_1', 'codex');
-  });
-
-  it('preflight skips when sessionId is undefined', () => {
-    const tracker = createSessionTracker(mockDb, ['codex'], 'codex');
-    tracker.preflight(undefined);
-
-    expect(activateSession).not.toHaveBeenCalled();
-  });
-
-  it('preflight does not set tracking ID when activateSession fails', () => {
-    vi.mocked(activateSession).mockReturnValue(err('STORAGE_ERROR: readonly'));
-    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-
-    const tracker = createSessionTracker(mockDb, ['codex'], 'codex');
-    tracker.preflight('sess_1');
-    tracker.recordFailure();
-
-    expect(markSessionFailed).not.toHaveBeenCalled();
-    consoleSpy.mockRestore();
-  });
-
-  it('recordSuccess without preflight calls getOrCreateSession + saveReview + markSessionCompleted', () => {
-    const tracker = createSessionTracker(mockDb, ['codex'], 'codex');
-    tracker.recordSuccess('sess_1', review);
-
-    expect(getOrCreateSession).toHaveBeenCalledWith(mockDb, 'sess_1', 'codex');
-    expect(saveReview).toHaveBeenCalledWith(mockDb, review);
-    expect(markSessionCompleted).toHaveBeenCalledWith(mockDb, 'sess_1');
-  });
-
-  it('recordSuccess with preflight skips getOrCreateSession and uses preflightId for complete', () => {
-    const tracker = createSessionTracker(mockDb, ['codex'], 'codex');
-    tracker.preflight('sess_preflight');
-    tracker.recordSuccess('sess_codex', review);
-
-    expect(getOrCreateSession).not.toHaveBeenCalled();
-    expect(saveReview).toHaveBeenCalledWith(mockDb, review);
-    expect(markSessionCompleted).toHaveBeenCalledWith(mockDb, 'sess_preflight');
-  });
-
-  it('recordFailure calls markSessionFailed with preflightId', () => {
-    const tracker = createSessionTracker(mockDb, ['codex'], 'codex');
-    tracker.preflight('sess_1');
-    tracker.recordFailure();
-
-    expect(markSessionFailed).toHaveBeenCalledWith(mockDb, 'sess_1');
-  });
-
-  it('recordFailure is no-op without preflight', () => {
-    const tracker = createSessionTracker(mockDb, ['codex'], 'codex');
-    tracker.recordFailure();
-
-    expect(markSessionFailed).not.toHaveBeenCalled();
-  });
-
-  it('recordFailureBestEffort swallows errors', () => {
-    vi.mocked(markSessionFailed).mockImplementation(() => { throw new Error('db closed'); });
-
-    const tracker = createSessionTracker(mockDb, ['codex'], 'codex');
-    tracker.preflight('sess_1');
-
-    expect(() => tracker.recordFailureBestEffort()).not.toThrow();
-  });
-});
-
-describe('cross-provider resume guard', () => {
-  const sessionRow = (provider: string | null) =>
-    ok({
-      session_id: 'sess_x',
-      status: 'completed' as const,
-      created_at: '2026-01-01',
-      completed_at: '2026-01-02',
-      provider,
-    });
-
-  it('rejects resuming a session created by a different provider', () => {
-    vi.mocked(getSession).mockReturnValue(sessionRow('gemini'));
-    const tracker = createSessionTracker(mockDb, ['codex'], 'codex');
-
-    const result = tracker.preflight('sess_x');
+    const result = checkSessionProvider(mockDb, 's', ['codex', 'gemini']);
 
     expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.error).toContain('PROVIDER_MISMATCH');
-      expect(result.error).toContain('gemini');
-      expect(result.error).toContain('codex');
-    }
-    // A rejected resume must not mutate session state.
-    expect(activateSession).not.toHaveBeenCalled();
+    if (!result.ok) expect(result.error).toContain(ErrorCode.SESSION_ROUTING_UNAVAILABLE);
+  });
+});
+
+describe('createSessionTracker', () => {
+  it('uses a no-op Result-returning tracker without a database', () => {
+    const tracker = createSessionTracker(undefined, ['codex'], 'codex');
+    expect(tracker.preflight('sess_1')).toEqual(ok(undefined));
+    expect(tracker.recordSuccess('sess_1', review)).toEqual(ok(undefined));
+    tracker.recordFailure();
+    tracker.recordFailureBestEffort();
+    expect(recordReviewOutcome).not.toHaveBeenCalled();
+    expect(markSessionFailed).not.toHaveBeenCalled();
   });
 
-  it('allows resuming a session created by the same provider', () => {
-    vi.mocked(getSession).mockReturnValue(sessionRow('codex'));
+  it('preflight is read-only and does not durably activate or create the session', () => {
     const tracker = createSessionTracker(mockDb, ['codex'], 'codex');
 
-    const result = tracker.preflight('sess_x');
+    expect(tracker.preflight('sess_1')).toEqual(ok(undefined));
 
-    expect(result.ok).toBe(true);
-    expect(activateSession).toHaveBeenCalledWith(mockDb, 'sess_x', 'codex');
+    expect(getSessionProvider).toHaveBeenCalledWith(mockDb, 'sess_1');
+    expect(getOrCreateSession).not.toHaveBeenCalled();
+    expect(markSessionFailed).not.toHaveBeenCalled();
   });
 
-  it('allows resuming a legacy session with a null provider', () => {
-    vi.mocked(getSession).mockReturnValue(sessionRow(null));
-    const tracker = createSessionTracker(mockDb, ['gemini'], 'gemini');
+  it('passes preflight and returned ids to the atomic outcome operation', () => {
+    vi.mocked(getSessionProvider).mockReturnValue(ok({ provider: 'codex' }));
+    const tracker = createSessionTracker(mockDb, ['codex'], 'codex');
+    tracker.preflight('owner');
 
-    const result = tracker.preflight('sess_x');
+    const result = tracker.recordSuccess('survivor', review, 'gemini', { provider: 'gemini' });
 
-    expect(result.ok).toBe(true);
-    expect(activateSession).toHaveBeenCalledWith(mockDb, 'sess_x', 'gemini');
+    expect(result).toEqual(ok(undefined));
+    expect(recordReviewOutcome).toHaveBeenCalledWith(mockDb, {
+      preflightSessionId: 'owner',
+      preflightProvider: 'codex',
+      resultSessionId: 'survivor',
+      servingProvider: 'gemini',
+      ownerModelIdentity: { provider: 'gemini' },
+      review,
+    });
   });
 
-  it('tags a freshly created session with the active provider', () => {
-    const tracker = createSessionTracker(mockDb, ['gemini'], 'gemini');
-    tracker.recordSuccess('sess_new', review);
+  it('returns a persistence error from recordSuccess to the caller', () => {
+    vi.mocked(recordReviewOutcome).mockReturnValue(err('STORAGE_ERROR: readonly'));
+    const tracker = createSessionTracker(mockDb, ['codex'], 'codex');
 
-    expect(getOrCreateSession).toHaveBeenCalledWith(mockDb, 'sess_new', 'gemini');
+    expect(tracker.recordSuccess('sess_1', review)).toEqual(err('STORAGE_ERROR: readonly'));
+  });
+
+  it('rejects a foreign resume without remembering it for later mutation', () => {
+    vi.mocked(getSessionProvider).mockReturnValue(ok({ provider: 'gemini' }));
+    const tracker = createSessionTracker(mockDb, ['codex'], 'codex');
+
+    expect(tracker.preflight('foreign').ok).toBe(false);
+    tracker.recordFailure();
+
+    expect(markSessionFailed).not.toHaveBeenCalled();
+  });
+
+  it('marks the preflight owner failed after a provider error without pre-activation', () => {
+    vi.mocked(getSessionProvider).mockReturnValue(ok({ provider: 'codex' }));
+    const tracker = createSessionTracker(mockDb, ['codex'], 'codex');
+    tracker.preflight('owner');
+
+    tracker.recordFailure();
+
+    expect(getOrCreateSession).toHaveBeenCalledWith(mockDb, 'owner', 'codex');
+    expect(markSessionFailed).toHaveBeenCalledWith(mockDb, 'owner');
+  });
+
+  it('atomically creates and fails a fresh partial provider session', () => {
+    const transaction = vi.fn((fn: () => void) => fn);
+    const dbWithTransaction = { transaction } as never;
+    const tracker = createSessionTracker(dbWithTransaction, ['codex'], 'codex');
+
+    tracker.recordFailure('partial-thread');
+
+    expect(getOrCreateSession).toHaveBeenCalledWith(dbWithTransaction, 'partial-thread', 'codex');
+    expect(markSessionFailed).toHaveBeenCalledWith(dbWithTransaction, 'partial-thread');
+  });
+
+  it('recordFailureBestEffort swallows a closed-db throw', () => {
+    vi.mocked(getSessionProvider).mockReturnValue(ok({ provider: 'codex' }));
+    vi.mocked(markSessionFailed).mockImplementation(() => {
+      throw new Error('closed');
+    });
+    const tracker = createSessionTracker(mockDb, ['codex'], 'codex');
+    tracker.preflight('owner');
+
+    expect(() => tracker.recordFailureBestEffort()).not.toThrow();
+    expect(getOrCreateSession).toHaveBeenCalledWith(mockDb, 'owner', 'codex');
   });
 });

--- a/src/storage/session-tracker.ts
+++ b/src/storage/session-tracker.ts
@@ -1,9 +1,12 @@
 import type Database from 'better-sqlite3';
 import type { SaveReviewInput } from './reviews.js';
-import { saveReview } from './reviews.js';
-import { activateSession, getOrCreateSession, getSession, markSessionCompleted, markSessionFailed } from './sessions.js';
+import { getOrCreateSession, getSessionProvider, markSessionFailed } from './sessions.js';
+import { recordReviewOutcome } from './review-outcome.js';
 import { ok, err, ErrorCode } from '../utils/errors.js';
 import type { Result } from '../utils/errors.js';
+import { escapeTerminalControls } from '../utils/terminal.js';
+import type { ReviewProvider } from '../config/types.js';
+import { toReviewProvider } from '../config/types.js';
 
 export interface SessionTracker {
   // Returns an error when the resumed session was created by a different
@@ -13,7 +16,12 @@ export interface SessionTracker {
   // (may differ from the tracker's configured provider under failover). It tags
   // a NEW session's provenance so a failed-over session is owned by the provider
   // that served it. Falls back to the configured provider when omitted.
-  recordSuccess(resultSessionId: string, review: SaveReviewInput, servingProvider?: string): void;
+  recordSuccess(
+    resultSessionId: string,
+    review: SaveReviewInput,
+    servingProvider?: ReviewProvider,
+    ownerModelIdentity?: unknown,
+  ): Result<void>;
   // sessionId surfaces partial-chunk failures where chunk 1 created a
   // Codex thread but a later chunk errored — the tool layer must mark
   // that thread's session failed rather than orphaning it (T-001).
@@ -23,110 +31,107 @@ export interface SessionTracker {
 
 const NULL_TRACKER: SessionTracker = {
   preflight: () => ok(undefined),
-  recordSuccess() {},
+  recordSuccess: () => ok(undefined),
   recordFailure() {},
   recordFailureBestEffort() {},
 };
 
-// Read-only cross-provider guard: a session created by one provider cannot be
-// resumed under a backend that doesn't serve that provider (their thread/
-// conversation ids are not interchangeable). Fails OPEN — returns ok when there
-// is no db, no session id, a read error, or an unknown/legacy-null owner — so a
-// guard we can't evaluate never blocks a review. Shared by the MCP tracker
-// (below) and the CLI, which has no tracker/recording of its own.
+// Read-only cross-provider guard. An absent/legacy row may fall back to the
+// configured primary, but an unavailable lookup cannot safely guess which
+// provider owns the conversation.
+function inspectSessionProvider(
+  db: Database.Database | undefined,
+  sessionId: string | undefined,
+  providers: readonly string[],
+): Result<ReviewProvider | null> {
+  if (typeof sessionId !== 'string') return ok(null);
+  // No shared database at all (CLI run without a reviews.db, ISS-018) is not a
+  // failed lookup: there is nothing to consult, so the guard fails OPEN and the
+  // backend resolves routing itself. A database we HAVE but cannot read is the
+  // unsafe case below.
+  if (!db) return ok(null);
+  let existing: ReturnType<typeof getSessionProvider>;
+  try {
+    existing = getSessionProvider(db, sessionId);
+  } catch {
+    return err(
+      `${ErrorCode.SESSION_ROUTING_UNAVAILABLE}: session ownership could not be established safely`,
+    );
+  }
+  if (!existing.ok) {
+    return err(
+      `${ErrorCode.SESSION_ROUTING_UNAVAILABLE}: session ownership could not be established safely`,
+    );
+  }
+  if (!existing.data?.provider) return ok(null);
+  const storedOwner = existing.data.provider;
+  const owner = toReviewProvider(storedOwner);
+  if (!owner) {
+    return err(
+      `${ErrorCode.SESSION_ROUTING_UNAVAILABLE}: session ownership could not be established safely`,
+    );
+  }
+  if (!providers.includes(owner)) {
+    return err(
+      `${ErrorCode.PROVIDER_MISMATCH}: session ${sessionId} was created by the '${storedOwner}' provider, ` +
+        `which is not active (available: ${providers.join(', ')}). Start a new session, or configure ` +
+        `the '${storedOwner}' provider to continue this one.`,
+    );
+  }
+  return ok(owner);
+}
+
 export function checkSessionProvider(
   db: Database.Database | undefined,
   sessionId: string | undefined,
   providers: readonly string[],
 ): Result<void> {
-  if (!db || typeof sessionId !== 'string') return ok(undefined);
-  // getSession is already Result-safe, but guard against any future throw so the
-  // fail-open contract holds no matter what the read does.
-  let existing: ReturnType<typeof getSession>;
-  try {
-    existing = getSession(db, sessionId);
-  } catch {
-    return ok(undefined);
-  }
-  if (!existing.ok || !existing.data || !existing.data.provider) return ok(undefined);
-  const owner = existing.data.provider;
-  if (!providers.includes(owner)) {
-    return err(
-      `${ErrorCode.PROVIDER_MISMATCH}: session ${sessionId} was created by the '${owner}' provider, ` +
-        `which is not active (available: ${providers.join(', ')}). Start a new session, or configure ` +
-        `the '${owner}' provider to continue this one.`,
-    );
-  }
-  return ok(undefined);
+  const inspected = inspectSessionProvider(db, sessionId, providers);
+  return inspected.ok ? ok(undefined) : inspected;
 }
 
 // providers is the guard set (every provider this backend serves); taggingProvider
 // is the provider stamped on NEW sessions (a composite presents as its primary).
 export function createSessionTracker(
   db: Database.Database | undefined,
-  providers: readonly string[],
-  taggingProvider: string,
+  providers: readonly ReviewProvider[],
+  taggingProvider: ReviewProvider,
 ): SessionTracker {
   if (!db) return NULL_TRACKER;
 
   let preflightId: string | undefined;
+  let preflightProvider: ReviewProvider | undefined;
 
   return {
     preflight(sessionId) {
       if (typeof sessionId !== 'string') return ok(undefined);
-      // Cross-provider guard runs before activateSession so a rejected resume
-      // never mutates the session's state.
-      const guard = checkSessionProvider(db, sessionId, providers);
+      // Preflight is deliberately read-only. Persisting an in-progress row here
+      // would claim durable state before the provider has produced anything and
+      // would leave stale rows when the review or storage later fails.
+      const guard = inspectSessionProvider(db, sessionId, providers);
       if (!guard.ok) return guard;
-      const result = activateSession(db, sessionId, taggingProvider);
-      if (result.ok) {
-        preflightId = sessionId;
-      } else {
-        console.error(`Failed to activate session: ${result.error}`);
-      }
+      preflightId = sessionId;
+      preflightProvider = guard.data ?? taggingProvider;
       return ok(undefined);
     },
 
-    recordSuccess(resultSessionId, review, servingProvider) {
-      if (!preflightId) {
-        // Fresh review: tag provenance with the provider that actually served
-        // (failover may have switched it), defaulting to the configured one.
-        const sessionResult = getOrCreateSession(db, resultSessionId, servingProvider ?? taggingProvider);
-        if (!sessionResult.ok) {
-          console.error(`Failed to track session: ${sessionResult.error}`);
-        }
-      }
-      const completeId = preflightId ?? resultSessionId;
-      // saveReview and markSessionCompleted must succeed or fail together —
-      // otherwise a save failure would leave the session marked complete with
-      // no review row, producing inconsistent state across review_history /
-      // review_status.
-      try {
-        db.transaction(() => {
-          const saveResult = saveReview(db, review);
-          if (!saveResult.ok) throw new Error(saveResult.error);
-          const completeResult = markSessionCompleted(db, completeId);
-          if (!completeResult.ok) throw new Error(completeResult.error);
-        })();
-      } catch (e) {
-        console.error(`recordSuccess transaction failed: ${e instanceof Error ? e.message : String(e)}`);
-      }
+    recordSuccess(resultSessionId, review, servingProvider, ownerModelIdentity) {
+      return recordReviewOutcome(db, {
+        preflightSessionId: preflightId,
+        preflightProvider,
+        resultSessionId,
+        servingProvider: servingProvider ?? taggingProvider,
+        ownerModelIdentity,
+        review,
+      });
     },
 
     recordFailure(sessionId) {
       const id = preflightId ?? sessionId;
       if (!id) return;
-      // Preflight path: row already exists from activateSession — single UPDATE.
-      if (preflightId) {
-        const failResult = markSessionFailed(db, preflightId);
-        if (!failResult.ok) {
-          console.error(`Failed to mark session failed: ${failResult.error}`);
-        }
-        return;
-      }
-      // Fresh-session path (T-001): chunk 1 created a Codex thread but no DB
-      // row exists. Create-then-fail must be atomic so we never persist a row
-      // that's missing the failed status.
+      // No row is created during preflight. Once the provider actually fails,
+      // create-if-absent and mark failed atomically so review_status still has a
+      // durable terminal state for both resumed and fresh partial sessions.
       try {
         db.transaction(() => {
           const sessionResult = getOrCreateSession(db, id, taggingProvider);
@@ -135,13 +140,25 @@ export function createSessionTracker(
           if (!failResult.ok) throw new Error(failResult.error);
         })();
       } catch (e) {
-        console.error(`recordFailure transaction failed: ${e instanceof Error ? e.message : String(e)}`);
+        console.error(
+          `recordFailure transaction failed: ${escapeTerminalControls(e instanceof Error ? e.message : String(e))}`,
+        );
       }
     },
 
     recordFailureBestEffort() {
       if (!preflightId) return;
-      try { markSessionFailed(db, preflightId); } catch { /* best-effort */ }
+      const id = preflightId;
+      try {
+        db.transaction(() => {
+          const sessionResult = getOrCreateSession(db, id, taggingProvider);
+          if (!sessionResult.ok) throw new Error(sessionResult.error);
+          const failResult = markSessionFailed(db, id);
+          if (!failResult.ok) throw new Error(failResult.error);
+        })();
+      } catch {
+        /* best-effort */
+      }
     },
   };
 }

--- a/src/storage/sessions.test.ts
+++ b/src/storage/sessions.test.ts
@@ -4,6 +4,7 @@ import {
   initSessionsDb,
   getOrCreateSession,
   getSession,
+  getSessionProvider,
   markSessionCompleted,
   markSessionFailed,
   activateSession,
@@ -28,6 +29,14 @@ describe('initSessionsDb', () => {
     expect(() => initSessionsDb(db)).not.toThrow();
   });
 
+  it('creates the nullable model identity column', () => {
+    const columns = db.pragma('table_info(sessions)') as Array<{ name: string }>;
+    expect(columns.map((column) => column.name)).toContain('model_identity_json');
+
+    const result = getOrCreateSession(db, 'model-null');
+    expect(result.ok && result.data.model_identity_json).toBeNull();
+  });
+
   it('migrates old schema by adding completed_at column', () => {
     const oldDb = new Database(':memory:');
     oldDb.exec(`
@@ -46,6 +55,30 @@ describe('initSessionsDb', () => {
       .prepare('SELECT completed_at FROM sessions WHERE session_id = ?')
       .get('test') as { completed_at: string | null };
     expect(row.completed_at).toBeNull();
+  });
+
+  it('migrates a populated schema with model identity null without changing existing fields', () => {
+    const oldDb = new Database(':memory:');
+    oldDb.exec(`
+      CREATE TABLE sessions (
+        session_id TEXT PRIMARY KEY,
+        status TEXT NOT NULL DEFAULT 'in_progress',
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        completed_at TEXT,
+        provider TEXT
+      );
+      INSERT INTO sessions (session_id, status, provider)
+      VALUES ('legacy-model', 'completed', 'codex');
+    `);
+
+    initSessionsDb(oldDb);
+
+    expect(
+      oldDb
+        .prepare('SELECT status, provider, model_identity_json FROM sessions WHERE session_id = ?')
+        .get('legacy-model'),
+    ).toEqual({ status: 'completed', provider: 'codex', model_identity_json: null });
+    oldDb.close();
   });
 });
 
@@ -283,7 +316,9 @@ describe('provider provenance', () => {
         completed_at TEXT
       )
     `);
-    oldDb.prepare("INSERT INTO sessions (session_id, status) VALUES (?, 'completed')").run('legacy-1');
+    oldDb
+      .prepare("INSERT INTO sessions (session_id, status) VALUES (?, 'completed')")
+      .run('legacy-1');
 
     expect(() => initSessionsDb(oldDb)).not.toThrow();
 
@@ -311,5 +346,27 @@ describe('getSession', () => {
     const result = getSession(db, 'nope');
     expect(result.ok).toBe(true);
     if (result.ok) expect(result.data).toBeNull();
+  });
+});
+
+describe('getSessionProvider', () => {
+  it('reads provider without requiring the model metadata column', () => {
+    const legacy = new Database(':memory:');
+    legacy.exec(`
+      CREATE TABLE sessions (
+        session_id TEXT PRIMARY KEY,
+        status TEXT NOT NULL DEFAULT 'in_progress',
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        completed_at TEXT,
+        provider TEXT
+      );
+      INSERT INTO sessions (session_id, provider) VALUES ('legacy', 'gemini');
+    `);
+
+    expect(getSessionProvider(legacy, 'legacy')).toEqual({
+      ok: true,
+      data: { provider: 'gemini' },
+    });
+    legacy.close();
   });
 });

--- a/src/storage/sessions.ts
+++ b/src/storage/sessions.ts
@@ -1,6 +1,8 @@
 import type Database from 'better-sqlite3';
 import { ok, err, ErrorCode } from '../utils/errors.js';
 import type { Result } from '../utils/errors.js';
+import { ModelIdentitySchema } from '../review/types.js';
+import type { ModelIdentity } from '../review/types.js';
 
 export interface SessionInfo {
   session_id: string;
@@ -10,44 +12,94 @@ export interface SessionInfo {
   // Which review provider created this session ('codex' | 'gemini'). A plain
   // TEXT tag — storage stays backend-agnostic. Null for legacy rows.
   provider: string | null;
+  // Owner-conversation identity. Null for legacy/unrecorded sessions. Kept as
+  // JSON in the row so storage remains an immutable persistence boundary.
+  model_identity_json?: string | null;
 }
 
-export function initSessionsDb(db: Database.Database): void {
+export type SessionModelMetadata =
+  | { status: 'recorded'; model: ModelIdentity }
+  | { status: 'legacy_unrecorded' }
+  | { status: 'invalid' };
+
+export function parseSessionModelIdentityJson(
+  value: string | null,
+  expectedProvider?: string | null,
+): SessionModelMetadata {
+  if (value === null) return { status: 'legacy_unrecorded' };
+  try {
+    const parsed = ModelIdentitySchema.safeParse(JSON.parse(value));
+    if (!parsed.success || parsed.data.role !== 'review') return { status: 'invalid' };
+    if (expectedProvider !== undefined && parsed.data.provider !== expectedProvider) {
+      return { status: 'invalid' };
+    }
+    return { status: 'recorded', model: parsed.data };
+  } catch {
+    return { status: 'invalid' };
+  }
+}
+
+function sessionColumns(db: Database.Database): Set<string> {
+  const rows = db.pragma('table_info(sessions)') as Array<{ name: string }>;
+  return new Set(rows.map((row) => row.name));
+}
+
+function initializeSessionsTable(db: Database.Database): void {
   db.exec(`
     CREATE TABLE IF NOT EXISTS sessions (
       session_id TEXT PRIMARY KEY,
       status TEXT NOT NULL DEFAULT 'in_progress',
       created_at TEXT NOT NULL DEFAULT (datetime('now')),
       completed_at TEXT,
-      provider TEXT
+      provider TEXT,
+      model_identity_json TEXT
     )
   `);
-  // Migrations for databases created before these columns existed. Each ALTER
-  // throws if the column is already present — expected for new databases.
-  for (const ddl of [
-    'ALTER TABLE sessions ADD COLUMN completed_at TEXT',
-    'ALTER TABLE sessions ADD COLUMN provider TEXT',
-  ]) {
-    try {
+
+  const migrations = [
+    ['completed_at', 'ALTER TABLE sessions ADD COLUMN completed_at TEXT'],
+    ['provider', 'ALTER TABLE sessions ADD COLUMN provider TEXT'],
+    ['model_identity_json', 'ALTER TABLE sessions ADD COLUMN model_identity_json TEXT'],
+  ] as const;
+  let columns = sessionColumns(db);
+  for (const [name, ddl] of migrations) {
+    if (!columns.has(name)) {
       db.exec(ddl);
-    } catch {
-      // Column already exists.
+      columns = sessionColumns(db);
     }
+  }
+  for (const [name] of migrations) {
+    if (!columns.has(name))
+      throw new Error(`sessions migration verification failed: missing ${name}`);
+  }
+}
+
+export function initSessionsDb(db: Database.Database): void {
+  if (db.inTransaction) {
+    initializeSessionsTable(db);
+    return;
+  }
+  db.exec('BEGIN IMMEDIATE');
+  try {
+    initializeSessionsTable(db);
+    db.exec('COMMIT');
+  } catch (error) {
+    if (db.inTransaction) db.exec('ROLLBACK');
+    throw error;
   }
 }
 
 const SELECT_SESSION =
-  'SELECT session_id, status, created_at, completed_at, provider FROM sessions WHERE session_id = ?';
+  'SELECT session_id, status, created_at, completed_at, provider, model_identity_json FROM sessions WHERE session_id = ?';
 
 export function getOrCreateSession(
   db: Database.Database,
   sessionId: string,
   provider?: string,
+  modelIdentityJson?: string | null,
 ): Result<SessionInfo> {
   try {
-    const existing = db
-      .prepare(SELECT_SESSION)
-      .get(sessionId) as SessionInfo | undefined;
+    const existing = db.prepare(SELECT_SESSION).get(sessionId) as SessionInfo | undefined;
 
     if (existing) {
       // Never overwrite an existing session's provider — provenance is fixed
@@ -55,11 +107,11 @@ export function getOrCreateSession(
       return ok(existing);
     }
 
-    db.prepare('INSERT INTO sessions (session_id, provider) VALUES (?, ?)').run(sessionId, provider ?? null);
+    db.prepare(
+      'INSERT INTO sessions (session_id, provider, model_identity_json) VALUES (?, ?, ?)',
+    ).run(sessionId, provider ?? null, modelIdentityJson ?? null);
 
-    const created = db
-      .prepare(SELECT_SESSION)
-      .get(sessionId) as SessionInfo;
+    const created = db.prepare(SELECT_SESSION).get(sessionId) as SessionInfo;
 
     return ok(created);
   } catch (e) {
@@ -80,28 +132,52 @@ export function getSession(db: Database.Database, sessionId: string): Result<Ses
   }
 }
 
+export interface SessionProviderInfo {
+  provider: string | null;
+}
+
+// Deliberately excludes model_identity_json so provider guards keep working on
+// readonly databases created by an older binary that has not run the model
+// metadata migration yet.
+export function getSessionProvider(
+  db: Database.Database,
+  sessionId: string,
+): Result<SessionProviderInfo | null> {
+  try {
+    const row = db.prepare('SELECT provider FROM sessions WHERE session_id = ?').get(sessionId) as
+      | SessionProviderInfo
+      | undefined;
+    return ok(row ?? null);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return err(`${ErrorCode.STORAGE_ERROR}: ${msg}`);
+  }
+}
+
 export function activateSession(
   db: Database.Database,
   sessionId: string,
   provider?: string,
+  modelIdentityJson?: string | null,
 ): Result<SessionInfo> {
   try {
     // Tag the provider on insert and backfill it on a NULL row, but never
     // overwrite an existing provider — provenance is fixed at creation. Without
     // this, a session first materialized via the resume/preflight path stays
     // provider=NULL forever, silently defeating the cross-provider guard (m1).
-    db.prepare(`
-      INSERT INTO sessions (session_id, status, completed_at, provider)
-      VALUES (?, 'in_progress', NULL, ?)
+    db.prepare(
+      `
+      INSERT INTO sessions (session_id, status, completed_at, provider, model_identity_json)
+      VALUES (?, 'in_progress', NULL, ?, ?)
       ON CONFLICT(session_id) DO UPDATE SET
         status = 'in_progress',
         completed_at = NULL,
-        provider = COALESCE(sessions.provider, excluded.provider)
-    `).run(sessionId, provider ?? null);
+        provider = COALESCE(sessions.provider, excluded.provider),
+        model_identity_json = COALESCE(excluded.model_identity_json, sessions.model_identity_json)
+    `,
+    ).run(sessionId, provider ?? null, modelIdentityJson ?? null);
 
-    const row = db
-      .prepare(SELECT_SESSION)
-      .get(sessionId) as SessionInfo;
+    const row = db.prepare(SELECT_SESSION).get(sessionId) as SessionInfo;
 
     return ok(row);
   } catch (e) {
@@ -110,10 +186,7 @@ export function activateSession(
   }
 }
 
-export function markSessionCompleted(
-  db: Database.Database,
-  sessionId: string,
-): Result<void> {
+export function markSessionCompleted(db: Database.Database, sessionId: string): Result<void> {
   try {
     db.prepare(
       "UPDATE sessions SET status = 'completed', completed_at = datetime('now') WHERE session_id = ?",
@@ -125,10 +198,7 @@ export function markSessionCompleted(
   }
 }
 
-export function markSessionFailed(
-  db: Database.Database,
-  sessionId: string,
-): Result<void> {
+export function markSessionFailed(db: Database.Database, sessionId: string): Result<void> {
   try {
     db.prepare(
       "UPDATE sessions SET status = 'failed', completed_at = datetime('now') WHERE session_id = ?",

--- a/src/tools/review-code.test.ts
+++ b/src/tools/review-code.test.ts
@@ -1,395 +1,156 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { registerReviewCodeTool } from './review-code.js';
-import type { ReviewBackend } from '../backends/backend.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import type { CodeReviewResult } from '../review/types.js';
-import { ok, err } from '../utils/errors.js';
-
-vi.mock('../storage/reviews.js', () => ({
-  saveReview: vi.fn(),
-}));
-
-vi.mock('../storage/sessions.js', () => ({
-  getOrCreateSession: vi.fn(),
-  getSession: vi.fn(),
-  markSessionCompleted: vi.fn(),
-  markSessionFailed: vi.fn(),
-  activateSession: vi.fn(),
-}));
+import type { ReviewBackend } from '../backends/backend.js';
+import type { ReviewLifecycle } from '../review/lifecycle.js';
+import type { CodeReviewResult, ModelIdentity } from '../review/types.js';
+import { err, ok } from '../utils/errors.js';
+import { registerReviewCodeTool } from './review-code.js';
 
 vi.mock('../utils/resolve-diff.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../utils/resolve-diff.js')>();
-  return {
-    ...actual,
-    resolveCodeDiff: vi.fn(),
-  };
+  return { ...actual, resolveCodeDiff: vi.fn() };
 });
 
-import { saveReview } from '../storage/reviews.js';
-import { getOrCreateSession, getSession, markSessionCompleted, markSessionFailed, activateSession } from '../storage/sessions.js';
 import { resolveCodeDiff } from '../utils/resolve-diff.js';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type HandlerFn = (args: Record<string, unknown>, extra: unknown) => Promise<any>;
 
-let mockClient: ReviewBackend;
-let mockServer: { registerTool: ReturnType<typeof vi.fn> };
-let handler: HandlerFn;
+const MODEL: ModelIdentity = {
+  provider: 'gemini',
+  role: 'review',
+  requested: null,
+  resolved: 'Gemini 3.5 Pro (High)',
+  observed: null,
+  evidence: 'bridge_selection',
+};
 
-const validResult: CodeReviewResult = {
+const RESULT: CodeReviewResult = {
   verdict: 'request_changes',
   summary: 'Issues found',
   findings: [
     {
-      severity: 'critical',
+      severity: 'major',
       category: 'bug',
-      description: 'Null pointer dereference',
+      description: 'Null dereference',
       file: 'src/index.ts',
       line: 42,
-      suggestion: 'Add null check',
+      suggestion: 'Add a guard',
     },
   ],
-  session_id: 'thread_xyz',
+  session_id: 'code-session',
+  provider: 'gemini',
+  models: [MODEL],
+  provenance: { persistence: 'durable', warning: null },
 };
+
+let client: ReviewBackend;
+let lifecycle: ReviewLifecycle;
+let server: { registerTool: ReturnType<typeof vi.fn> };
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mockClient = {
+  client = {
     provider: 'codex',
-    providers: ['codex'],
+    providers: ['codex', 'gemini'],
     allowsModelOverrideOnResume: false,
     reviewPlan: vi.fn(),
     reviewCode: vi.fn(),
     reviewPrecommit: vi.fn(),
   };
-  mockServer = { registerTool: vi.fn() };
-  // Default: resolveCodeDiff passes through whatever diff is provided
-  vi.mocked(resolveCodeDiff).mockImplementation(async (args) => {
-    return ok(args.diff ?? 'auto-captured diff');
-  });
+  lifecycle = {
+    reviewPlan: vi.fn(),
+    reviewCode: vi.fn().mockResolvedValue(ok(RESULT)),
+    reviewPrecommit: vi.fn(),
+  };
+  server = { registerTool: vi.fn() };
+  vi.mocked(resolveCodeDiff).mockImplementation(async ({ diff }) => ok(diff ?? 'captured diff'));
 });
 
-function setupHandler(db?: unknown) {
-  registerReviewCodeTool(mockServer as unknown as McpServer, mockClient, db as never);
-  handler = mockServer.registerTool.mock.calls[0][2] as HandlerFn;
+function setup(useLifecycle = true): HandlerFn {
+  registerReviewCodeTool(
+    server as unknown as McpServer,
+    client,
+    undefined,
+    useLifecycle ? lifecycle : undefined,
+  );
+  return server.registerTool.mock.calls[0][2] as HandlerFn;
 }
 
 describe('registerReviewCodeTool', () => {
-  beforeEach(() => setupHandler());
-
-  it('registers tool with name review_code', () => {
-    expect(mockServer.registerTool).toHaveBeenCalledTimes(1);
-    expect(mockServer.registerTool.mock.calls[0][0]).toBe('review_code');
+  it('registers bounded model and session input schemas', () => {
+    setup();
+    expect(server.registerTool.mock.calls[0][0]).toBe('review_code');
+    const schema = server.registerTool.mock.calls[0][1].inputSchema as Record<
+      string,
+      { parse(value: unknown): unknown }
+    >;
+    expect(() => schema.model.parse('x'.repeat(201))).toThrow();
+    expect(() => schema.session_id.parse('x\u007fy')).toThrow();
   });
 
-  it('diff input returns structured review', async () => {
-    vi.mocked(mockClient.reviewCode).mockResolvedValue(ok(validResult));
+  it('resolves and forwards the exact diff to the lifecycle', async () => {
+    const response = await setup()({ diff: 'explicit diff', context: 'intent' }, {});
 
-    const result = await handler({ diff: 'some diff content' }, {});
-
-    expect(result.content).toHaveLength(1);
-    expect(result.content[0].type).toBe('text');
-    const parsed = JSON.parse(result.content[0].text);
-    expect(parsed.verdict).toBe('request_changes');
-    expect(parsed.session_id).toBe('thread_xyz');
-    expect(result.isError).toBeUndefined();
+    expect(resolveCodeDiff).toHaveBeenCalledWith({ diff: 'explicit diff', auto_diff: true });
+    expect(lifecycle.reviewCode).toHaveBeenCalledWith(
+      expect.objectContaining({ diff: 'explicit diff', context: 'intent' }),
+    );
+    expect(JSON.parse(response.content[0].text)).toEqual(RESULT);
   });
 
-  it('rejects session_id + model when the backend disallows model override on resume (Codex)', async () => {
-    const result = await handler({ diff: 'some diff', session_id: 's1', model: 'gpt-5.4' }, {});
-
-    expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain('Cannot change model on a resumed session');
-    expect(mockClient.reviewCode).not.toHaveBeenCalled();
-  });
-
-  it('allows session_id + model when the backend permits override on resume (Gemini)', async () => {
-    mockClient.allowsModelOverrideOnResume = true;
-    vi.mocked(mockClient.reviewCode).mockResolvedValue(ok(validResult));
-
-    const result = await handler({ diff: 'some diff', session_id: 's1', model: 'Gemini 3.1 Pro (High)' }, {});
-
-    expect(result.isError).toBeUndefined();
-    expect(mockClient.reviewCode).toHaveBeenCalledWith(
-      expect.objectContaining({ session_id: 's1', model: 'Gemini 3.1 Pro (High)' }),
+  it('auto-captures when diff is omitted', async () => {
+    await setup()({}, {});
+    expect(resolveCodeDiff).toHaveBeenCalledWith({ diff: undefined, auto_diff: true });
+    expect(lifecycle.reviewCode).toHaveBeenCalledWith(
+      expect.objectContaining({ diff: 'captured diff' }),
     );
   });
 
-  it('findings include file/line references', async () => {
-    vi.mocked(mockClient.reviewCode).mockResolvedValue(ok(validResult));
-
-    const result = await handler({ diff: 'some diff' }, {});
-
-    const parsed = JSON.parse(result.content[0].text);
-    expect(parsed.findings[0].file).toBe('src/index.ts');
-    expect(parsed.findings[0].line).toBe(42);
-    expect(parsed.findings[0].suggestion).toBe('Add null check');
-  });
-
-  it('Codex client error propagates as MCP error', async () => {
-    vi.mocked(mockClient.reviewCode).mockResolvedValue(
-      err('RESPONSE_PARSE_ERROR: malformed JSON in response'),
+  it('returns synthetic model/provenance metadata without lifecycle mutation', async () => {
+    vi.mocked(resolveCodeDiff).mockResolvedValue(
+      err('NO_WORKING_CHANGES: No changes found vs HEAD.'),
     );
 
-    const result = await handler({ diff: 'some diff' }, {});
+    const response = await setup()({ session_id: 'existing' }, {});
+    const parsed = JSON.parse(response.content[0].text);
 
-    expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain('RESPONSE_PARSE_ERROR');
-  });
-
-  it('unexpected thrown error returns MCP error', async () => {
-    vi.mocked(mockClient.reviewCode).mockRejectedValue(new Error('connection reset'));
-
-    const result = await handler({ diff: 'some diff' }, {});
-
-    expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain('connection reset');
-  });
-
-  it('session_id forwarded to client', async () => {
-    vi.mocked(mockClient.reviewCode).mockResolvedValue(ok(validResult));
-
-    await handler({ diff: 'some diff', session_id: 'existing_session' }, {});
-
-    expect(mockClient.reviewCode).toHaveBeenCalledWith(
-      expect.objectContaining({ session_id: 'existing_session' }),
-    );
-  });
-
-  it('does not save to storage when no db provided', async () => {
-    vi.mocked(mockClient.reviewCode).mockResolvedValue(ok(validResult));
-
-    await handler({ diff: 'some diff' }, {});
-
-    expect(saveReview).not.toHaveBeenCalled();
-  });
-});
-
-describe('registerReviewCodeTool with db', () => {
-  // transaction(fn)() invokes fn synchronously — matches better-sqlite3's
-  // shape that recordSuccess uses for atomicity (T-002).
-  const mockDb = { transaction: <T>(fn: () => T) => () => fn() };
-
-  beforeEach(() => {
-    vi.mocked(getOrCreateSession).mockReturnValue(ok({ session_id: 'thread_xyz', status: 'in_progress' as const, created_at: '2026-01-01', completed_at: null, provider: null }));
-    vi.mocked(getSession).mockReturnValue(ok(null));
-    vi.mocked(activateSession).mockReturnValue(ok({ session_id: 'thread_xyz', status: 'in_progress' as const, created_at: '2026-01-01', completed_at: null, provider: null }));
-    vi.mocked(markSessionCompleted).mockReturnValue(ok(undefined));
-    vi.mocked(markSessionFailed).mockReturnValue(ok(undefined));
-    vi.mocked(saveReview).mockReturnValue(ok(undefined));
-    setupHandler(mockDb);
-  });
-
-  it('saves review to storage on success', async () => {
-    vi.mocked(mockClient.reviewCode).mockResolvedValue(ok(validResult));
-
-    await handler({ diff: 'some diff' }, {});
-
-    expect(saveReview).toHaveBeenCalledWith(mockDb, {
-      session_id: 'thread_xyz',
-      type: 'code',
-      verdict: 'request_changes',
-      summary: 'Issues found',
-      findings_json: JSON.stringify(validResult.findings),
+    expect(parsed).toMatchObject({
+      verdict: 'approve',
+      session_id: 'existing',
+      models: [],
+      provenance: { persistence: 'not_recorded', warning: null },
     });
+    expect(lifecycle.reviewCode).not.toHaveBeenCalled();
   });
 
-  it('creates session entry on success', async () => {
-    vi.mocked(mockClient.reviewCode).mockResolvedValue(ok(validResult));
+  it('returns git and lifecycle failures as MCP errors', async () => {
+    vi.mocked(resolveCodeDiff).mockResolvedValueOnce(err('GIT_ERROR: failed'));
+    expect((await setup()({}, {})).isError).toBe(true);
 
-    await handler({ diff: 'some diff' }, {});
-
-    expect(getOrCreateSession).toHaveBeenCalledWith(mockDb, 'thread_xyz', 'codex');
+    server = { registerTool: vi.fn() };
+    vi.mocked(resolveCodeDiff).mockResolvedValueOnce(ok('diff'));
+    vi.mocked(lifecycle.reviewCode).mockResolvedValueOnce(err('REVIEW_BUSY: active'));
+    const response = await setup()({}, {});
+    expect(response.isError).toBe(true);
+    expect(response.content[0].text).toContain('REVIEW_BUSY');
   });
 
-  it('does not save on client error', async () => {
-    vi.mocked(mockClient.reviewCode).mockResolvedValue(
-      err('REVIEW_TIMEOUT: timed out'),
+  it('defers resumed model validation to the owner-aware lifecycle', async () => {
+    vi.mocked(lifecycle.reviewCode).mockResolvedValueOnce(
+      err('INVALID_INPUT: Cannot change model on a resumed session.'),
     );
-
-    await handler({ diff: 'some diff' }, {});
-
-    expect(saveReview).not.toHaveBeenCalled();
-  });
-
-  it('marks session completed after save', async () => {
-    vi.mocked(mockClient.reviewCode).mockResolvedValue(ok(validResult));
-
-    await handler({ diff: 'some diff' }, {});
-
-    expect(markSessionCompleted).toHaveBeenCalledWith(mockDb, 'thread_xyz');
-  });
-
-  it('logs warning when getOrCreateSession fails', async () => {
-    vi.mocked(mockClient.reviewCode).mockResolvedValue(ok(validResult));
-    vi.mocked(getOrCreateSession).mockReturnValue(err('STORAGE_ERROR: table missing'));
-    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-
-    const result = await handler({ diff: 'some diff' }, {});
-
-    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to track session'));
-    expect(result.isError).toBeUndefined();
-    consoleSpy.mockRestore();
-  });
-
-  it('logs warning when markSessionCompleted fails', async () => {
-    vi.mocked(mockClient.reviewCode).mockResolvedValue(ok(validResult));
-    vi.mocked(markSessionCompleted).mockReturnValue(err('STORAGE_ERROR: readonly'));
-    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-
-    const result = await handler({ diff: 'some diff' }, {});
-
-    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('readonly'));
-    expect(result.isError).toBeUndefined();
-    consoleSpy.mockRestore();
-  });
-
-  it('logs warning when saveReview fails but still returns success', async () => {
-    vi.mocked(mockClient.reviewCode).mockResolvedValue(ok(validResult));
-    vi.mocked(saveReview).mockReturnValue(err('STORAGE_ERROR: disk full'));
-    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-
-    const result = await handler({ diff: 'some diff' }, {});
-
-    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('STORAGE_ERROR'));
-    expect(result.isError).toBeUndefined();
-    consoleSpy.mockRestore();
-  });
-
-  it('activates session before client call when session_id provided', async () => {
-    vi.mocked(mockClient.reviewCode).mockResolvedValue(ok(validResult));
-
-    await handler({ diff: 'some diff', session_id: 'thread_xyz' }, {});
-
-    expect(activateSession).toHaveBeenCalledWith(mockDb, 'thread_xyz', 'codex');
-    const activateOrder = vi.mocked(activateSession).mock.invocationCallOrder[0];
-    const reviewOrder = vi.mocked(mockClient.reviewCode).mock.invocationCallOrder[0];
-    expect(activateOrder).toBeLessThan(reviewOrder);
-  });
-
-  it('does not activate session when no session_id provided', async () => {
-    vi.mocked(mockClient.reviewCode).mockResolvedValue(ok(validResult));
-
-    await handler({ diff: 'some diff' }, {});
-
-    expect(activateSession).not.toHaveBeenCalled();
-    expect(getOrCreateSession).toHaveBeenCalledWith(mockDb, 'thread_xyz', 'codex');
-  });
-
-  it('marks session failed when client returns error and session_id provided', async () => {
-    vi.mocked(mockClient.reviewCode).mockResolvedValue(err('REVIEW_TIMEOUT: timed out'));
-
-    const result = await handler({ diff: 'some diff', session_id: 'thread_xyz' }, {});
-
-    expect(result.isError).toBe(true);
-    expect(markSessionFailed).toHaveBeenCalledWith(mockDb, 'thread_xyz');
-  });
-
-  it('marks session failed when handler throws and session_id provided', async () => {
-    vi.mocked(mockClient.reviewCode).mockRejectedValue(new Error('network error'));
-
-    const result = await handler({ diff: 'some diff', session_id: 'thread_xyz' }, {});
-
-    expect(result.isError).toBe(true);
-    expect(markSessionFailed).toHaveBeenCalledWith(mockDb, 'thread_xyz');
-  });
-
-  it('does not mark session failed when activateSession fails', async () => {
-    vi.mocked(activateSession).mockReturnValue(err('STORAGE_ERROR: readonly'));
-    vi.mocked(mockClient.reviewCode).mockResolvedValue(err('REVIEW_TIMEOUT: timed out'));
-    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-
-    const result = await handler({ diff: 'some diff', session_id: 'thread_xyz' }, {});
-
-    expect(result.isError).toBe(true);
-    expect(markSessionFailed).not.toHaveBeenCalled();
-    consoleSpy.mockRestore();
-  });
-
-  it('uses preflightId for markSessionCompleted when session_id provided', async () => {
-    vi.mocked(activateSession).mockReturnValue(ok({ session_id: 'thread_xyz', status: 'in_progress' as const, created_at: '2026-01-01', completed_at: null, provider: null }));
-    const codexResult = { ...validResult, session_id: 'thread_different' };
-    vi.mocked(mockClient.reviewCode).mockResolvedValue(ok(codexResult));
-
-    await handler({ diff: 'some diff', session_id: 'thread_xyz' }, {});
-
-    expect(markSessionCompleted).toHaveBeenCalledWith(mockDb, 'thread_xyz');
-  });
-
-  it('rejects a cross-provider resume without calling the backend or failing the session', async () => {
-    vi.mocked(getSession).mockReturnValue(
-      ok({ session_id: 'thread_xyz', status: 'completed' as const, created_at: '2026-01-01', completed_at: '2026-01-02', provider: 'gemini' }),
-    );
-
-    const result = await handler({ diff: 'some diff', session_id: 'thread_xyz' }, {});
-
-    expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain('PROVIDER_MISMATCH');
-    expect(mockClient.reviewCode).not.toHaveBeenCalled();
-    expect(activateSession).not.toHaveBeenCalled();
-    expect(markSessionFailed).not.toHaveBeenCalled();
-  });
-});
-
-describe('review_code auto_diff', () => {
-  beforeEach(() => setupHandler());
-
-  it('auto-captures changes when diff is omitted', async () => {
-    vi.mocked(resolveCodeDiff).mockResolvedValue(ok('auto-captured diff'));
-    vi.mocked(mockClient.reviewCode).mockResolvedValue(ok(validResult));
-
-    await handler({}, {});
-
-    expect(resolveCodeDiff).toHaveBeenCalledWith({ diff: undefined, auto_diff: undefined });
-    expect(mockClient.reviewCode).toHaveBeenCalledWith(
-      expect.objectContaining({ diff: 'auto-captured diff' }),
+    const response = await setup()({ diff: 'diff', session_id: 'session-1', model: 'gpt-5.5' }, {});
+    expect(response.isError).toBe(true);
+    expect(resolveCodeDiff).toHaveBeenCalled();
+    expect(lifecycle.reviewCode).toHaveBeenCalledWith(
+      expect.objectContaining({ session_id: 'session-1', model: 'gpt-5.5' }),
     );
   });
 
-  it('passes explicit diff through resolveCodeDiff', async () => {
-    vi.mocked(resolveCodeDiff).mockResolvedValue(ok('explicit diff'));
-    vi.mocked(mockClient.reviewCode).mockResolvedValue(ok(validResult));
-
-    await handler({ diff: 'explicit diff' }, {});
-
-    expect(resolveCodeDiff).toHaveBeenCalledWith(
-      expect.objectContaining({ diff: 'explicit diff' }),
-    );
-  });
-
-  it('returns approve-shaped response when no working changes', async () => {
-    vi.mocked(resolveCodeDiff).mockResolvedValue(
-      err('NO_WORKING_CHANGES: No changes found vs HEAD.'),
-    );
-
-    const result = await handler({}, {});
-
-    expect(result.isError).toBeUndefined();
-    const parsed = JSON.parse(result.content[0].text);
-    expect(parsed.verdict).toBe('approve');
-    expect(parsed.summary).toBe('No changes found to review.');
-    expect(parsed.findings).toEqual([]);
-    expect(parsed.session_id).toBe('');
-  });
-
-  it('returns MCP error when git fails', async () => {
-    vi.mocked(resolveCodeDiff).mockResolvedValue(
-      err('GIT_ERROR: fatal: not a git repository'),
-    );
-
-    const result = await handler({}, {});
-
-    expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain('GIT_ERROR');
-  });
-
-  it('does not call client.reviewCode when no working changes', async () => {
-    vi.mocked(resolveCodeDiff).mockResolvedValue(
-      err('NO_WORKING_CHANGES: No changes found vs HEAD.'),
-    );
-
-    await handler({}, {});
-
-    expect(mockClient.reviewCode).not.toHaveBeenCalled();
+  it('retains the no-lifecycle compatibility path', async () => {
+    vi.mocked(client.reviewCode).mockResolvedValue(ok(RESULT));
+    const response = await setup(false)({ diff: 'diff' }, {});
+    expect(JSON.parse(response.content[0].text)).toEqual(RESULT);
   });
 });

--- a/src/tools/review-code.ts
+++ b/src/tools/review-code.ts
@@ -1,12 +1,20 @@
 import { z } from 'zod';
+import { randomUUID } from 'node:crypto';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type Database from 'better-sqlite3';
 import type { ReviewBackend } from '../backends/backend.js';
 import { sessionModelConflictMessage } from '../backends/orchestrator.js';
 import { resolveCodeDiff, NO_WORKING_CHANGES } from '../utils/resolve-diff.js';
 import { createSessionTracker } from '../storage/session-tracker.js';
+import type { ReviewLifecycle } from '../review/lifecycle.js';
+import { ModelSelectorSchema, SessionIdSchema } from '../utils/input-validation.js';
 
-export function registerReviewCodeTool(server: McpServer, client: ReviewBackend, db?: Database.Database): void {
+export function registerReviewCodeTool(
+  server: McpServer,
+  client: ReviewBackend,
+  db?: Database.Database,
+  lifecycle?: ReviewLifecycle,
+): void {
   server.registerTool(
     'review_code',
     {
@@ -16,28 +24,29 @@ export function registerReviewCodeTool(server: McpServer, client: ReviewBackend,
         'The diff parameter MUST contain actual git diff output (from git diff, gh pr diff, etc.), ' +
         'NOT a summary or description of changes. ' +
         'If you reviewed a plan first, pass the same session_id so the reviewer checks the code against the plan. ' +
-        'Returns a verdict (approve/request_changes/reject) and findings with file, line, severity, and suggestions.',
+        'Returns a verdict, findings, responding models, and persistence provenance.',
       inputSchema: {
-        diff: z.string().optional().describe(
-          'Raw git diff output to review. Must be unified diff format ' +
-          '(output of git diff, gh pr diff, etc.). Do NOT pass summaries or descriptions. ' +
-          'If omitted, auto-captures changes via git diff HEAD.',
-        ),
-        auto_diff: z.boolean().optional().default(true).describe(
-          'Auto-capture working tree changes (staged + unstaged) via git diff HEAD',
-        ),
-        context: z.string().optional().describe('Intent of the changes'),
-        session_id: z.string().optional().describe('Continue from previous review'),
-        criteria: z.array(z.string()).optional().describe('Review criteria to focus on'),
-        model: z
+        diff: z
           .string()
-          .min(1)
           .optional()
           .describe(
-            'Override the configured default model for this call (e.g., "gpt-5.5"), or "latest". ' +
-              'With the Codex provider this cannot be combined with session_id (a resumed thread ' +
-              'keeps its model); the Gemini provider allows changing model on a resumed session.',
+            'Raw git diff output to review. Must be unified diff format ' +
+              '(output of git diff, gh pr diff, etc.). Do NOT pass summaries or descriptions. ' +
+              'If omitted, auto-captures changes via git diff HEAD.',
           ),
+        auto_diff: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe('Auto-capture working tree changes (staged + unstaged) via git diff HEAD'),
+        context: z.string().optional().describe('Intent of the changes'),
+        session_id: SessionIdSchema.optional().describe('Continue from previous review'),
+        criteria: z.array(z.string()).optional().describe('Review criteria to focus on'),
+        model: ModelSelectorSchema.optional().describe(
+          'Override the configured default model for this call (e.g., "gpt-5.5"), or "latest". ' +
+            'With the Codex provider this cannot be combined with session_id; compare returned ' +
+            'resolved and observed labels for runtime changes. Gemini allows changing model on resume.',
+        ),
         deliberate: z
           .boolean()
           .optional()
@@ -45,16 +54,16 @@ export function registerReviewCodeTool(server: McpServer, client: ReviewBackend,
             'Per-call override of the configured review mode: true = both providers review (deliberation); ' +
               'false = single provider with failover. Omit to use the configured mode. Requires a two-provider ' +
               'setup; requesting deliberation under a single-provider config returns an error. Under ' +
-              'deliberate-deep, the returned verdict reflects both providers\' independent reviews and is NOT ' +
+              "deliberate-deep, the returned verdict reflects both providers' independent reviews and is NOT " +
               'recomputed from cross-review adjudications — treat deliberation.divergent[].adjudication as ' +
               'advisory input for your own synthesis.',
           ),
       },
     },
     async (args) => {
-      // Reject session_id + model only when the backend can't change model on
-      // resume. See review-plan.ts for the rationale.
-      if (!client.allowsModelOverrideOnResume && args.session_id && args.model) {
+      // The shared lifecycle performs owner-aware validation before admission;
+      // this scalar gate remains only for the no-lifecycle compatibility path.
+      if (!lifecycle && !client.allowsModelOverrideOnResume && args.session_id && args.model) {
         return {
           content: [{ type: 'text' as const, text: sessionModelConflictMessage() }],
           isError: true,
@@ -63,7 +72,10 @@ export function registerReviewCodeTool(server: McpServer, client: ReviewBackend,
       const tracker = createSessionTracker(db, client.providers, client.provider);
       try {
         // Resolve diff (auto-capture or explicit)
-        const diffResult = await resolveCodeDiff({ diff: args.diff, auto_diff: args.auto_diff });
+        const diffResult = await resolveCodeDiff({
+          diff: args.diff,
+          auto_diff: args.auto_diff ?? true,
+        });
         if (!diffResult.ok) {
           if (diffResult.error.startsWith(NO_WORKING_CHANGES)) {
             return {
@@ -74,7 +86,9 @@ export function registerReviewCodeTool(server: McpServer, client: ReviewBackend,
                     verdict: 'approve',
                     summary: 'No changes found to review.',
                     findings: [],
-                    session_id: args.session_id ?? '',
+                    session_id: args.session_id ?? randomUUID(),
+                    models: [],
+                    provenance: { persistence: 'not_recorded', warning: null },
                   }),
                 },
               ],
@@ -83,6 +97,14 @@ export function registerReviewCodeTool(server: McpServer, client: ReviewBackend,
           return { content: [{ type: 'text' as const, text: diffResult.error }], isError: true };
         }
         const diff = diffResult.data;
+
+        if (lifecycle) {
+          const result = await lifecycle.reviewCode({ ...args, diff });
+          if (!result.ok) {
+            return { content: [{ type: 'text' as const, text: result.error }], isError: true };
+          }
+          return { content: [{ type: 'text' as const, text: JSON.stringify(result.data) }] };
+        }
 
         const preflight = tracker.preflight(args.session_id);
         if (!preflight.ok) {
@@ -111,7 +133,12 @@ export function registerReviewCodeTool(server: McpServer, client: ReviewBackend,
       } catch (e) {
         tracker.recordFailureBestEffort();
         return {
-          content: [{ type: 'text' as const, text: `Unexpected error: ${e instanceof Error ? e.message : String(e)}` }],
+          content: [
+            {
+              type: 'text' as const,
+              text: `Unexpected error: ${e instanceof Error ? e.message : String(e)}`,
+            },
+          ],
           isError: true,
         };
       }

--- a/src/tools/review-history.test.ts
+++ b/src/tools/review-history.test.ts
@@ -27,6 +27,20 @@ describe('registerReviewHistoryTool', () => {
     expect(mockServer.registerTool.mock.calls[0][0]).toBe('review_history');
   });
 
+  it('bounds last_n to 1..100 and validates decimal cursors', () => {
+    const schema = mockServer.registerTool.mock.calls[0][1].inputSchema as Record<
+      string,
+      { parse(value: unknown): unknown }
+    >;
+    expect(() => schema.last_n.parse(1)).not.toThrow();
+    expect(() => schema.last_n.parse(100)).not.toThrow();
+    expect(() => schema.last_n.parse(0)).toThrow();
+    expect(() => schema.last_n.parse(101)).toThrow();
+    expect(() => schema.cursor.parse('42')).not.toThrow();
+    expect(() => schema.cursor.parse('01')).toThrow();
+    expect(() => schema.cursor.parse('not-an-id')).toThrow();
+  });
+
   it('returns reviews for a specific session_id', async () => {
     saveReview(db, {
       session_id: 'thread_1',
@@ -42,6 +56,7 @@ describe('registerReviewHistoryTool', () => {
     const parsed = JSON.parse(result.content[0].text);
     expect(parsed.reviews).toHaveLength(1);
     expect(parsed.reviews[0].summary).toBe('Good plan');
+    expect(parsed.next_cursor).toBeNull();
   });
 
   it('returns last_n recent reviews when no session_id', async () => {
@@ -66,6 +81,7 @@ describe('registerReviewHistoryTool', () => {
     const parsed = JSON.parse(result.content[0].text);
     expect(parsed.reviews).toHaveLength(1);
     expect(parsed.reviews[0].summary).toBe('Second');
+    expect(parsed.next_cursor).toBe('2');
   });
 
   it('defaults to last 10 reviews when neither session_id nor last_n', async () => {
@@ -92,6 +108,57 @@ describe('registerReviewHistoryTool', () => {
     expect(result.isError).toBeUndefined();
     const parsed = JSON.parse(result.content[0].text);
     expect(parsed.reviews).toEqual([]);
+    expect(parsed.next_cursor).toBeNull();
+  });
+
+  it('paginates recent reviews newest-first without overlap', async () => {
+    for (let i = 1; i <= 3; i++) {
+      saveReview(db, {
+        session_id: `recent_${i}`,
+        type: 'code',
+        verdict: 'approve',
+        summary: `Review ${i}`,
+        findings_json: '[]',
+      });
+    }
+
+    const first = JSON.parse((await handler({ last_n: 2 }, {})).content[0].text);
+    const second = JSON.parse(
+      (await handler({ last_n: 2, cursor: first.next_cursor }, {})).content[0].text,
+    );
+
+    expect(first.reviews.map((review: { summary: string }) => review.summary)).toEqual([
+      'Review 3',
+      'Review 2',
+    ]);
+    expect(second.reviews.map((review: { summary: string }) => review.summary)).toEqual([
+      'Review 1',
+    ]);
+    expect(second.next_cursor).toBeNull();
+  });
+
+  it('paginates one session oldest-first and defaults its page size to 100', async () => {
+    for (let i = 1; i <= 102; i++) {
+      saveReview(db, {
+        session_id: 'one-session',
+        type: 'plan',
+        verdict: 'approve',
+        summary: `Review ${i}`,
+        findings_json: '[]',
+      });
+    }
+
+    const first = JSON.parse((await handler({ session_id: 'one-session' }, {})).content[0].text);
+    const second = JSON.parse(
+      (await handler({ session_id: 'one-session', cursor: first.next_cursor }, {})).content[0].text,
+    );
+
+    expect(first.reviews).toHaveLength(100);
+    expect(first.reviews[0].summary).toBe('Review 1');
+    expect(second.reviews.map((review: { summary: string }) => review.summary)).toEqual([
+      'Review 101',
+      'Review 102',
+    ]);
   });
 
   it('storage error returns MCP error', async () => {

--- a/src/tools/review-history.ts
+++ b/src/tools/review-history.ts
@@ -1,7 +1,13 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type Database from 'better-sqlite3';
-import { getReviewsBySession, getRecentReviews } from '../storage/reviews.js';
+import { getRecentReviewsPage, getReviewsBySessionPage } from '../storage/reviews.js';
+import { SessionIdSchema } from '../utils/input-validation.js';
+
+const ReviewCursorSchema = z
+  .string()
+  .regex(/^[1-9]\d*$/, 'cursor must be a positive decimal review-row ID')
+  .refine((value) => Number.isSafeInteger(Number(value)), 'cursor is outside the safe range');
 
 export function registerReviewHistoryTool(server: McpServer, db: Database.Database): void {
   server.registerTool(
@@ -9,31 +15,63 @@ export function registerReviewHistoryTool(server: McpServer, db: Database.Databa
     {
       description:
         'Look up past review results. Query by session_id to see all reviews in a session, ' +
-        'or use last_n to get recent reviews. Useful for checking what was already reviewed.',
+        'or use last_n to get recent reviews. Results include immutable responding-model snapshots ' +
+        'and a next_cursor for bounded pagination.',
       inputSchema: {
-        session_id: z.string().optional().describe('Specific session to query'),
-        last_n: z.number().int().positive().optional().describe('Return last N reviews'),
+        session_id: SessionIdSchema.optional().describe('Specific session to query'),
+        last_n: z.number().int().min(1).max(100).optional().describe('Return 1–100 reviews'),
+        cursor: ReviewCursorSchema.optional().describe(
+          'Decimal review-row cursor returned as next_cursor by the preceding page',
+        ),
       },
     },
     async (args) => {
       try {
         if (args.session_id) {
-          const result = getReviewsBySession(db, args.session_id);
+          const result = getReviewsBySessionPage(db, args.session_id, {
+            limit: args.last_n ?? 100,
+            cursor: args.cursor,
+          });
           if (!result.ok) {
             return { content: [{ type: 'text' as const, text: result.error }], isError: true };
           }
-          return { content: [{ type: 'text' as const, text: JSON.stringify({ reviews: result.data }) }] };
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: JSON.stringify({
+                  reviews: result.data.items,
+                  next_cursor: result.data.nextCursor,
+                }),
+              },
+            ],
+          };
         }
 
         const limit = args.last_n ?? 10;
-        const result = getRecentReviews(db, limit);
+        const result = getRecentReviewsPage(db, { limit, cursor: args.cursor });
         if (!result.ok) {
           return { content: [{ type: 'text' as const, text: result.error }], isError: true };
         }
-        return { content: [{ type: 'text' as const, text: JSON.stringify({ reviews: result.data }) }] };
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                reviews: result.data.items,
+                next_cursor: result.data.nextCursor,
+              }),
+            },
+          ],
+        };
       } catch (e) {
         return {
-          content: [{ type: 'text' as const, text: `Unexpected error: ${e instanceof Error ? e.message : String(e)}` }],
+          content: [
+            {
+              type: 'text' as const,
+              text: `Unexpected error: ${e instanceof Error ? e.message : String(e)}`,
+            },
+          ],
           isError: true,
         };
       }

--- a/src/tools/review-plan.test.ts
+++ b/src/tools/review-plan.test.ts
@@ -1,42 +1,39 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { registerReviewPlanTool } from './review-plan.js';
-import type { ReviewBackend } from '../backends/backend.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import type { PlanReviewResult } from '../review/types.js';
-import { ok, err } from '../utils/errors.js';
-
-vi.mock('../storage/reviews.js', () => ({
-  saveReview: vi.fn(),
-}));
-
-vi.mock('../storage/sessions.js', () => ({
-  getOrCreateSession: vi.fn(),
-  getSession: vi.fn(),
-  markSessionCompleted: vi.fn(),
-  markSessionFailed: vi.fn(),
-  activateSession: vi.fn(),
-}));
-
-import { saveReview } from '../storage/reviews.js';
-import { getOrCreateSession, getSession, markSessionCompleted, markSessionFailed, activateSession } from '../storage/sessions.js';
+import type { ReviewBackend } from '../backends/backend.js';
+import type { ReviewLifecycle } from '../review/lifecycle.js';
+import type { ModelIdentity, PlanReviewResult } from '../review/types.js';
+import { err, ok } from '../utils/errors.js';
+import { registerReviewPlanTool } from './review-plan.js';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type HandlerFn = (args: Record<string, unknown>, extra: unknown) => Promise<any>;
 
-let mockClient: ReviewBackend;
-let mockServer: { registerTool: ReturnType<typeof vi.fn> };
-let handler: HandlerFn;
-
-const validResult: PlanReviewResult = {
-  verdict: 'approve',
-  summary: 'Plan looks solid',
-  findings: [{ severity: 'minor', category: 'style', description: 'Consider renaming', file: null, line: null, suggestion: null }],
-  session_id: 'thread_abc',
+const MODEL: ModelIdentity = {
+  provider: 'codex',
+  role: 'review',
+  requested: null,
+  resolved: 'gpt-5.6-sol',
+  observed: 'gpt-5.6-sol',
+  evidence: 'runtime_session_record',
 };
 
+const RESULT: PlanReviewResult = {
+  verdict: 'approve',
+  summary: 'Plan looks solid',
+  findings: [],
+  session_id: '01901234-5678-7abc-8def-0123456789ab',
+  provider: 'codex',
+  models: [MODEL],
+  provenance: { persistence: 'durable', warning: null },
+};
+
+let client: ReviewBackend;
+let lifecycle: ReviewLifecycle;
+let server: { registerTool: ReturnType<typeof vi.fn> };
+
 beforeEach(() => {
-  vi.clearAllMocks();
-  mockClient = {
+  client = {
     provider: 'codex',
     providers: ['codex'],
     allowsModelOverrideOnResume: false,
@@ -44,268 +41,88 @@ beforeEach(() => {
     reviewCode: vi.fn(),
     reviewPrecommit: vi.fn(),
   };
-  mockServer = { registerTool: vi.fn() };
+  lifecycle = {
+    reviewPlan: vi.fn().mockResolvedValue(ok(RESULT)),
+    reviewCode: vi.fn(),
+    reviewPrecommit: vi.fn(),
+  };
+  server = { registerTool: vi.fn() };
 });
 
-function setupHandler(db?: unknown) {
-  registerReviewPlanTool(mockServer as unknown as McpServer, mockClient, db as never);
-  handler = mockServer.registerTool.mock.calls[0][2] as HandlerFn;
+function setup(useLifecycle = true): HandlerFn {
+  registerReviewPlanTool(
+    server as unknown as McpServer,
+    client,
+    undefined,
+    useLifecycle ? lifecycle : undefined,
+  );
+  return server.registerTool.mock.calls[0][2] as HandlerFn;
 }
 
 describe('registerReviewPlanTool', () => {
-  beforeEach(() => setupHandler());
-
-  it('registers tool with name review_plan', () => {
-    expect(mockServer.registerTool).toHaveBeenCalledTimes(1);
-    expect(mockServer.registerTool.mock.calls[0][0]).toBe('review_plan');
+  it('registers the tool and bounded model/session validators', () => {
+    setup();
+    expect(server.registerTool.mock.calls[0][0]).toBe('review_plan');
+    const schema = server.registerTool.mock.calls[0][1].inputSchema as Record<
+      string,
+      { parse(value: unknown): unknown }
+    >;
+    expect(() => schema.plan.parse(undefined)).toThrow();
+    expect(schema.model.parse('  gpt-5.6-sol  ')).toBe('gpt-5.6-sol');
+    expect(() => schema.model.parse(`gpt\nforged`)).toThrow();
+    expect(() => schema.session_id.parse(' surrounded ')).toThrow();
   });
 
-  it('inputSchema marks plan as required (z.string, not optional)', () => {
-    const config = mockServer.registerTool.mock.calls[0][1] as { inputSchema: Record<string, unknown> };
-    const planField = config.inputSchema.plan;
-    expect(planField).toBeDefined();
-    expect(() => (planField as { parse: (v: unknown) => unknown }).parse('hello')).not.toThrow();
-    expect(() => (planField as { parse: (v: unknown) => unknown }).parse(undefined)).toThrow();
+  it('returns lifecycle model and provenance metadata unchanged', async () => {
+    const handler = setup();
+    const response = await handler({ plan: 'My plan' }, {});
+
+    expect(response.isError).toBeUndefined();
+    expect(JSON.parse(response.content[0].text)).toEqual(RESULT);
+    expect(lifecycle.reviewPlan).toHaveBeenCalledWith({ plan: 'My plan' });
+    expect(client.reviewPlan).not.toHaveBeenCalled();
   });
 
-  it('valid plan input returns structured review', async () => {
-    vi.mocked(mockClient.reviewPlan).mockResolvedValue(ok(validResult));
-
-    const result = await handler({ plan: 'My plan' }, {});
-
-    expect(result.content).toHaveLength(1);
-    expect(result.content[0].type).toBe('text');
-    const parsed = JSON.parse(result.content[0].text);
-    expect(parsed.verdict).toBe('approve');
-    expect(parsed.summary).toBe('Plan looks solid');
-    expect(parsed.findings).toHaveLength(1);
-    expect(parsed.session_id).toBe('thread_abc');
-    expect(result.isError).toBeUndefined();
+  it('returns a lifecycle failure as an MCP error', async () => {
+    vi.mocked(lifecycle.reviewPlan).mockResolvedValue(err('REVIEW_BUSY: active'));
+    const response = await setup()({ plan: 'My plan' }, {});
+    expect(response.isError).toBe(true);
+    expect(response.content[0].text).toContain('REVIEW_BUSY');
   });
 
-  it('Codex client error propagates as MCP error', async () => {
-    vi.mocked(mockClient.reviewPlan).mockResolvedValue(
-      err('REVIEW_TIMEOUT: review timed out after 300s'),
+  it('defers resumed model validation to the owner-aware lifecycle', async () => {
+    vi.mocked(lifecycle.reviewPlan).mockResolvedValueOnce(
+      err('INVALID_INPUT: Cannot change model on a resumed session.'),
     );
-
-    const result = await handler({ plan: 'My plan' }, {});
-
-    expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain('REVIEW_TIMEOUT');
-  });
-
-  it('unexpected thrown error returns MCP error', async () => {
-    vi.mocked(mockClient.reviewPlan).mockRejectedValue(new Error('network failure'));
-
-    const result = await handler({ plan: 'My plan' }, {});
-
-    expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain('network failure');
-  });
-
-  it('session_id passed through to client', async () => {
-    vi.mocked(mockClient.reviewPlan).mockResolvedValue(ok(validResult));
-
-    await handler({ plan: 'My plan', session_id: 'existing_session' }, {});
-
-    expect(mockClient.reviewPlan).toHaveBeenCalledWith(
-      expect.objectContaining({ session_id: 'existing_session' }),
+    const response = await setup()(
+      { plan: 'My plan', session_id: 'session-1', model: 'gpt-5.5' },
+      {},
+    );
+    expect(response.isError).toBe(true);
+    expect(lifecycle.reviewPlan).toHaveBeenCalledWith(
+      expect.objectContaining({ session_id: 'session-1', model: 'gpt-5.5' }),
     );
   });
 
-  it('does not save to storage when no db provided', async () => {
-    vi.mocked(mockClient.reviewPlan).mockResolvedValue(ok(validResult));
-
-    await handler({ plan: 'My plan' }, {});
-
-    expect(saveReview).not.toHaveBeenCalled();
-  });
-
-  it('rejects session_id + model when the backend disallows model override on resume (Codex)', async () => {
-    const result = await handler({ plan: 'My plan', session_id: 's1', model: 'gpt-5.4' }, {});
-
-    expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain('Cannot change model on a resumed session');
-    expect(mockClient.reviewPlan).not.toHaveBeenCalled();
-  });
-
-  it('allows session_id + model when the backend permits override on resume (Gemini)', async () => {
-    mockClient.allowsModelOverrideOnResume = true;
-    vi.mocked(mockClient.reviewPlan).mockResolvedValue(ok(validResult));
-
-    const result = await handler({ plan: 'My plan', session_id: 's1', model: 'Gemini 3.1 Pro (High)' }, {});
-
-    expect(result.isError).toBeUndefined();
-    expect(mockClient.reviewPlan).toHaveBeenCalledWith(
-      expect.objectContaining({ session_id: 's1', model: 'Gemini 3.1 Pro (High)' }),
+  it('allows a Gemini model change on resume', async () => {
+    client.allowsModelOverrideOnResume = true;
+    const handler = setup();
+    await handler({ plan: 'My plan', session_id: 'session-1', model: 'Gemini 3.5 Pro (High)' }, {});
+    expect(lifecycle.reviewPlan).toHaveBeenCalledWith(
+      expect.objectContaining({ session_id: 'session-1', model: 'Gemini 3.5 Pro (High)' }),
     );
   });
-});
 
-describe('registerReviewPlanTool with db', () => {
-  // transaction(fn)() invokes fn synchronously — matches better-sqlite3's
-  // shape that recordSuccess uses for atomicity (T-002).
-  const mockDb = { transaction: <T>(fn: () => T) => () => fn() };
-
-  beforeEach(() => {
-    vi.mocked(getOrCreateSession).mockReturnValue(ok({ session_id: 'thread_abc', status: 'in_progress' as const, created_at: '2026-01-01', completed_at: null, provider: null }));
-    vi.mocked(getSession).mockReturnValue(ok(null));
-    vi.mocked(activateSession).mockReturnValue(ok({ session_id: 'thread_abc', status: 'in_progress' as const, created_at: '2026-01-01', completed_at: null, provider: null }));
-    vi.mocked(markSessionCompleted).mockReturnValue(ok(undefined));
-    vi.mocked(markSessionFailed).mockReturnValue(ok(undefined));
-    vi.mocked(saveReview).mockReturnValue(ok(undefined));
-    setupHandler(mockDb);
+  it('retains the no-lifecycle compatibility path', async () => {
+    vi.mocked(client.reviewPlan).mockResolvedValue(ok(RESULT));
+    const response = await setup(false)({ plan: 'My plan' }, {});
+    expect(JSON.parse(response.content[0].text)).toEqual(RESULT);
   });
 
-  it('saves review to storage on success', async () => {
-    vi.mocked(mockClient.reviewPlan).mockResolvedValue(ok(validResult));
-
-    await handler({ plan: 'My plan' }, {});
-
-    expect(saveReview).toHaveBeenCalledWith(mockDb, {
-      session_id: 'thread_abc',
-      type: 'plan',
-      verdict: 'approve',
-      summary: 'Plan looks solid',
-      findings_json: JSON.stringify(validResult.findings),
-    });
-  });
-
-  it('creates session entry on success', async () => {
-    vi.mocked(mockClient.reviewPlan).mockResolvedValue(ok(validResult));
-
-    await handler({ plan: 'My plan' }, {});
-
-    expect(getOrCreateSession).toHaveBeenCalledWith(mockDb, 'thread_abc', 'codex');
-  });
-
-  it('does not save on client error', async () => {
-    vi.mocked(mockClient.reviewPlan).mockResolvedValue(
-      err('REVIEW_TIMEOUT: timed out'),
-    );
-
-    await handler({ plan: 'My plan' }, {});
-
-    expect(saveReview).not.toHaveBeenCalled();
-  });
-
-  it('marks session completed after save', async () => {
-    vi.mocked(mockClient.reviewPlan).mockResolvedValue(ok(validResult));
-
-    await handler({ plan: 'My plan' }, {});
-
-    expect(markSessionCompleted).toHaveBeenCalledWith(mockDb, 'thread_abc');
-  });
-
-  it('logs warning when getOrCreateSession fails', async () => {
-    vi.mocked(mockClient.reviewPlan).mockResolvedValue(ok(validResult));
-    vi.mocked(getOrCreateSession).mockReturnValue(err('STORAGE_ERROR: table missing'));
-    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-
-    const result = await handler({ plan: 'My plan' }, {});
-
-    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to track session'));
-    expect(result.isError).toBeUndefined();
-    consoleSpy.mockRestore();
-  });
-
-  it('logs warning when markSessionCompleted fails', async () => {
-    vi.mocked(mockClient.reviewPlan).mockResolvedValue(ok(validResult));
-    vi.mocked(markSessionCompleted).mockReturnValue(err('STORAGE_ERROR: readonly'));
-    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-
-    const result = await handler({ plan: 'My plan' }, {});
-
-    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('readonly'));
-    expect(result.isError).toBeUndefined();
-    consoleSpy.mockRestore();
-  });
-
-  it('logs warning when saveReview fails but still returns success', async () => {
-    vi.mocked(mockClient.reviewPlan).mockResolvedValue(ok(validResult));
-    vi.mocked(saveReview).mockReturnValue(err('STORAGE_ERROR: disk full'));
-    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-
-    const result = await handler({ plan: 'My plan' }, {});
-
-    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('STORAGE_ERROR'));
-    expect(result.isError).toBeUndefined();
-    consoleSpy.mockRestore();
-  });
-
-  it('activates session before client call when session_id provided', async () => {
-    vi.mocked(mockClient.reviewPlan).mockResolvedValue(ok(validResult));
-
-    await handler({ plan: 'My plan', session_id: 'thread_abc' }, {});
-
-    expect(activateSession).toHaveBeenCalledWith(mockDb, 'thread_abc', 'codex');
-    // activateSession should be called before reviewPlan
-    const activateOrder = vi.mocked(activateSession).mock.invocationCallOrder[0];
-    const reviewOrder = vi.mocked(mockClient.reviewPlan).mock.invocationCallOrder[0];
-    expect(activateOrder).toBeLessThan(reviewOrder);
-  });
-
-  it('does not activate session when no session_id provided', async () => {
-    vi.mocked(mockClient.reviewPlan).mockResolvedValue(ok(validResult));
-
-    await handler({ plan: 'My plan' }, {});
-
-    expect(activateSession).not.toHaveBeenCalled();
-    expect(getOrCreateSession).toHaveBeenCalledWith(mockDb, 'thread_abc', 'codex');
-  });
-
-  it('marks session failed when client returns error and session_id provided', async () => {
-    vi.mocked(mockClient.reviewPlan).mockResolvedValue(err('REVIEW_TIMEOUT: timed out'));
-
-    const result = await handler({ plan: 'My plan', session_id: 'thread_abc' }, {});
-
-    expect(result.isError).toBe(true);
-    expect(markSessionFailed).toHaveBeenCalledWith(mockDb, 'thread_abc');
-  });
-
-  it('marks session failed when handler throws and session_id provided', async () => {
-    vi.mocked(mockClient.reviewPlan).mockRejectedValue(new Error('network error'));
-
-    const result = await handler({ plan: 'My plan', session_id: 'thread_abc' }, {});
-
-    expect(result.isError).toBe(true);
-    expect(markSessionFailed).toHaveBeenCalledWith(mockDb, 'thread_abc');
-  });
-
-  it('does not mark session failed when activateSession fails', async () => {
-    vi.mocked(activateSession).mockReturnValue(err('STORAGE_ERROR: readonly'));
-    vi.mocked(mockClient.reviewPlan).mockResolvedValue(err('REVIEW_TIMEOUT: timed out'));
-    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-
-    const result = await handler({ plan: 'My plan', session_id: 'thread_abc' }, {});
-
-    expect(result.isError).toBe(true);
-    expect(markSessionFailed).not.toHaveBeenCalled();
-    consoleSpy.mockRestore();
-  });
-
-  it('uses preflightId for markSessionCompleted when session_id provided', async () => {
-    vi.mocked(activateSession).mockReturnValue(ok({ session_id: 'thread_abc', status: 'in_progress' as const, created_at: '2026-01-01', completed_at: null, provider: null }));
-    const codexResult = { ...validResult, session_id: 'thread_different' };
-    vi.mocked(mockClient.reviewPlan).mockResolvedValue(ok(codexResult));
-
-    await handler({ plan: 'My plan', session_id: 'thread_abc' }, {});
-
-    expect(markSessionCompleted).toHaveBeenCalledWith(mockDb, 'thread_abc');
-  });
-
-  it('rejects a cross-provider resume without calling the backend or failing the session', async () => {
-    vi.mocked(getSession).mockReturnValue(
-      ok({ session_id: 'thread_abc', status: 'completed' as const, created_at: '2026-01-01', completed_at: '2026-01-02', provider: 'gemini' }),
-    );
-
-    const result = await handler({ plan: 'My plan', session_id: 'thread_abc' }, {});
-
-    expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain('PROVIDER_MISMATCH');
-    expect(mockClient.reviewPlan).not.toHaveBeenCalled();
-    // The session belongs to the other provider — do not touch its state.
-    expect(activateSession).not.toHaveBeenCalled();
-    expect(markSessionFailed).not.toHaveBeenCalled();
+  it('turns an unexpected lifecycle exception into an MCP error', async () => {
+    vi.mocked(lifecycle.reviewPlan).mockRejectedValue(new Error('network failure'));
+    const response = await setup()({ plan: 'My plan' }, {});
+    expect(response.isError).toBe(true);
+    expect(response.content[0].text).toContain('network failure');
   });
 });

--- a/src/tools/review-plan.ts
+++ b/src/tools/review-plan.ts
@@ -4,31 +4,34 @@ import type Database from 'better-sqlite3';
 import type { ReviewBackend } from '../backends/backend.js';
 import { sessionModelConflictMessage } from '../backends/orchestrator.js';
 import { createSessionTracker } from '../storage/session-tracker.js';
+import type { ReviewLifecycle } from '../review/lifecycle.js';
+import { ModelSelectorSchema, SessionIdSchema } from '../utils/input-validation.js';
 
-export function registerReviewPlanTool(server: McpServer, client: ReviewBackend, db?: Database.Database): void {
+export function registerReviewPlanTool(
+  server: McpServer,
+  client: ReviewBackend,
+  db?: Database.Database,
+  lifecycle?: ReviewLifecycle,
+): void {
   server.registerTool(
     'review_plan',
     {
       description:
         'Get an independent code review of your implementation plan before writing code. ' +
         'Call this after drafting a plan and before implementing it. ' +
-        'Returns a verdict (approve/revise/reject), findings with severity and suggestions, and a session_id. ' +
+        'Returns a verdict (approve/revise/reject), findings, session_id, responding models, and persistence provenance. ' +
         'Pass the returned session_id to review_code later so the reviewer has full context.',
       inputSchema: {
         plan: z.string().describe('The implementation plan to review'),
         context: z.string().optional().describe('Project context and constraints'),
         focus: z.array(z.string()).optional().describe('Review focus areas'),
         depth: z.enum(['quick', 'thorough']).optional().describe('Review depth'),
-        session_id: z.string().optional().describe('Continue from a previous review session'),
-        model: z
-          .string()
-          .min(1)
-          .optional()
-          .describe(
-            'Override the configured default model for this call (e.g., "gpt-5.5"), or "latest". ' +
-              'With the Codex provider this cannot be combined with session_id (a resumed thread ' +
-              'keeps its model); the Gemini provider allows changing model on a resumed session.',
-          ),
+        session_id: SessionIdSchema.optional().describe('Continue from a previous review session'),
+        model: ModelSelectorSchema.optional().describe(
+          'Override the configured default model for this call (e.g., "gpt-5.5"), or "latest". ' +
+            'With the Codex provider this cannot be combined with session_id; compare returned ' +
+            'resolved and observed labels for runtime changes. Gemini allows changing model on resume.',
+        ),
         deliberate: z
           .boolean()
           .optional()
@@ -36,23 +39,39 @@ export function registerReviewPlanTool(server: McpServer, client: ReviewBackend,
             'Per-call override of the configured review mode: true = both providers review (deliberation); ' +
               'false = single provider with failover. Omit to use the configured mode. Requires a two-provider ' +
               'setup; requesting deliberation under a single-provider config returns an error. Under ' +
-              'deliberate-deep, the returned verdict reflects both providers\' independent reviews and is NOT ' +
+              "deliberate-deep, the returned verdict reflects both providers' independent reviews and is NOT " +
               'recomputed from cross-review adjudications — treat deliberation.divergent[].adjudication as ' +
               'advisory input for your own synthesis.',
           ),
       },
     },
     async (args) => {
-      // Reject session_id + model only for backends that can't change model on
-      // resume (Codex, whose SDK reasserts --model). Done here, before
-      // preflight(), so this pure input error doesn't mark a valid session
-      // `failed`. Backends that allow override on resume (Gemini) fall through
-      // and honor the model — the orchestrator applies the same capability gate.
-      if (!client.allowsModelOverrideOnResume && args.session_id && args.model) {
+      // The shared lifecycle validates against the owning leaf before admission.
+      // Keep the scalar gate only for the legacy no-lifecycle compatibility path.
+      if (!lifecycle && !client.allowsModelOverrideOnResume && args.session_id && args.model) {
         return {
           content: [{ type: 'text' as const, text: sessionModelConflictMessage() }],
           isError: true,
         };
+      }
+      if (lifecycle) {
+        try {
+          const result = await lifecycle.reviewPlan(args);
+          if (!result.ok) {
+            return { content: [{ type: 'text' as const, text: result.error }], isError: true };
+          }
+          return { content: [{ type: 'text' as const, text: JSON.stringify(result.data) }] };
+        } catch (e) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: `Unexpected error: ${e instanceof Error ? e.message : String(e)}`,
+              },
+            ],
+            isError: true,
+          };
+        }
       }
       const tracker = createSessionTracker(db, client.providers, client.provider);
       try {
@@ -83,7 +102,12 @@ export function registerReviewPlanTool(server: McpServer, client: ReviewBackend,
       } catch (e) {
         tracker.recordFailureBestEffort();
         return {
-          content: [{ type: 'text' as const, text: `Unexpected error: ${e instanceof Error ? e.message : String(e)}` }],
+          content: [
+            {
+              type: 'text' as const,
+              text: `Unexpected error: ${e instanceof Error ? e.message : String(e)}`,
+            },
+          ],
           isError: true,
         };
       }

--- a/src/tools/review-precommit.test.ts
+++ b/src/tools/review-precommit.test.ts
@@ -1,48 +1,48 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { registerReviewPrecommitTool } from './review-precommit.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { ReviewBackend } from '../backends/backend.js';
 import { DEFAULT_CONFIG } from '../config/types.js';
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import type { PrecommitResult } from '../review/types.js';
-import { ok, err } from '../utils/errors.js';
+import type { ReviewLifecycle } from '../review/lifecycle.js';
+import type { ModelIdentity, PrecommitResult } from '../review/types.js';
+import { err, ok } from '../utils/errors.js';
+import { registerReviewPrecommitTool } from './review-precommit.js';
 
-vi.mock('../utils/git.js', () => ({
-  getStagedDiff: vi.fn(),
-}));
+vi.mock('../utils/resolve-diff.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../utils/resolve-diff.js')>();
+  return { ...actual, resolvePrecommitDiff: vi.fn() };
+});
 
-vi.mock('../storage/reviews.js', () => ({
-  saveReview: vi.fn(),
-}));
-
-vi.mock('../storage/sessions.js', () => ({
-  getOrCreateSession: vi.fn(),
-  getSession: vi.fn(),
-  markSessionCompleted: vi.fn(),
-  markSessionFailed: vi.fn(),
-  activateSession: vi.fn(),
-}));
-
-import { getStagedDiff } from '../utils/git.js';
-import { saveReview } from '../storage/reviews.js';
-import { getOrCreateSession, getSession, markSessionCompleted, markSessionFailed, activateSession } from '../storage/sessions.js';
+import { resolvePrecommitDiff } from '../utils/resolve-diff.js';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type HandlerFn = (args: Record<string, unknown>, extra: unknown) => Promise<any>;
 
-let mockClient: ReviewBackend;
-let mockServer: { registerTool: ReturnType<typeof vi.fn> };
-let handler: HandlerFn;
+const MODEL: ModelIdentity = {
+  provider: 'codex',
+  role: 'review',
+  requested: null,
+  resolved: 'gpt-5.6-sol',
+  observed: 'gpt-5.6-sol',
+  evidence: 'runtime_session_record',
+};
 
-const validResult: PrecommitResult = {
+const RESULT: PrecommitResult = {
   ready_to_commit: true,
   blockers: [],
-  warnings: ['Large diff'],
-  session_id: 'thread_pre',
+  warnings: [],
+  session_id: 'precommit-session',
+  provider: 'codex',
+  models: [MODEL],
+  provenance: { persistence: 'durable', warning: null },
 };
+
+let client: ReviewBackend;
+let lifecycle: ReviewLifecycle;
+let server: { registerTool: ReturnType<typeof vi.fn> };
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mockClient = {
+  client = {
     provider: 'codex',
     providers: ['codex'],
     allowsModelOverrideOnResume: false,
@@ -50,391 +50,113 @@ beforeEach(() => {
     reviewCode: vi.fn(),
     reviewPrecommit: vi.fn(),
   };
-  mockServer = { registerTool: vi.fn() };
+  lifecycle = {
+    reviewPlan: vi.fn(),
+    reviewCode: vi.fn(),
+    reviewPrecommit: vi.fn().mockResolvedValue(ok(RESULT)),
+  };
+  server = { registerTool: vi.fn() };
+  vi.mocked(resolvePrecommitDiff).mockImplementation(async ({ diff }) =>
+    ok(diff ?? 'captured staged diff'),
+  );
 });
 
-function setupHandler(db?: unknown, config = DEFAULT_CONFIG) {
-  registerReviewPrecommitTool(mockServer as unknown as McpServer, mockClient, db as never, config);
-  const calls = mockServer.registerTool.mock.calls;
-  handler = calls[calls.length - 1][2] as HandlerFn;
+function setup(autoDiff = true, useLifecycle = true): HandlerFn {
+  registerReviewPrecommitTool(
+    server as unknown as McpServer,
+    client,
+    undefined,
+    {
+      ...DEFAULT_CONFIG,
+      review_standards: {
+        ...DEFAULT_CONFIG.review_standards,
+        precommit: { ...DEFAULT_CONFIG.review_standards.precommit, auto_diff: autoDiff },
+      },
+    },
+    useLifecycle ? lifecycle : undefined,
+  );
+  return server.registerTool.mock.calls[0][2] as HandlerFn;
 }
 
-// A config whose precommit auto_diff default is flipped to `false`.
-const configAutoDiffFalse = {
-  ...DEFAULT_CONFIG,
-  review_standards: {
-    ...DEFAULT_CONFIG.review_standards,
-    precommit: { ...DEFAULT_CONFIG.review_standards.precommit, auto_diff: false },
-  },
-};
-
 describe('registerReviewPrecommitTool', () => {
-  beforeEach(() => setupHandler());
-
-  it('registers tool with name review_precommit', () => {
-    expect(mockServer.registerTool).toHaveBeenCalledTimes(1);
-    expect(mockServer.registerTool.mock.calls[0][0]).toBe('review_precommit');
+  it('registers bounded model and session schemas', () => {
+    setup();
+    expect(server.registerTool.mock.calls[0][0]).toBe('review_precommit');
+    const schema = server.registerTool.mock.calls[0][1].inputSchema as Record<
+      string,
+      { parse(value: unknown): unknown }
+    >;
+    expect(() => schema.model.parse('gpt\u0085forged')).toThrow();
+    expect(() => schema.session_id.parse(' x')).toThrow();
   });
 
-  it('auto_diff captures staged changes', async () => {
-    vi.mocked(getStagedDiff).mockResolvedValue(ok('staged diff content'));
-    vi.mocked(mockClient.reviewPrecommit).mockResolvedValue(ok(validResult));
+  it('uses project auto_diff default and forwards the resolved diff', async () => {
+    const response = await setup(false)({}, {});
 
-    const result = await handler({}, {});
-
-    expect(getStagedDiff).toHaveBeenCalledTimes(1);
-    expect(mockClient.reviewPrecommit).toHaveBeenCalledWith(
-      expect.objectContaining({ diff: 'staged diff content' }),
-    );
-    const parsed = JSON.parse(result.content[0].text);
-    expect(parsed.ready_to_commit).toBe(true);
-    expect(result.isError).toBeUndefined();
-  });
-
-  it('ISS-004: falls back to config precommit.auto_diff when no arg is passed (false → no capture)', async () => {
-    setupHandler(undefined, configAutoDiffFalse); // re-register with auto_diff:false
-    vi.mocked(getStagedDiff).mockResolvedValue(ok('staged diff content'));
-
-    const result = await handler({}, {}); // no auto_diff arg → config default (false)
-
-    expect(getStagedDiff).not.toHaveBeenCalled(); // auto-capture disabled by config
-    // With auto_diff off and no explicit diff, there's nothing to review.
-    expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain('auto_diff disabled and no diff provided');
-  });
-
-  it('ISS-004: an explicit auto_diff arg overrides the config default', async () => {
-    setupHandler(undefined, configAutoDiffFalse); // config says false...
-    vi.mocked(getStagedDiff).mockResolvedValue(ok('staged diff content'));
-    vi.mocked(mockClient.reviewPrecommit).mockResolvedValue(ok(validResult));
-
-    await handler({ auto_diff: true }, {}); // ...but the explicit arg wins
-
-    expect(getStagedDiff).toHaveBeenCalledTimes(1);
-  });
-
-  it('rejects session_id + model when the backend disallows model override on resume (Codex)', async () => {
-    const result = await handler({ session_id: 's1', model: 'gpt-5.4' }, {});
-
-    expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain('Cannot change model on a resumed session');
-    expect(mockClient.reviewPrecommit).not.toHaveBeenCalled();
-  });
-
-  it('allows session_id + model when the backend permits override on resume (Gemini)', async () => {
-    mockClient.allowsModelOverrideOnResume = true;
-    vi.mocked(getStagedDiff).mockResolvedValue(ok('some diff'));
-    vi.mocked(mockClient.reviewPrecommit).mockResolvedValue(ok(validResult));
-
-    const result = await handler({ session_id: 's1', model: 'Gemini 3.1 Pro (High)' }, {});
-
-    expect(result.isError).toBeUndefined();
-    expect(mockClient.reviewPrecommit).toHaveBeenCalledWith(
-      expect.objectContaining({ session_id: 's1', model: 'Gemini 3.1 Pro (High)' }),
-    );
-  });
-
-  it('no staged changes returns warning', async () => {
-    vi.mocked(getStagedDiff).mockResolvedValue(ok(''));
-
-    const result = await handler({}, {});
-
-    expect(mockClient.reviewPrecommit).not.toHaveBeenCalled();
-    const parsed = JSON.parse(result.content[0].text);
-    expect(parsed.ready_to_commit).toBe(false);
-    expect(parsed.warnings).toContain('No staged changes found');
-  });
-
-  it('ready_to_commit is false when blockers exist', async () => {
-    vi.mocked(getStagedDiff).mockResolvedValue(ok('some diff'));
-    const blockedResult: PrecommitResult = {
-      ready_to_commit: false,
-      blockers: ['Missing error handling in auth module'],
-      warnings: [],
-      session_id: 'thread_blocked',
-    };
-    vi.mocked(mockClient.reviewPrecommit).mockResolvedValue(ok(blockedResult));
-
-    const result = await handler({}, {});
-
-    const parsed = JSON.parse(result.content[0].text);
-    expect(parsed.ready_to_commit).toBe(false);
-    expect(parsed.blockers).toContain('Missing error handling in auth module');
-  });
-
-  it('explicit diff skips getStagedDiff when auto_diff is false', async () => {
-    vi.mocked(mockClient.reviewPrecommit).mockResolvedValue(ok(validResult));
-
-    await handler({ diff: 'explicit diff', auto_diff: false }, {});
-
-    expect(getStagedDiff).not.toHaveBeenCalled();
-    expect(mockClient.reviewPrecommit).toHaveBeenCalledWith(
-      expect.objectContaining({ diff: 'explicit diff' }),
-    );
-  });
-
-  it('explicit diff takes precedence over auto_diff', async () => {
-    vi.mocked(mockClient.reviewPrecommit).mockResolvedValue(ok(validResult));
-
-    await handler({ diff: 'explicit diff', auto_diff: true }, {});
-
-    expect(getStagedDiff).not.toHaveBeenCalled();
-    expect(mockClient.reviewPrecommit).toHaveBeenCalledWith(
-      expect.objectContaining({ diff: 'explicit diff' }),
-    );
-  });
-
-  it('forwards model override to client (T-011)', async () => {
-    vi.mocked(mockClient.reviewPrecommit).mockResolvedValue(ok(validResult));
-
-    await handler({ diff: 'explicit diff', auto_diff: false, model: 'gpt-5.4' }, {});
-
-    expect(mockClient.reviewPrecommit).toHaveBeenCalledWith(
-      expect.objectContaining({ model: 'gpt-5.4' }),
-    );
-  });
-
-  it('auto_diff false + no diff returns error', async () => {
-    const result = await handler({ auto_diff: false }, {});
-
-    expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain('auto_diff disabled and no diff provided');
-    expect(getStagedDiff).not.toHaveBeenCalled();
-    expect(mockClient.reviewPrecommit).not.toHaveBeenCalled();
-  });
-
-  it('getStagedDiff failure returns MCP error', async () => {
-    vi.mocked(getStagedDiff).mockResolvedValue(err('GIT_ERROR: not a git repository'));
-
-    const result = await handler({}, {});
-
-    expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain('GIT_ERROR');
-    expect(mockClient.reviewPrecommit).not.toHaveBeenCalled();
-  });
-
-  it('no staged changes preserves caller session_id', async () => {
-    vi.mocked(getStagedDiff).mockResolvedValue(ok(''));
-
-    const result = await handler({ session_id: 'thread_existing' }, {});
-
-    const parsed = JSON.parse(result.content[0].text);
-    expect(parsed.session_id).toBe('thread_existing');
-    expect(parsed.ready_to_commit).toBe(false);
-  });
-
-  it('unexpected thrown error returns MCP error', async () => {
-    vi.mocked(getStagedDiff).mockResolvedValue(ok('some diff'));
-    vi.mocked(mockClient.reviewPrecommit).mockRejectedValue(new Error('timeout'));
-
-    const result = await handler({}, {});
-
-    expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain('timeout');
-  });
-
-  it('does not save to storage when no db provided', async () => {
-    vi.mocked(getStagedDiff).mockResolvedValue(ok('some diff'));
-    vi.mocked(mockClient.reviewPrecommit).mockResolvedValue(ok(validResult));
-
-    await handler({}, {});
-
-    expect(saveReview).not.toHaveBeenCalled();
-  });
-});
-
-describe('registerReviewPrecommitTool with db', () => {
-  // transaction(fn)() invokes fn synchronously — matches better-sqlite3's
-  // shape that recordSuccess uses for atomicity (T-002).
-  const mockDb = { transaction: <T>(fn: () => T) => () => fn() };
-
-  beforeEach(() => {
-    vi.mocked(getOrCreateSession).mockReturnValue(ok({ session_id: 'thread_pre', status: 'in_progress' as const, created_at: '2026-01-01', completed_at: null, provider: null }));
-    vi.mocked(getSession).mockReturnValue(ok(null));
-    vi.mocked(activateSession).mockReturnValue(ok({ session_id: 'thread_pre', status: 'in_progress' as const, created_at: '2026-01-01', completed_at: null, provider: null }));
-    vi.mocked(markSessionCompleted).mockReturnValue(ok(undefined));
-    vi.mocked(markSessionFailed).mockReturnValue(ok(undefined));
-    vi.mocked(saveReview).mockReturnValue(ok(undefined));
-    setupHandler(mockDb);
-  });
-
-  it('saves review to storage on success', async () => {
-    vi.mocked(getStagedDiff).mockResolvedValue(ok('some diff'));
-    vi.mocked(mockClient.reviewPrecommit).mockResolvedValue(ok(validResult));
-
-    await handler({}, {});
-
-    expect(saveReview).toHaveBeenCalledWith(mockDb, {
-      session_id: 'thread_pre',
-      type: 'precommit',
-      verdict: 'approve',
-      summary: 'Large diff',
-      findings_json: '[]',
+    expect(resolvePrecommitDiff).toHaveBeenCalledWith({ diff: undefined, auto_diff: false });
+    expect(lifecycle.reviewPrecommit).toHaveBeenCalledWith({
+      diff: 'captured staged diff',
+      checklist: undefined,
+      session_id: undefined,
+      model: undefined,
     });
+    expect(JSON.parse(response.content[0].text)).toEqual(RESULT);
   });
 
-  it('creates session entry on success', async () => {
-    vi.mocked(getStagedDiff).mockResolvedValue(ok('some diff'));
-    vi.mocked(mockClient.reviewPrecommit).mockResolvedValue(ok(validResult));
-
-    await handler({}, {});
-
-    expect(getOrCreateSession).toHaveBeenCalledWith(mockDb, 'thread_pre', 'codex');
+  it('lets an explicit auto_diff value override config', async () => {
+    await setup(false)({ auto_diff: true }, {});
+    expect(resolvePrecommitDiff).toHaveBeenCalledWith({ diff: undefined, auto_diff: true });
   });
 
-  it('rejected review with blockers uses blockers for summary', async () => {
-    vi.mocked(getStagedDiff).mockResolvedValue(ok('some diff'));
-    const blockedResult: PrecommitResult = {
+  it('returns no-staged synthetic metadata before lifecycle admission', async () => {
+    vi.mocked(resolvePrecommitDiff).mockResolvedValue(
+      err('NO_STAGED_CHANGES: No staged changes found.'),
+    );
+    const response = await setup()({ session_id: 'existing' }, {});
+    expect(JSON.parse(response.content[0].text)).toMatchObject({
       ready_to_commit: false,
-      blockers: ['Missing error handling', 'SQL injection risk'],
-      warnings: [],
-      session_id: 'thread_blocked',
-    };
-    vi.mocked(mockClient.reviewPrecommit).mockResolvedValue(ok(blockedResult));
-
-    await handler({}, {});
-
-    expect(saveReview).toHaveBeenCalledWith(mockDb, expect.objectContaining({
-      verdict: 'reject',
-      summary: 'Missing error handling; SQL injection risk',
-    }));
+      session_id: 'existing',
+      models: [],
+      provenance: { persistence: 'not_recorded', warning: null },
+    });
+    expect(lifecycle.reviewPrecommit).not.toHaveBeenCalled();
   });
 
-  it('does not save on client error', async () => {
-    vi.mocked(getStagedDiff).mockResolvedValue(ok('some diff'));
-    vi.mocked(mockClient.reviewPrecommit).mockResolvedValue(
-      err('REVIEW_TIMEOUT: timed out'),
+  it('returns diff and lifecycle failures as MCP errors', async () => {
+    vi.mocked(resolvePrecommitDiff).mockResolvedValueOnce(err('GIT_ERROR: failed'));
+    expect((await setup()({}, {})).isError).toBe(true);
+
+    server = { registerTool: vi.fn() };
+    vi.mocked(resolvePrecommitDiff).mockResolvedValueOnce(ok('diff'));
+    vi.mocked(lifecycle.reviewPrecommit).mockResolvedValueOnce(err('REVIEW_BUSY: active'));
+    const response = await setup()({}, {});
+    expect(response.isError).toBe(true);
+    expect(response.content[0].text).toContain('REVIEW_BUSY');
+  });
+
+  it('defers resumed model validation to the owner-aware lifecycle', async () => {
+    vi.mocked(lifecycle.reviewPrecommit).mockResolvedValueOnce(
+      err('INVALID_INPUT: Cannot change model on a resumed session.'),
     );
-
-    await handler({}, {});
-
-    expect(saveReview).not.toHaveBeenCalled();
-  });
-
-  it('marks session completed after save', async () => {
-    vi.mocked(getStagedDiff).mockResolvedValue(ok('some diff'));
-    vi.mocked(mockClient.reviewPrecommit).mockResolvedValue(ok(validResult));
-
-    await handler({}, {});
-
-    expect(markSessionCompleted).toHaveBeenCalledWith(mockDb, 'thread_pre');
-  });
-
-  it('logs warning when getOrCreateSession fails', async () => {
-    vi.mocked(getStagedDiff).mockResolvedValue(ok('some diff'));
-    vi.mocked(mockClient.reviewPrecommit).mockResolvedValue(ok(validResult));
-    vi.mocked(getOrCreateSession).mockReturnValue(err('STORAGE_ERROR: table missing'));
-    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-
-    const result = await handler({}, {});
-
-    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to track session'));
-    expect(result.isError).toBeUndefined();
-    consoleSpy.mockRestore();
-  });
-
-  it('logs warning when markSessionCompleted fails', async () => {
-    vi.mocked(getStagedDiff).mockResolvedValue(ok('some diff'));
-    vi.mocked(mockClient.reviewPrecommit).mockResolvedValue(ok(validResult));
-    vi.mocked(markSessionCompleted).mockReturnValue(err('STORAGE_ERROR: readonly'));
-    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-
-    const result = await handler({}, {});
-
-    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('readonly'));
-    expect(result.isError).toBeUndefined();
-    consoleSpy.mockRestore();
-  });
-
-  it('logs warning when saveReview fails but still returns success', async () => {
-    vi.mocked(getStagedDiff).mockResolvedValue(ok('some diff'));
-    vi.mocked(mockClient.reviewPrecommit).mockResolvedValue(ok(validResult));
-    vi.mocked(saveReview).mockReturnValue(err('STORAGE_ERROR: disk full'));
-    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-
-    const result = await handler({}, {});
-
-    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('STORAGE_ERROR'));
-    expect(result.isError).toBeUndefined();
-    consoleSpy.mockRestore();
-  });
-
-  it('activates session before client call when session_id provided', async () => {
-    vi.mocked(getStagedDiff).mockResolvedValue(ok('some diff'));
-    vi.mocked(mockClient.reviewPrecommit).mockResolvedValue(ok(validResult));
-
-    await handler({ session_id: 'thread_pre' }, {});
-
-    expect(activateSession).toHaveBeenCalledWith(mockDb, 'thread_pre', 'codex');
-    const activateOrder = vi.mocked(activateSession).mock.invocationCallOrder[0];
-    const reviewOrder = vi.mocked(mockClient.reviewPrecommit).mock.invocationCallOrder[0];
-    expect(activateOrder).toBeLessThan(reviewOrder);
-  });
-
-  it('does not activate session when no session_id provided', async () => {
-    vi.mocked(getStagedDiff).mockResolvedValue(ok('some diff'));
-    vi.mocked(mockClient.reviewPrecommit).mockResolvedValue(ok(validResult));
-
-    await handler({}, {});
-
-    expect(activateSession).not.toHaveBeenCalled();
-    expect(getOrCreateSession).toHaveBeenCalledWith(mockDb, 'thread_pre', 'codex');
-  });
-
-  it('marks session failed when client returns error and session_id provided', async () => {
-    vi.mocked(getStagedDiff).mockResolvedValue(ok('some diff'));
-    vi.mocked(mockClient.reviewPrecommit).mockResolvedValue(err('REVIEW_TIMEOUT: timed out'));
-
-    const result = await handler({ session_id: 'thread_pre' }, {});
-
-    expect(result.isError).toBe(true);
-    expect(markSessionFailed).toHaveBeenCalledWith(mockDb, 'thread_pre');
-  });
-
-  it('does not activate session for no-staged-changes early return', async () => {
-    vi.mocked(getStagedDiff).mockResolvedValue(ok(''));
-
-    await handler({ session_id: 'thread_pre' }, {});
-
-    expect(activateSession).not.toHaveBeenCalled();
-  });
-
-  it('does not mark session failed when activateSession fails', async () => {
-    vi.mocked(getStagedDiff).mockResolvedValue(ok('some diff'));
-    vi.mocked(activateSession).mockReturnValue(err('STORAGE_ERROR: readonly'));
-    vi.mocked(mockClient.reviewPrecommit).mockResolvedValue(err('REVIEW_TIMEOUT: timed out'));
-    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-
-    const result = await handler({ session_id: 'thread_pre' }, {});
-
-    expect(result.isError).toBe(true);
-    expect(markSessionFailed).not.toHaveBeenCalled();
-    consoleSpy.mockRestore();
-  });
-
-  it('uses preflightId for markSessionCompleted when session_id provided', async () => {
-    vi.mocked(getStagedDiff).mockResolvedValue(ok('some diff'));
-    vi.mocked(activateSession).mockReturnValue(ok({ session_id: 'thread_pre', status: 'in_progress' as const, created_at: '2026-01-01', completed_at: null, provider: null }));
-    const codexResult = { ...validResult, session_id: 'thread_different' };
-    vi.mocked(mockClient.reviewPrecommit).mockResolvedValue(ok(codexResult));
-
-    await handler({ session_id: 'thread_pre' }, {});
-
-    expect(markSessionCompleted).toHaveBeenCalledWith(mockDb, 'thread_pre');
-  });
-
-  it('rejects a cross-provider resume without calling the backend or failing the session', async () => {
-    vi.mocked(getStagedDiff).mockResolvedValue(ok('some diff'));
-    vi.mocked(getSession).mockReturnValue(
-      ok({ session_id: 'thread_pre', status: 'completed' as const, created_at: '2026-01-01', completed_at: '2026-01-02', provider: 'gemini' }),
+    const response = await setup()({ session_id: 'session-1', model: 'gpt-5.5' }, {});
+    expect(response.isError).toBe(true);
+    expect(resolvePrecommitDiff).toHaveBeenCalled();
+    expect(lifecycle.reviewPrecommit).toHaveBeenCalledWith(
+      expect.objectContaining({ session_id: 'session-1', model: 'gpt-5.5' }),
     );
+  });
 
-    const result = await handler({ session_id: 'thread_pre' }, {});
+  it('allows Gemini model changes and forwards the selector', async () => {
+    client.allowsModelOverrideOnResume = true;
+    await setup()({ session_id: 'session-1', model: 'Gemini 3.5 Pro (High)' }, {});
+    expect(lifecycle.reviewPrecommit).toHaveBeenCalledWith(
+      expect.objectContaining({ model: 'Gemini 3.5 Pro (High)' }),
+    );
+  });
 
-    expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain('PROVIDER_MISMATCH');
-    expect(mockClient.reviewPrecommit).not.toHaveBeenCalled();
-    expect(activateSession).not.toHaveBeenCalled();
-    expect(markSessionFailed).not.toHaveBeenCalled();
+  it('retains the no-lifecycle compatibility path', async () => {
+    vi.mocked(client.reviewPrecommit).mockResolvedValue(ok(RESULT));
+    const response = await setup(true, false)({}, {});
+    expect(JSON.parse(response.content[0].text)).toEqual(RESULT);
   });
 });

--- a/src/tools/review-precommit.ts
+++ b/src/tools/review-precommit.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { randomUUID } from 'node:crypto';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type Database from 'better-sqlite3';
 import type { ReviewBackend } from '../backends/backend.js';
@@ -6,12 +7,15 @@ import type { ReviewBridgeConfig } from '../config/types.js';
 import { sessionModelConflictMessage } from '../backends/orchestrator.js';
 import { resolvePrecommitDiff, NO_STAGED_CHANGES } from '../utils/resolve-diff.js';
 import { createSessionTracker } from '../storage/session-tracker.js';
+import type { ReviewLifecycle } from '../review/lifecycle.js';
+import { ModelSelectorSchema, SessionIdSchema } from '../utils/input-validation.js';
 
 export function registerReviewPrecommitTool(
   server: McpServer,
   client: ReviewBackend,
   db: Database.Database | undefined,
   config: ReviewBridgeConfig,
+  lifecycle?: ReviewLifecycle,
 ): void {
   server.registerTool(
     'review_precommit',
@@ -19,30 +23,28 @@ export function registerReviewPrecommitTool(
       description:
         'Final sanity check right before committing. Auto-captures staged git changes. ' +
         'Call this after git add and before git commit to catch last-minute issues. ' +
-        'Returns ready_to_commit (boolean), blockers that must be fixed, and warnings.',
+        'Returns ready_to_commit, blockers, warnings, responding models, and persistence provenance.',
       inputSchema: {
         auto_diff: z
           .boolean()
           .optional()
-          .describe('Auto-capture staged git changes. Omit to use the project config default (review_standards.precommit.auto_diff).'),
-        diff: z.string().optional().describe('Explicit diff to review instead of auto-capture'),
-        session_id: z.string().optional().describe('Continue from previous review'),
-        checklist: z.array(z.string()).optional().describe('Custom pre-commit checks'),
-        model: z
-          .string()
-          .min(1)
-          .optional()
           .describe(
-            'Override the configured default model for this call (e.g., "gpt-5.5"), or "latest". ' +
-              'With the Codex provider this cannot be combined with session_id (a resumed thread ' +
-              'keeps its model); the Gemini provider allows changing model on a resumed session.',
+            'Auto-capture staged git changes. Omit to use the project config default (review_standards.precommit.auto_diff).',
           ),
+        diff: z.string().optional().describe('Explicit diff to review instead of auto-capture'),
+        session_id: SessionIdSchema.optional().describe('Continue from previous review'),
+        checklist: z.array(z.string()).optional().describe('Custom pre-commit checks'),
+        model: ModelSelectorSchema.optional().describe(
+          'Override the configured default model for this call (e.g., "gpt-5.5"), or "latest". ' +
+            'With the Codex provider this cannot be combined with session_id; compare returned ' +
+            'resolved and observed labels for runtime changes. Gemini allows changing model on resume.',
+        ),
       },
     },
     async (args) => {
-      // Reject session_id + model only when the backend can't change model on
-      // resume. See review-plan.ts for the rationale.
-      if (!client.allowsModelOverrideOnResume && args.session_id && args.model) {
+      // The shared lifecycle performs owner-aware validation before admission;
+      // this scalar gate remains only for the no-lifecycle compatibility path.
+      if (!lifecycle && !client.allowsModelOverrideOnResume && args.session_id && args.model) {
         return {
           content: [{ type: 'text' as const, text: sessionModelConflictMessage() }],
           isError: true,
@@ -66,7 +68,9 @@ export function registerReviewPrecommitTool(
                     ready_to_commit: false,
                     blockers: [],
                     warnings: ['No staged changes found'],
-                    session_id: args.session_id ?? '',
+                    session_id: args.session_id ?? randomUUID(),
+                    models: [],
+                    provenance: { persistence: 'not_recorded', warning: null },
                   }),
                 },
               ],
@@ -75,6 +79,19 @@ export function registerReviewPrecommitTool(
           return { content: [{ type: 'text' as const, text: diffResult.error }], isError: true };
         }
         const diff = diffResult.data;
+
+        if (lifecycle) {
+          const result = await lifecycle.reviewPrecommit({
+            diff,
+            checklist: args.checklist,
+            session_id: args.session_id,
+            model: args.model,
+          });
+          if (!result.ok) {
+            return { content: [{ type: 'text' as const, text: result.error }], isError: true };
+          }
+          return { content: [{ type: 'text' as const, text: JSON.stringify(result.data) }] };
+        }
 
         // Pre-flight: guard cross-provider resume, then activate session after
         // diff resolved and before the client call.
@@ -110,7 +127,12 @@ export function registerReviewPrecommitTool(
       } catch (e) {
         tracker.recordFailureBestEffort();
         return {
-          content: [{ type: 'text' as const, text: `Unexpected error: ${e instanceof Error ? e.message : String(e)}` }],
+          content: [
+            {
+              type: 'text' as const,
+              text: `Unexpected error: ${e instanceof Error ? e.message : String(e)}`,
+            },
+          ],
           isError: true,
         };
       }

--- a/src/tools/review-status.test.ts
+++ b/src/tools/review-status.test.ts
@@ -3,6 +3,7 @@ import Database from 'better-sqlite3';
 import { registerReviewStatusTool } from './review-status.js';
 import { initSessionsDb, getOrCreateSession } from '../storage/sessions.js';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { createSessionRegistry } from '../storage/session-registry.js';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type HandlerFn = (args: Record<string, unknown>, extra: unknown) => Promise<any>;
@@ -93,5 +94,21 @@ describe('registerReviewStatusTool', () => {
 
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain('Unexpected error');
+  });
+
+  it('prefers live memory-only registry status over durable storage', async () => {
+    const registry = createSessionRegistry();
+    const admission = registry.admit('memory-session');
+    const server = { registerTool: vi.fn() };
+    registerReviewStatusTool(server as unknown as McpServer, db, registry);
+    const liveHandler = server.registerTool.mock.calls[0][2] as HandlerFn;
+
+    const result = await liveHandler({ session_id: 'memory-session' }, {});
+
+    expect(JSON.parse(result.content[0].text)).toMatchObject({
+      status: 'in_progress',
+      session_id: 'memory-session',
+    });
+    if (admission.ok) admission.data.release();
   });
 });

--- a/src/tools/review-status.ts
+++ b/src/tools/review-status.ts
@@ -1,9 +1,14 @@
-import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type Database from 'better-sqlite3';
 import type { SessionInfo } from '../storage/sessions.js';
+import type { SessionRegistry } from '../storage/session-registry.js';
+import { SessionIdSchema } from '../utils/input-validation.js';
 
-export function registerReviewStatusTool(server: McpServer, db: Database.Database): void {
+export function registerReviewStatusTool(
+  server: McpServer,
+  db: Database.Database,
+  registry?: SessionRegistry,
+): void {
   server.registerTool(
     'review_status',
     {
@@ -11,18 +16,41 @@ export function registerReviewStatusTool(server: McpServer, db: Database.Databas
         'Check whether a review session is still running, completed, or failed. ' +
         'Use this if a review call timed out or you need to verify session state.',
       inputSchema: {
-        session_id: z.string().describe('Session ID to check status of'),
+        session_id: SessionIdSchema.describe('Session ID to check status of'),
       },
     },
     async (args) => {
       try {
+        const live = registry?.getStatus(args.session_id);
+        if (live) {
+          const end = live.completedAt ?? Date.now();
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: JSON.stringify({
+                  status: live.status,
+                  session_id: live.sessionId,
+                  elapsed_seconds: Math.max(0, Math.round((end - live.startedAt) / 1000)),
+                }),
+              },
+            ],
+          };
+        }
         const row = db
-          .prepare('SELECT session_id, status, created_at, completed_at FROM sessions WHERE session_id = ?')
+          .prepare(
+            'SELECT session_id, status, created_at, completed_at FROM sessions WHERE session_id = ?',
+          )
           .get(args.session_id) as SessionInfo | undefined;
 
         if (!row) {
           return {
-            content: [{ type: 'text' as const, text: JSON.stringify({ status: 'not_found', session_id: args.session_id }) }],
+            content: [
+              {
+                type: 'text' as const,
+                text: JSON.stringify({ status: 'not_found', session_id: args.session_id }),
+              },
+            ],
           };
         }
 
@@ -36,18 +64,25 @@ export function registerReviewStatusTool(server: McpServer, db: Database.Databas
         }
 
         return {
-          content: [{
-            type: 'text' as const,
-            text: JSON.stringify({
-              status: row.status,
-              session_id: row.session_id,
-              elapsed_seconds: elapsedSeconds,
-            }),
-          }],
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                status: row.status,
+                session_id: row.session_id,
+                elapsed_seconds: elapsedSeconds,
+              }),
+            },
+          ],
         };
       } catch (e) {
         return {
-          content: [{ type: 'text' as const, text: `Unexpected error: ${e instanceof Error ? e.message : String(e)}` }],
+          content: [
+            {
+              type: 'text' as const,
+              text: `Unexpected error: ${e instanceof Error ? e.message : String(e)}`,
+            },
+          ],
           isError: true,
         };
       }

--- a/src/utils/errors.test.ts
+++ b/src/utils/errors.test.ts
@@ -64,6 +64,8 @@ describe('ErrorCode enum', () => {
     expect(ErrorCode.RATE_LIMITED).toBe('RATE_LIMITED');
     expect(ErrorCode.NETWORK_ERROR).toBe('NETWORK_ERROR');
     expect(ErrorCode.PROVIDER_UNAVAILABLE).toBe('PROVIDER_UNAVAILABLE');
+    expect(ErrorCode.REVIEW_BUSY).toBe('REVIEW_BUSY');
+    expect(ErrorCode.SESSION_ROUTING_UNAVAILABLE).toBe('SESSION_ROUTING_UNAVAILABLE');
     expect(ErrorCode.INVALID_INPUT).toBe('INVALID_INPUT');
     expect(ErrorCode.UNKNOWN_ERROR).toBe('UNKNOWN_ERROR');
   });
@@ -76,8 +78,8 @@ describe('ErrorCode enum', () => {
     });
   });
 
-  it('has exactly 14 members', () => {
+  it('has exactly 16 members', () => {
     const keys = Object.keys(ErrorCode);
-    expect(keys).toHaveLength(14);
+    expect(keys).toHaveLength(16);
   });
 });

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -14,13 +14,13 @@ export enum ErrorCode {
   // quarantined (e.g. macOS XProtect trashing the codex binary). Distinct from a
   // model/auth/rate error: the provider never started, so it's failover-eligible.
   PROVIDER_UNAVAILABLE = 'PROVIDER_UNAVAILABLE',
+  REVIEW_BUSY = 'REVIEW_BUSY',
+  SESSION_ROUTING_UNAVAILABLE = 'SESSION_ROUTING_UNAVAILABLE',
   INVALID_INPUT = 'INVALID_INPUT',
   UNKNOWN_ERROR = 'UNKNOWN_ERROR',
 }
 
-export type Result<T> =
-  | { ok: true; data: T }
-  | { ok: false; error: string; session_id?: string };
+export type Result<T> = { ok: true; data: T } | { ok: false; error: string; session_id?: string };
 
 export function ok<T>(data: T): Result<T> {
   return { ok: true, data };

--- a/src/utils/input-validation.test.ts
+++ b/src/utils/input-validation.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { ModelSelectorSchema, SessionIdSchema } from './input-validation.js';
+
+describe('ModelSelectorSchema', () => {
+  it('trims ordinary surrounding spaces', () => {
+    expect(ModelSelectorSchema.parse('  gpt-5.6-sol  ')).toBe('gpt-5.6-sol');
+  });
+
+  it('accepts printable selectors from 1 through 200 characters after trimming', () => {
+    expect(ModelSelectorSchema.safeParse('x').success).toBe(true);
+    expect(ModelSelectorSchema.parse(`  ${'x'.repeat(200)}  `)).toHaveLength(200);
+  });
+
+  it('rejects blank and overlong selectors', () => {
+    expect(ModelSelectorSchema.safeParse('').success).toBe(false);
+    expect(ModelSelectorSchema.safeParse('   ').success).toBe(false);
+    expect(ModelSelectorSchema.safeParse('x'.repeat(201)).success).toBe(false);
+  });
+
+  it('rejects C0, C1, and DEL control characters anywhere in the input', () => {
+    for (const code of [0x00, 0x09, 0x0a, 0x1f, 0x7f, 0x80, 0x85, 0x9f]) {
+      expect(ModelSelectorSchema.safeParse(`safe${String.fromCharCode(code)}forged`).success).toBe(
+        false,
+      );
+    }
+  });
+});
+
+describe('SessionIdSchema', () => {
+  it('accepts printable session IDs from 1 through 256 characters', () => {
+    expect(SessionIdSchema.safeParse('a').success).toBe(true);
+    expect(SessionIdSchema.safeParse('x'.repeat(256)).success).toBe(true);
+  });
+
+  it('rejects blank, overlong, and surrounding-whitespace IDs without trimming them', () => {
+    for (const sessionId of ['', ' ', ' session', 'session ', 'x'.repeat(257)]) {
+      expect(SessionIdSchema.safeParse(sessionId).success).toBe(false);
+    }
+  });
+
+  it('rejects C0, C1, and DEL control characters', () => {
+    for (const code of [0x00, 0x09, 0x0a, 0x1f, 0x7f, 0x80, 0x85, 0x9f]) {
+      expect(SessionIdSchema.safeParse(`safe${String.fromCharCode(code)}forged`).success).toBe(
+        false,
+      );
+    }
+  });
+});

--- a/src/utils/input-validation.ts
+++ b/src/utils/input-validation.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod';
+
+// C0 (U+0000–U+001F), DEL (U+007F), and C1 (U+0080–U+009F) can forge
+// terminal/log lines or alter subprocess arguments. Keep this check shared so
+// config, MCP, CLI, and persisted metadata apply the same boundary rules.
+export function containsControlCharacters(value: string): boolean {
+  for (let index = 0; index < value.length; index++) {
+    const code = value.charCodeAt(index);
+    if (code <= 0x1f || (code >= 0x7f && code <= 0x9f)) return true;
+  }
+  return false;
+}
+
+const ControlFreeStringSchema = z.string().refine((value) => !containsControlCharacters(value), {
+  message: 'must not contain control characters',
+});
+
+// Model names are an open selector, not an allowlist. Normalize ordinary
+// surrounding whitespace, then enforce a bounded printable value.
+export const ModelSelectorSchema = ControlFreeStringSchema.transform((value) => value.trim()).pipe(
+  z.string().min(1, 'must not be empty').max(200, 'must be at most 200 characters'),
+);
+
+// Session IDs are opaque provider-owned identifiers. Never normalize them: a
+// caller must supply the exact identifier that was returned by the provider.
+export const SessionIdSchema = ControlFreeStringSchema.min(1, 'must not be empty')
+  .max(256, 'must be at most 256 characters')
+  .refine((value) => value === value.trim(), {
+    message: 'must not have surrounding whitespace',
+  });

--- a/src/utils/terminal.test.ts
+++ b/src/utils/terminal.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { escapeTerminalControls } from './terminal.js';
+
+describe('escapeTerminalControls', () => {
+  it('leaves printable Unicode unchanged', () => {
+    expect(escapeTerminalControls('gpt-5.6-sol — Gemini')).toBe('gpt-5.6-sol — Gemini');
+  });
+
+  it('renders common whitespace controls as visible escape sequences', () => {
+    expect(escapeTerminalControls('a\tb\nc\rd')).toBe('a\\tb\\nc\\rd');
+  });
+
+  it('escapes every C0, DEL, and C1 control without emitting raw bytes', () => {
+    const codes = [
+      ...Array.from({ length: 0x20 }, (_, code) => code),
+      ...Array.from({ length: 0x21 }, (_, offset) => 0x7f + offset),
+    ];
+    for (const code of codes) {
+      const expected =
+        code === 0x09
+          ? '\\t'
+          : code === 0x0a
+            ? '\\n'
+            : code === 0x0d
+              ? '\\r'
+              : `\\x${code.toString(16).toUpperCase().padStart(2, '0')}`;
+      const output = escapeTerminalControls(String.fromCharCode(code));
+      expect(output).toBe(expected);
+      expect(
+        [...output].every((char) => {
+          const outputCode = char.charCodeAt(0);
+          return outputCode > 0x1f && (outputCode < 0x7f || outputCode > 0x9f);
+        }),
+      ).toBe(true);
+    }
+  });
+});

--- a/src/utils/terminal.ts
+++ b/src/utils/terminal.ts
@@ -1,0 +1,44 @@
+function hexByte(code: number): string {
+  return code.toString(16).toUpperCase().padStart(2, '0');
+}
+
+export function escapeTerminalControls(value: string): string {
+  let escaped = '';
+  for (const char of value) {
+    const code = char.charCodeAt(0);
+    switch (code) {
+      case 0x09:
+        escaped += '\\t';
+        break;
+      case 0x0a:
+        escaped += '\\n';
+        break;
+      case 0x0d:
+        escaped += '\\r';
+        break;
+      default:
+        if (code <= 0x1f || (code >= 0x7f && code <= 0x9f)) {
+          escaped += `\\x${hexByte(code)}`;
+        } else {
+          escaped += char;
+        }
+    }
+  }
+  return escaped;
+}
+
+// JSON.stringify escapes C0 characters, but JSON permits DEL/C1 bytes to be
+// emitted literally. Render those as JSON-compatible Unicode escapes so JSON
+// mode remains parse-equivalent without allowing terminal-control bytes through.
+export function stringifyTerminalSafeJson(value: unknown): string {
+  const serialized = JSON.stringify(value) ?? 'null';
+  let safe = '';
+  for (const character of serialized) {
+    const code = character.charCodeAt(0);
+    safe +=
+      code <= 0x1f || (code >= 0x7f && code <= 0x9f)
+        ? `\\u${code.toString(16).padStart(4, '0')}`
+        : character;
+  }
+  return safe;
+}


### PR DESCRIPTION
## Summary

Every successful `review_plan` / `review_code` / `review_precommit` response now carries `models[]` (which provider and model actually responded, with `requested` / `resolved` / `observed` labels and an evidence source) and `provenance` (whether the result was durably recorded, memory-only, or synthetic). `review_history` returns immutable model snapshots with keyset pagination.

Highlights:
- **Codex runtime observation** reads the model from the local rollout record with UUIDv7 gating, containment and no-follow checks, bounded reverse reads, a 100 ms deadline and an LRU cache. Resumed threads keep the prior resolved identity and report a mismatch once rather than substituting today's default.
- **Gemini** reports the exact selected model with `observed: null` and caches the `agy models` catalog for five minutes.
- **Composites** report only successful contributors in deterministic order. Deliberation now catches rejected provider promises so a successful peer survives (ISS-025).
- **Shared review lifecycle** with admission limits (4 global, 1 per session), owner-aware resume validation, an in-memory registry, and two new error codes: `REVIEW_BUSY`, `SESSION_ROUTING_UNAVAILABLE`.
- **Storage**: atomic column migrations, `BEGIN IMMEDIATE` outcome writes with one busy retry, memory-only degradation with honest provenance, and a verified `(session_id, id)` index.
- **Hardening**: session id / model selector validation and terminal-control escaping on every output surface.
- **CLI guard** fails open when no `reviews.db` is reachable (ISS-018), restoring the documented behavior. A readable-but-broken database still fails closed.

## Review notes

Line-by-line diff review done per repository rules. One regression found and fixed in this PR: the CLI refused every `--session` resume when no `reviews.db` existed (verified live, now fails open at both the guard and the failover lookup). Remaining minor items are recorded as issues (ISS-026, ISS-031).

## Test plan

- [x] `npm test -- --run`: 44 files, 939 tests
- [x] `npm run lint`, `npm run typecheck`, `npm run build`
- [x] `git diff --check`
- [x] Live: default Codex call reports matching `resolved` / `observed`; resumed thread retains prior resolved identity and emits one mismatch warning; deliberate mode degrades to Codex-only when Gemini times out
- [x] Live: CLI resume with `REVIEW_BRIDGE_DB` pointed at a missing file no longer errors with `SESSION_ROUTING_UNAVAILABLE`

## Follow-ups

- PR #7 (cwd threading) touches the same backends and tools and will need a rebase onto this.
- Not included: `AGENTS.md` (corrupted copy, needs a rewrite) and `.codex/config.toml` (versioning undecided).

https://claude.ai/code/session_01DyzkySCXgJcFZXU4a4EP4J
